### PR TITLE
Remove C++ Code Scanning

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         language:
-          - cpp
           - python
 
     steps:


### PR DESCRIPTION
Code Scanning needs to be configured in order to properly work for compiled languages, see [here](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#no-code-found-during-the-build). We are going to postpone this step.