### PR TITLE
Replace unordered_map with a faster version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "third_party/cutlass"]
     path = third_party/cutlass
     url = https://github.com/NVIDIA/cutlass
+
+[submodule "third_party/parallel-hashmap"]
+ 	path = third_party/parallel-hashmap
+ 	url = https://github.com/greg7mdp/parallel-hashmap.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `CMake` support ([#5](https://github.com/pyg-team/pyg-lib/pull/5))
 - Added `pyg.cuda_version()` ([#4](https://github.com/pyg-team/pyg-lib/pull/4))
 ### Changed
+- Replace std::unordered_map with a faster phmap::flat_hash_map ([#65](https://github.com/pyg-team/pyg-lib/pull/65))
 - Fixed versions of `checkout` and `setup-python` in CI ([#52](https://github.com/pyg-team/pytorch_geometric/pull/52))
 - Make use of the `pyg_sphinx_theme` documentation template ([#47](https://github.com/pyg-team/pyg-lib/pull/47))
 - Auto-compute number of threads and blocks in CUDA kernels ([#41](https://github.com/pyg-team/pyg-lib/pull/41))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ file(GLOB_RECURSE ALL_HEADERS ${CSRC}/*.h)
 add_library(${PROJECT_NAME} SHARED ${ALL_SOURCES})
 target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(PHMAP_DIR third_party/parallel-hashmap)
+target_include_directories(${PROJECT_NAME} PRIVATE ${PHMAP_DIR})
+
 find_package(Torch REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
 

--- a/pyg_lib/csrc/sampler/cpu/mapper.h
+++ b/pyg_lib/csrc/sampler/cpu/mapper.h
@@ -2,6 +2,8 @@
 
 #include <ATen/ATen.h>
 
+#include "parallel_hashmap/phmap.h"
+
 namespace pyg {
 namespace sampler {
 
@@ -14,7 +16,7 @@ class Mapper {
       : num_nodes(num_nodes), num_entries(num_entries) {
     // Use a some simple heuristic to determine whether we can use a std::vector
     // to perform the mapping instead of relying on the more memory-friendly,
-    // but slower std::unordered_map implementation:
+    // but slower phmap::flat_hash_map implementation:
     use_vec = (num_nodes < 1000000) || (num_entries > num_nodes / 10);
 
     if (use_vec)
@@ -56,7 +58,7 @@ class Mapper {
 
   bool use_vec;
   std::vector<scalar_t> to_local_vec;
-  std::unordered_map<scalar_t, scalar_t> to_local_map;
+  phmap::flat_hash_map<scalar_t, scalar_t> to_local_map;
 };
 
 }  // namespace sampler


### PR DESCRIPTION
- Added parallel-hashmap to third_party.
- Replaced std::unordered_map with a faster phmap::flat_hash_map.

Results obtained using [main.py](https://github.com/pyg-team/pyg-lib/blob/master/benchmark/main.py) benchmark:
<img width="555" alt="Screenshot 2022-07-15 at 08 06 32" src="https://user-images.githubusercontent.com/58218729/179161448-ab141512-fe14-46e9-97d6-ac2a46ce9ce1.png">
*speedup = time unordered_map / time phmap
