### PR TITLE
fix(sampler): default value for `mapper_dict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added CSC mode to `pyg::sampler::neighbor_sample` and `pyg::sampler::hetero_neighbor_sample` ([#95](https://github.com/pyg-team/pyg-lib/pull/95), [#96](https://github.com/pyg-team/pyg-lib/pull/96))
 - Speed up `pyg::sampler::neighbor_sample` via `IndexTracker` implementation ([#84](https://github.com/pyg-team/pyg-lib/pull/84))
-- Added `pyg::sampler::hetero_neighbor_sample` implementation ([#90](https://github.com/pyg-team/pyg-lib/pull/90), [#92](https://github.com/pyg-team/pyg-lib/pull/92), [#94](https://github.com/pyg-team/pyg-lib/pull/94), [#97](https://github.com/pyg-team/pyg-lib/pull/97))
+- Added `pyg::sampler::hetero_neighbor_sample` implementation ([#90](https://github.com/pyg-team/pyg-lib/pull/90), [#92](https://github.com/pyg-team/pyg-lib/pull/92), [#94](https://github.com/pyg-team/pyg-lib/pull/94), [#97](https://github.com/pyg-team/pyg-lib/pull/97), [#98](https://github.com/pyg-team/pyg-lib/pull/98))
 - Added `pyg::utils::to_vector` implementation ([#88](https://github.com/pyg-team/pyg-lib/pull/88))
 - Added support for PyTorch 1.12 ([#57](https://github.com/pyg-team/pyg-lib/pull/57), [#58](https://github.com/pyg-team/pyg-lib/pull/58))
 - Added `grouped_matmul` and `segment_matmul` CUDA implementations via `cutlass` ([#51](https://github.com/pyg-team/pyg-lib/pull/51), [#56](https://github.com/pyg-team/pyg-lib/pull/56), [#61](https://github.com/pyg-team/pyg-lib/pull/61), [#64](https://github.com/pyg-team/pyg-lib/pull/64), [#69](https://github.com/pyg-team/pyg-lib/pull/69))

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -335,7 +335,6 @@ sample(const std::vector<node_type>& node_types,
       }
       slice_dict[k] = {0, 0};
     }
-
     for (const auto& k : edge_types) {
       L = std::max(L, num_neighbors_dict.at(to_rel_type(k)).size());
       sampler_dict.insert(

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -327,9 +327,15 @@ sample(const std::vector<node_type>& node_types,
     std::vector<scalar_t> seed_times;
     for (const auto& k : node_types) {
       sampled_nodes_dict[k];  // Initialize empty vector;
-      mapper_dict.insert({k, Mapper<node_t, scalar_t>(num_nodes_dict.at(k))});
+      if (num_nodes_dict.find(k) != num_nodes_dict.end()) {
+        mapper_dict.insert({k, Mapper<node_t, scalar_t>(num_nodes_dict.at(k))});
+      }
+      else {
+        mapper_dict.insert({k, Mapper<node_t, scalar_t>(0)});
+      }
       slice_dict[k] = {0, 0};
     }
+
     for (const auto& k : edge_types) {
       L = std::max(L, num_neighbors_dict.at(to_rel_type(k)).size());
       sampler_dict.insert(

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -329,8 +329,7 @@ sample(const std::vector<node_type>& node_types,
       sampled_nodes_dict[k];  // Initialize empty vector;
       if (num_nodes_dict.find(k) != num_nodes_dict.end()) {
         mapper_dict.insert({k, Mapper<node_t, scalar_t>(num_nodes_dict.at(k))});
-      }
-      else {
+      } else {
         mapper_dict.insert({k, Mapper<node_t, scalar_t>(0)});
       }
       slice_dict[k] = {0, 0};


### PR DESCRIPTION
Sets a default value of `0` nodes for nodes that occur in `node_types` but not `edge_types` (nodes that do not have any edges).