### PR TITLE
Add `IndexTracker` as faster alternative to `unordered_set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Speed up `pyg::sampler::neighbor_sample` via `IndexTracker` implementation ([#84](https://github.com/pyg-team/pyg-lib/pull/84))
 - Added `pyg::sampler::hetero_neighbor_sample` implementation ([#90](https://github.com/pyg-team/pyg-lib/pull/90))
 - Added `pyg::utils::to_vector` implementation ([#88](https://github.com/pyg-team/pyg-lib/pull/88))
 - Added support for PyTorch 1.12 ([#57](https://github.com/pyg-team/pyg-lib/pull/57), [#58](https://github.com/pyg-team/pyg-lib/pull/58))

--- a/pyg_lib/csrc/sampler/cpu/index_tracker.h
+++ b/pyg_lib/csrc/sampler/cpu/index_tracker.h
@@ -10,7 +10,7 @@ namespace sampler {
 template <typename scalar_t>
 class IndexTracker {
  public:
-  IndexTracker(const size_t size) : size(size) {
+  IndexTracker(const size_t& size) : size(size) {
     // TODO: add better switching threshold value mechanism?
     use_vec = (size < 100000);
 
@@ -40,7 +40,7 @@ class IndexTracker {
   }
 
  private:
-  const size_t size;
+  const size_t& size;
 
   bool use_vec;
   std::vector<char> vec;

--- a/pyg_lib/csrc/sampler/cpu/index_tracker.h
+++ b/pyg_lib/csrc/sampler/cpu/index_tracker.h
@@ -8,41 +8,43 @@ namespace pyg {
 namespace sampler {
 
 template <typename scalar_t>
-class IndicesTracker {
+class IndexTracker {
  public:
-  IndicesTracker(const scalar_t& size) : size(size) {
+  IndexTracker(const size_t size) : size(size) {
     // TODO: add better switching threshold value mechanism?
     use_vec = (size < 100000);
+
     if (use_vec)
-      rnd_indices_vec.resize(size, 0);
+      vec.resize(size, 0);
   }
 
-  bool tryInsert(const scalar_t& index) {
+  bool try_insert(const scalar_t& index) {
     if (use_vec) {
-      if (rnd_indices_vec[index] == 0) {
-        rnd_indices_vec[index] = 1;
+      if (vec[index] == 0) {
+        vec[index] = 1;
         return true;
       } else {
         return false;
       }
     } else {
-      return rnd_indices_set.insert(index).second;
+      return set.insert(index).second;
     }
   }
 
   void insert(const scalar_t& index) {
     if (use_vec) {
-      rnd_indices_vec[index] = 1;
+      vec[index] = 1;
     } else {
-      rnd_indices_set.insert(index);
+      set.insert(index);
     }
   }
 
  private:
-  const scalar_t& size;
+  const size_t size;
+
   bool use_vec;
-  std::vector<char> rnd_indices_vec;
-  phmap::flat_hash_set<scalar_t> rnd_indices_set;
+  std::vector<char> vec;
+  phmap::flat_hash_set<scalar_t> set;
 };
 
 }  // namespace sampler

--- a/pyg_lib/csrc/sampler/cpu/indices_tracker.h
+++ b/pyg_lib/csrc/sampler/cpu/indices_tracker.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include "parallel_hashmap/phmap.h"
+
+namespace pyg {
+namespace sampler {
+
+template <typename scalar_t>
+class IndicesTracker {
+ public:
+  IndicesTracker(const scalar_t& size) : size(size) {
+    // TODO: add better switching threshold value mechanism?
+    use_vec = (size < 100000);
+    if (use_vec)
+      rnd_indices_vec.resize(size, 0);
+  }
+
+  bool tryInsert(const scalar_t& index) {
+    if (use_vec) {
+      if (rnd_indices_vec[index] == 0) {
+        rnd_indices_vec[index] = 1;
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return rnd_indices_set.insert(index).second;
+    }
+  }
+
+  void insert(const scalar_t& index) {
+    if (use_vec) {
+      rnd_indices_vec[index] = 1;
+    } else {
+      rnd_indices_set.insert(index);
+    }
+  }
+
+ private:
+  const scalar_t& size;
+  bool use_vec;
+  std::vector<char> rnd_indices_vec;
+  phmap::flat_hash_set<scalar_t> rnd_indices_set;
+};
+
+}  // namespace sampler
+}  // namespace pyg

--- a/pyg_lib/csrc/sampler/cpu/mapper.h
+++ b/pyg_lib/csrc/sampler/cpu/mapper.h
@@ -12,7 +12,7 @@ namespace sampler {
 template <typename node_t, typename scalar_t>
 class Mapper {
  public:
-  Mapper(size_t num_nodes, size_t num_entries = -1)
+  Mapper(const size_t num_nodes, const size_t num_entries = -1)
       : num_nodes(num_nodes), num_entries(num_entries) {
     // We use some simple heuristic to determine whether we can use a vector
     // to perform the mapping instead of relying on the more memory-friendly,
@@ -27,7 +27,7 @@ class Mapper {
     }
 
     if (use_vec) {
-      to_local_vec = std::vector<scalar_t>(num_nodes, -1);
+      to_local_vec.resize(num_nodes, -1);
     }
   }
 
@@ -78,7 +78,7 @@ class Mapper {
   }
 
  private:
-  size_t num_nodes, num_entries;
+  const size_t num_nodes, num_entries;
   scalar_t curr = 0;
 
   bool use_vec;

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -2,7 +2,7 @@
 #include <torch/library.h>
 
 #include "pyg_lib/csrc/random/cpu/rand_engine.h"
-#include "pyg_lib/csrc/sampler/cpu/indices_tracker.h"
+#include "pyg_lib/csrc/sampler/cpu/index_tracker.h"
 #include "pyg_lib/csrc/sampler/cpu/mapper.h"
 #include "pyg_lib/csrc/sampler/subgraph.h"
 #include "pyg_lib/csrc/utils/cpu/convert.h"
@@ -61,12 +61,12 @@ class NeighborSampler {
 
     // Case 3: Sample without replacement:
     else {
-      auto indicesTracker = pyg::sampler::IndicesTracker<scalar_t>(population);
+      auto index_tracker = IndexTracker<scalar_t>(population);
       for (size_t i = population - count; i < population; ++i) {
         auto rnd = generator(0, i + 1);
-        if (!indicesTracker.tryInsert(rnd)) {
+        if (!index_tracker.try_insert(rnd)) {
           rnd = i;
-          indicesTracker.insert(i);
+          index_tracker.insert(i);
         }
         const auto edge_id = row_start + rnd;
         add(edge_id, global_src_node, local_src_node, dst_mapper,


### PR DESCRIPTION
Apply usage of indicesTracker mechanism in neighbor sample.
IndicesTracker is replacing the unordered_set usage by using vector<char> indexing or flat_hash_set (base on population size).
Contributors/Kudos: @kgajdamo @OlhaBabicheva 
![image](https://user-images.githubusercontent.com/28142714/188426714-142466c7-863b-4177-b2a3-640d73700caf.png)
![image](https://user-images.githubusercontent.com/28142714/188426798-6d35fac5-0763-4640-843c-0966bf0b9a32.png)
