### PR TITLE
Benchmark scripts and `pyg::sampler::Mapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added `pyg::sampler::Mapper` utility for mapping global to local node indices ([#45](https://github.com/pyg-team/pyg-lib/pull/45)
+- Added benchmark script ([#45](https://github.com/pyg-team/pyg-lib/pull/45)
 - Added download script for benchmark data ([#44](https://github.com/pyg-team/pyg-lib/pull/44)
 - Added `biased sampling` utils ([#38](https://github.com/pyg-team/pyg-lib/pull/38))
 - Added `CHANGELOG.md` ([#39](https://github.com/pyg-team/pyg-lib/pull/39))

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -11,7 +11,7 @@ from pyg_lib.testing import to_edge_index, withDataset, withSeed
 def test_subgraph(dataset, **kwargs):
     (rowptr, col), num_nodes = dataset, dataset[0].size(0) - 1
     perm = torch.randperm(num_nodes, dtype=rowptr.dtype, device=rowptr.device)
-    nodes = perm[:num_nodes // 2]
+    nodes = perm[:num_nodes // 100]
 
     t = time.perf_counter()
     for _ in range(10):

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -1,0 +1,30 @@
+import time
+
+import torch
+
+import pyg_lib
+from pyg_lib.testing import to_edge_index, withDataset, withSeed
+
+
+@withDataset('DIMACS10', 'citationCiteseer')
+@withSeed
+def test_subgraph(dataset, **kwargs):
+    (rowptr, col), num_nodes = dataset, dataset[0].size(0) - 1
+    perm = torch.randperm(num_nodes, dtype=rowptr.dtype, device=rowptr.device)
+    nodes = perm[:num_nodes // 2]
+
+    t = time.perf_counter()
+    for _ in range(10):
+        pyg_lib.sampler.subgraph(rowptr, col, nodes)
+    print(time.perf_counter() - t)
+
+    edge_index = to_edge_index(rowptr, col)
+    from torch_geometric.utils import subgraph
+
+    t = time.perf_counter()
+    for _ in range(10):
+        subgraph(nodes, edge_index, num_nodes=num_nodes, relabel_nodes=True)
+    print(time.perf_counter() - t)
+
+
+test_subgraph()

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -6,8 +6,8 @@ import pyg_lib
 from pyg_lib.testing import to_edge_index, withDataset, withSeed
 
 
-@withDataset('DIMACS10', 'citationCiteseer')
 @withSeed
+@withDataset('DIMACS10', 'citationCiteseer')
 def test_subgraph(dataset, **kwargs):
     (rowptr, col), num_nodes = dataset, dataset[0].size(0) - 1
     perm = torch.randperm(num_nodes, dtype=rowptr.dtype, device=rowptr.device)

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -27,4 +27,5 @@ def test_subgraph(dataset, **kwargs):
     print(time.perf_counter() - t)
 
 
-test_subgraph()
+if __name__ == '__main__':
+    test_subgraph()

--- a/pyg_lib/csrc/sampler/cpu/mapper.h
+++ b/pyg_lib/csrc/sampler/cpu/mapper.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace pyg {
+namespace sampler {
+
+template <typename scalar_t>
+class Mapper {
+ public:
+  Mapper(scalar_t num_nodes, scalar_t num_entries)
+      : num_nodes(num_nodes), num_entries(num_entries) {
+    // Use a some simple heuristic to determine whether we can use a std::vector
+    // to perform the mapping instead of relying on the more memory-friendly,
+    // but slower std::unordered_map implementation:
+    use_vec = (num_nodes < 1000000) || (num_entries > num_nodes / 10);
+
+    if (use_vec)
+      to_local_vec = std::vector<scalar_t>(num_nodes, -1);
+  }
+
+  void fill(const scalar_t* nodes_data, const scalar_t size) {
+    if (use_vec) {
+      for (scalar_t i = 0; i < size; ++i)
+        to_local_vec[nodes_data[i]] = i;
+    } else {
+      for (scalar_t i = 0; i < size; ++i)
+        to_local_map.insert({nodes_data[i], i});
+    }
+  }
+
+  void fill(const at::Tensor& nodes) {
+    fill(nodes.data_ptr<scalar_t>(), nodes.numel());
+  }
+
+  bool exists(const scalar_t& node) {
+    if (use_vec)
+      return to_local_vec[node] >= 0;
+    else
+      return to_local_map.count(node) > 0;
+  }
+
+  scalar_t map(const scalar_t& node) {
+    if (use_vec)
+      return to_local_vec[node];
+    else {
+      const auto search = to_local_map.find(node);
+      return search != to_local_map.end() ? search->second : -1;
+    }
+  }
+
+ private:
+  scalar_t num_nodes, num_entries;
+
+  bool use_vec;
+  std::vector<scalar_t> to_local_vec;
+  std::unordered_map<scalar_t, scalar_t> to_local_map;
+};
+
+}  // namespace sampler
+}  // namespace pyg

--- a/pyg_lib/csrc/sampler/cpu/mapper.h
+++ b/pyg_lib/csrc/sampler/cpu/mapper.h
@@ -5,6 +5,8 @@
 namespace pyg {
 namespace sampler {
 
+// TODO Implement `Mapper` as an interface/abstract class to allow for other
+// implementations as well.
 template <typename scalar_t>
 class Mapper {
  public:

--- a/pyg_lib/csrc/sampler/cpu/subgraph_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/subgraph_kernel.cpp
@@ -9,6 +9,36 @@ namespace sampler {
 
 namespace {
 
+#define PARALLEL_FOR(n, start, end) at::parallel_for(0, (n), at::internal::GRAIN_SIZE, [&](int64_t (start), int64_t (end))
+
+template <typename scalar_t>
+class Mapper {
+ public:
+  Mapper(scalar_t num_nodes, scalar_t num_entries)
+      : num_nodes(num_nodes), num_entries(num_entries) {
+    to_local_vec = std::vector<scalar_t>(num_nodes, -1);
+  }
+
+  void fill(const at::Tensor& nodes) {
+    const auto nodes_data = nodes.data_ptr<scalar_t>();
+    auto grain_size = at::internal::GRAIN_SIZE;
+    PARALLEL_FOR(nodes.numel(), start, end) {
+      for (scalar_t i = start; i < end; ++i)
+        to_local_vec[nodes_data[i]] = i;
+    });
+  }
+
+  bool exists(const scalar_t& node) { return to_local_vec[node] >= 0; }
+
+  scalar_t map(const scalar_t& node) { return to_local_vec[node]; }
+
+ private:
+  scalar_t num_nodes;
+  scalar_t num_entries;
+  std::vector<scalar_t> to_local_vec;
+  std::unordered_map<scalar_t, scalar_t> to_local_map;
+};
+
 std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>> subgraph_kernel(
     const at::Tensor& rowptr,
     const at::Tensor& col,
@@ -18,31 +48,30 @@ std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>> subgraph_kernel(
   TORCH_CHECK(col.is_cpu(), "'col' must be a CPU tensor");
   TORCH_CHECK(nodes.is_cpu(), "'nodes' must be a CPU tensor");
 
-  const auto deg = rowptr.new_empty({nodes.size(0)});
   const auto out_rowptr = rowptr.new_empty({nodes.size(0) + 1});
   at::Tensor out_col;
   c10::optional<at::Tensor> out_edge_id = c10::nullopt;
 
   AT_DISPATCH_INTEGRAL_TYPES(nodes.scalar_type(), "subgraph_kernel", [&] {
+    auto mapper = Mapper<scalar_t>(rowptr.size(0) - 1, nodes.size(0));
+    mapper.fill(nodes);
+
     const auto rowptr_data = rowptr.data_ptr<scalar_t>();
     const auto col_data = col.data_ptr<scalar_t>();
     const auto nodes_data = nodes.data_ptr<scalar_t>();
 
-    std::unordered_map<scalar_t, scalar_t> to_local_node;
-    for (scalar_t i = 0; i < nodes.size(0); ++i)  // TODO parallelize
-      to_local_node.insert({nodes_data[i], i});
-
     // We first iterate over all nodes and collect information about the number
     // of edges in the induced subgraph.
+    const auto deg = rowptr.new_empty({nodes.size(0)});
     auto deg_data = deg.data_ptr<scalar_t>();
     auto grain_size = at::internal::GRAIN_SIZE;
     at::parallel_for(0, nodes.size(0), grain_size, [&](int64_t _s, int64_t _e) {
-      for (scalar_t i = _s; i < _e; ++i) {
+      for (size_t i = _s; i < _e; ++i) {
         const auto v = nodes_data[i];
         // Iterate over all neighbors and check if they are part of `nodes`:
         scalar_t d = 0;
-        for (scalar_t j = rowptr_data[v]; j < rowptr_data[v + 1]; ++j) {
-          if (to_local_node.count(col_data[j]) > 0)
+        for (size_t j = rowptr_data[v]; j < rowptr_data[v + 1]; ++j) {
+          if (mapper.exists(col_data[j]))
             d++;
         }
         deg_data[i] = d;
@@ -73,13 +102,11 @@ std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>> subgraph_kernel(
         // Iterate over all neighbors and check if they are part of `nodes`:
         scalar_t offset = out_rowptr_data[i];
         for (scalar_t j = rowptr_data[v]; j < rowptr_data[v + 1]; ++j) {
-          const auto w = col_data[j];
-          const auto search = to_local_node.find(w);
-          if (search != to_local_node.end()) {
-            out_col_data[offset] = search->second;
+          const auto w = mapper.map(col_data[j]);
+          if (w >= 0) {
+            out_col_data[offset] = w;
             if (return_edge_id)
               out_edge_id_data[offset] = j;
-            offset++;
           }
         }
       }

--- a/pyg_lib/csrc/sampler/cpu/subgraph_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/subgraph_kernel.cpp
@@ -9,38 +9,32 @@ namespace sampler {
 
 namespace {
 
-#define PARALLEL_FOR(n, start, end) at::parallel_for(0, (n), at::internal::GRAIN_SIZE, [&](int64_t (start), int64_t (end))
-
 template <typename scalar_t>
 class Mapper {
  public:
   Mapper(scalar_t num_nodes, scalar_t num_entries)
       : num_nodes(num_nodes), num_entries(num_entries) {
-    // Use a some simple heuristic to determine whether we can use a vector to
-    // perform the mapping:
-    if (num_nodes < 1000000)
-      use_vec = true;
-    else if (num_entries > num_nodes / 10)
-      use_vec = true;
-    else
-      use_vec = false;
-
-    std::cout << "mapper initialized, use vec: " << use_vec << std::endl;
+    // Use a some simple heuristic to determine whether we can use a std::vector
+    // to perform the mapping instead of relying on the more memory-friendly,
+    // but slower std::unordered_map:
+    use_vec = (num_nodes < 1000000) || (num_entries > num_nodes / 10);
 
     if (use_vec)
       to_local_vec = std::vector<scalar_t>(num_nodes, -1);
   }
 
-  void fill(const at::Tensor& nodes) {
-    const auto nodes_data = nodes.data_ptr<scalar_t>();
-
+  void fill(const scalar_t* nodes_data, const scalar_t size) {
     if (use_vec) {
-      for (scalar_t i = 0; i < nodes.numel(); ++i)
+      for (scalar_t i = 0; i < size; ++i)
         to_local_vec[nodes_data[i]] = i;
     } else {
-      for (scalar_t i = 0; i < nodes.numel(); ++i)
+      for (scalar_t i = 0; i < size; ++i)
         to_local_map.insert({nodes_data[i], i});
     }
+  }
+
+  void fill(const at::Tensor& nodes) {
+    fill(nodes.data_ptr<scalar_t>(), nodes.numel());
   }
 
   bool exists(const scalar_t& node) {
@@ -60,8 +54,8 @@ class Mapper {
   }
 
  private:
-  scalar_t num_nodes;
-  scalar_t num_entries;
+  scalar_t num_nodes, num_entries;
+
   bool use_vec;
   std::vector<scalar_t> to_local_vec;
   std::unordered_map<scalar_t, scalar_t> to_local_map;


### PR DESCRIPTION
I thought `pyg::sampler::Mapper` is a clever way to re-use mapping functionality across several samplers. In addition, I noticed that the usage of `std::unordered_map` slows down `subgraph` creation by a significant factor, so I use a simple heuristic to determine if its usage is actually advantageous. 