### PR TITLE
Add neighbor sampler benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `grouped_matmul` and `segment_matmul` CUDA implementations via `cutlass` ([#51](https://github.com/pyg-team/pyg-lib/pull/51), [#56](https://github.com/pyg-team/pyg-lib/pull/56), [#61](https://github.com/pyg-team/pyg-lib/pull/61), [#64](https://github.com/pyg-team/pyg-lib/pull/64), [#69](https://github.com/pyg-team/pyg-lib/pull/69))
 - Added `pyg::sampler::neighbor_sample` implementation ([#54](https://github.com/pyg-team/pyg-lib/pull/54), [#76](https://github.com/pyg-team/pyg-lib/pull/76), [#77](https://github.com/pyg-team/pyg-lib/pull/77), [#78](https://github.com/pyg-team/pyg-lib/pull/78))
 - Added `pyg::sampler::Mapper` utility for mapping global to local node indices ([#45](https://github.com/pyg-team/pyg-lib/pull/45)))
-- Added benchmark script ([#45](https://github.com/pyg-team/pyg-lib/pull/45))
+- Added benchmark script ([#45](https://github.com/pyg-team/pyg-lib/pull/45), [#79](https://github.com/pyg-team/pyg-lib/pull/79))
 - Added download script for benchmark data ([#44](https://github.com/pyg-team/pyg-lib/pull/44))
 - Added `biased sampling` utils ([#38](https://github.com/pyg-team/pyg-lib/pull/38))
 - Added `CHANGELOG.md` ([#39](https://github.com/pyg-team/pyg-lib/pull/39))

--- a/benchmark/sampler/neighbor.py
+++ b/benchmark/sampler/neighbor.py
@@ -1,0 +1,62 @@
+import argparse
+import time
+
+import torch
+# uncomment below to enable torch.ops.torch_sparse.neighbor_sample
+# import torch_sparse
+from tqdm import tqdm
+
+import pyg_lib
+from pyg_lib.testing import withDataset, withSeed
+
+argparser = argparse.ArgumentParser('Neighbor Sampler benchmark')
+argparser.add_argument('--batch-sizes', nargs='+',
+                       default=[512, 1024, 2048, 4096, 8192], type=int)
+argparser.add_argument('--num_neighbors', default=[[-1], [15, 10, 5],
+                                                   [20, 15, 10]], type=int)
+argparser.add_argument('--replace', default=False, type=bool)
+argparser.add_argument('--directed', default=True, type=bool)
+
+args = argparser.parse_args()
+
+
+@withSeed
+@withDataset('DIMACS10', 'citationCiteseer', True)
+def test_neighbor(dataset, **kwargs):
+    (rowptr, col, colptr, row), num_nodes = dataset, dataset[0].size(0) - 1
+
+    for num_neighbors in args.num_neighbors:
+        for batch_size in args.batch_sizes:
+            # pyg-lib neighbor sampler
+            start = time.perf_counter()
+            for node in tqdm(range(num_nodes - batch_size)):
+                seed = torch.arange(node, node + batch_size)
+                pyg_lib.sampler.neighbor_sample(rowptr, col, seed,
+                                                num_neighbors, args.replace,
+                                                args.directed, disjoint=False,
+                                                return_edge_id=True)
+            stop = time.perf_counter()
+            print('-------------------------')
+            print('pyg-lib neighbor sample')
+            print(f'Batch size={batch_size}, '
+                  f'Num_neighbors={num_neighbors}, '
+                  f'Inference time={stop-start:.3f} seconds\n')
+
+            # pytorch-sparse neighbor sampler
+            start = time.perf_counter()
+            for node in tqdm(range(num_nodes - batch_size)):
+                seed = torch.arange(node, node + batch_size)
+                torch.ops.torch_sparse.neighbor_sample(colptr, row, seed,
+                                                       num_neighbors,
+                                                       args.replace,
+                                                       args.directed)
+            stop = time.perf_counter()
+            print('-------------------------')
+            print('pytorch_sparse neighbor sample')
+            print(f'Batch size={batch_size}, '
+                  f'Num_neighbors={num_neighbors}, '
+                  f'Inference time={stop-start:.3f} seconds\n')
+
+
+if __name__ == '__main__':
+    test_neighbor()

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -27,8 +27,7 @@ def withCUDA(func: Callable) -> Callable:
     return wrapper
 
 
-def withDataset(group: str, name: str,
-                return_csc: Optional[bool] = False) -> Callable:
+def withDataset(group: str, name: str) -> Callable:
     def decorator(func: Callable) -> Callable:
         def wrapper(*args, **kwargs):
             dataset = get_sparse_matrix(
@@ -36,7 +35,6 @@ def withDataset(group: str, name: str,
                 name,
                 dtype=kwargs.get('dtype', torch.long),
                 device=kwargs.get('device', None),
-                return_csc=return_csc,
             )
 
             func(*args, dataset=dataset, **kwargs)
@@ -54,12 +52,9 @@ def get_sparse_matrix(
     name: str,
     dtype: torch.dtype = torch.long,
     device: Optional[torch.device] = None,
-    return_csc: Optional[bool] = False,
-) -> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]:
+) -> Tuple[Tensor, Tensor]:
     r"""Returns a sparse matrix :obj:`(rowptr, col)` from the
     `Suite Sparse Matrix Collection <https://sparse.tamu.edu>`_.
-    In addition, may return a sparse matrix in CSC format,
-    then output will be :obj:`(rowptr, col, colptr, row)`.
 
     Args:
         group (string): The group of the sparse matrix.
@@ -68,14 +63,10 @@ def get_sparse_matrix(
             tensors. (default: :obj:`torch.long`)
         device (torch.device, optional): the desired device of returned
             tensors. (default: :obj:`None`)
-        return_csc (bool, optional): If set to :obj:`True`, will additionaly
-            return a sparse matrix in CSC format. (default: :obj:`False`)
 
     Returns:
-        (torch.Tensor, torch.Tensor, Optional[torch.Tensor],
-        Optional[torch.Tensor]): Compressed source node indices and target node
-        indices of the sparse matrix. In addition, may return a sparse matrix
-        in CSC format.
+        (torch.Tensor, torch.Tensor): Compressed source node indices and target
+        node indices of the sparse matrix.
     """
     path = osp.join(get_home_dir(), f'{name}.mat')
     if not osp.exists(path):
@@ -90,18 +81,10 @@ def get_sparse_matrix(
         print(' Done!')
 
     from scipy.io import loadmat
-    csr_mat = loadmat(path)['Problem'][0][0][2].tocsr()
+    mat = loadmat(path)['Problem'][0][0][2].tocsr()
 
-    rowptr = torch.from_numpy(csr_mat.indptr).to(device, dtype)
-    col = torch.from_numpy(csr_mat.indices).to(device, dtype)
-
-    if return_csc:
-        csc_mat = loadmat(path)['Problem'][0][0][2].tocsc()
-
-        colptr = torch.from_numpy(csc_mat.indptr).to(device, dtype)
-        row = torch.from_numpy(csc_mat.indices).to(device, dtype)
-
-        return rowptr, col, colptr, row
+    rowptr = torch.from_numpy(mat.indptr).to(device, dtype)
+    col = torch.from_numpy(mat.indices).to(device, dtype)
 
     return rowptr, col
 


### PR DESCRIPTION
- Added neighbor sampler benchmark to pyg-lib.
- Benchmark measures performance for the neighbor_sample from pyg-lib as well as neighbor_sample from pytorch_sparse.
- Added argument "return_csc" to withDataset decorator to optionally return matrix in CSC format (for the purpose of pytorch_sparse neighbor sample).
