### PR TITLE
explicitly specify where to import headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if (WITH_CUDA)
 endif()
 file(GLOB_RECURSE ALL_HEADERS ${CSRC}/*.h)
 add_library(${PROJECT_NAME} SHARED ${ALL_SOURCES})
+target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 find_package(Torch REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -12,7 +12,6 @@ include(GoogleTest)
 
 set(CTEST test/csrc)
 file(GLOB_RECURSE ALL_TESTS ${CTEST}/*.cpp)
-target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 foreach(test ${ALL_TESTS})
     get_filename_component(name ${test} NAME_WE)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -12,6 +12,7 @@ include(GoogleTest)
 
 set(CTEST test/csrc)
 file(GLOB_RECURSE ALL_TESTS ${CTEST}/*.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 foreach(test ${ALL_TESTS})
     get_filename_component(name ${test} NAME_WE)

--- a/pyg_lib/csrc/sampler/cpu/random_walk_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/random_walk_kernel.cpp
@@ -2,7 +2,7 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 
-#include "../../random/cpu/randint_engine.h"
+#include "pyg_lib/csrc/random/cpu/randint_engine.h"
 
 namespace pyg {
 namespace sampler {

--- a/pyg_lib/csrc/sampler/random_walk.h
+++ b/pyg_lib/csrc/sampler/random_walk.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include "../macros.h"
+#include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
 namespace sampler {

--- a/test/csrc/random/test_randint.cpp
+++ b/test/csrc/random/test_randint.cpp
@@ -3,7 +3,7 @@
 #include <set>
 #include <vector>
 
-#include "../../../pyg_lib/csrc/random/cpu/randint_engine.h"
+#include "pyg_lib/csrc/random/cpu/randint_engine.h"
 
 TEST(RandintRandomTest, BasicAssertions) {
   pyg::random::RandintEngine<int64_t> eng;

--- a/test/csrc/sampler/test_random_walk.cpp
+++ b/test/csrc/sampler/test_random_walk.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "pyg_lib/csrc/sampler/random_walk.h"
-#include "test/graph.h"
+#include "test/csrc/graph.h"
 
 TEST(RandomWalkTest, BasicAssertions) {
   auto options = at::TensorOptions().dtype(at::kLong);

--- a/test/csrc/sampler/test_random_walk.cpp
+++ b/test/csrc/sampler/test_random_walk.cpp
@@ -1,8 +1,8 @@
 #include <ATen/ATen.h>
 #include <gtest/gtest.h>
 
-#include "../../../pyg_lib/csrc/sampler/random_walk.h"
-#include "../graph.h"
+#include "pyg_lib/csrc/sampler/random_walk.h"
+#include "test/graph.h"
 
 TEST(RandomWalkTest, BasicAssertions) {
   auto options = at::TensorOptions().dtype(at::kLong);

--- a/test/csrc/test_library.cpp
+++ b/test/csrc/test_library.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "../../pyg_lib/csrc/library.h"
+#include "pyg_lib/csrc/library.h"
 
 TEST(CudaVersionTest, BasicAssertions) {
 #ifdef WITH_CUDA


### PR DESCRIPTION
In most C++ code style, we are not recommend to use relative path in include path because it is fragile to refactor and hard to debug when `../../blabla/../../blabla` happens.