### PR TITLE
Fix broken `pyg_lib.ops` package 

### DIFF
--- a/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
@@ -152,10 +152,17 @@ at::Tensor segment_matmul_kernel(const at::Tensor& input,
 
 }  // namespace
 
+  TORCH_LIBRARY(pyg, m) {
+  m.def("pyg::cuda_grouped_matmul(Tensor[] input, Tensor[] other) -> Tensor[]");
+  m.def(
+      "pyg::cuda_segment_matmul(Tensor input, Tensor ptr, Tensor other) -> "
+      "Tensor");
+}
+
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::cuda_grouped_matmul"),
          TORCH_FN(grouped_matmul_kernel));
-  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_matmul"),
+  m.impl(TORCH_SELECTIVE_NAME("pyg::cuda_segment_matmul"),
          TORCH_FN(segment_matmul_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
@@ -152,7 +152,7 @@ at::Tensor segment_matmul_kernel(const at::Tensor& input,
 
 }  // namespace
 
-  TORCH_LIBRARY(pyg, m) {
+TORCH_LIBRARY(pyg, m) {
   m.def("pyg::cuda_grouped_matmul(Tensor[] input, Tensor[] other) -> Tensor[]");
   m.def(
       "pyg::cuda_segment_matmul(Tensor input, Tensor ptr, Tensor other) -> "


### PR DESCRIPTION
some of the last minute changes to my last MR broke it. test_ops.py was not passing in master. these changes fix that.

master:
```
Traceback (most recent call last):
  File "test/ops/test_ops.py", line 46, in <module>
    test_segment_matmul_autograd()
  File "test/ops/test_ops.py", line 20, in test_segment_matmul_autograd
    out.sum().backward()
  File "/opt/conda/lib/python3.8/site-packages/torch/_tensor.py", line 399, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/opt/conda/lib/python3.8/site-packages/torch/autograd/__init__.py", line 173, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/opt/conda/lib/python3.8/site-packages/torch/autograd/function.py", line 253, in apply
    return user_fn(self, *args)
  File "/workspace/rgcn_pyg_lib_forward_bench/pyg-lib/pyg_lib/ops/__init__.py", line 30, in backward
    others_grad = torch.ops.pyg.grouped_matmul_kern(
  File "/opt/conda/lib/python3.8/site-packages/torch/_ops.py", line 191, in __getattr__
    op = torch._C._jit_get_operation(qualified_op_name)
RuntimeError: No such operator pyg::grouped_matmul_kern
```

after my fix:
```
test_segment_matmul_autograd passed!
test_grouped_matmul_autograd passed!
```