### PR TITLE
Clang-format with pre-commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Chromium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,9 @@ repos:
     hooks:
       - id: flake8
         name: Check PEP8
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.1
+    hooks:
+      - id: clang-format
+        name: Format C++ code

--- a/pyg_lib/csrc/library.cpp
+++ b/pyg_lib/csrc/library.cpp
@@ -15,9 +15,11 @@
 // For PyMODINIT_FUNC to work, we need to include Python.h
 #ifdef _WIN32
 #ifdef USE_PYTHON
-PyMODINIT_FUNC PyInit__C(void) { return NULL; }
-#endif // USE_PYTHON
-#endif // _WIN32
+PyMODINIT_FUNC PyInit__C(void) {
+  return NULL;
+}
+#endif  // USE_PYTHON
+#endif  // _WIN32
 
 namespace pyg {
 
@@ -29,6 +31,8 @@ int64_t cuda_version() {
 #endif
 }
 
-TORCH_LIBRARY_FRAGMENT(pyg, m) { m.def("cuda_version", &cuda_version); }
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def("cuda_version", &cuda_version);
+}
 
-} // namespace pyg
+}  // namespace pyg

--- a/pyg_lib/csrc/library.h
+++ b/pyg_lib/csrc/library.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "macros.h"
 #include <cstdint>
+#include "macros.h"
 
 namespace pyg {
 
@@ -14,5 +14,5 @@ extern "C" PYG_INLINE_VARIABLE auto _register_ops = &cuda_version;
 #pragma comment(linker, "/include:_register_ops")
 #endif
 
-} // namespace detail
-} // namespace pyg
+}  // namespace detail
+}  // namespace pyg


### PR DESCRIPTION
Add pre-commit config. It automatically format existing cpp code.
.clang-format file now uses a simple chromium style.