### PR TITLE
Introduce cpp micro-benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added benchmarking tool (Google Benchmark) along with `pyg::sampler::Mapper` benchmark example ([#101](https://github.com/pyg-team/pyg-lib/pull/101))
 - Added CSC mode to `pyg::sampler::neighbor_sample` and `pyg::sampler::hetero_neighbor_sample` ([#95](https://github.com/pyg-team/pyg-lib/pull/95), [#96](https://github.com/pyg-team/pyg-lib/pull/96))
 - Speed up `pyg::sampler::neighbor_sample` via `IndexTracker` implementation ([#84](https://github.com/pyg-team/pyg-lib/pull/84))
 - Added `pyg::sampler::hetero_neighbor_sample` implementation ([#90](https://github.com/pyg-team/pyg-lib/pull/90), [#92](https://github.com/pyg-team/pyg-lib/pull/92), [#94](https://github.com/pyg-team/pyg-lib/pull/94), [#97](https://github.com/pyg-team/pyg-lib/pull/97), [#98](https://github.com/pyg-team/pyg-lib/pull/98), [#99](https://github.com/pyg-team/pyg-lib/pull/99), [#102](https://github.com/pyg-team/pyg-lib/pull/102), [#110](https://github.com/pyg-team/pyg-lib/pull/110))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(PYG_VERSION 0.1.0)
 
 option(BUILD_TEST "Enable testing" OFF)
+option(BUILD_BENCHMARK "Enable benchmarks" OFF)
 option(WITH_COV "Enable code coverage" OFF)
 option(USE_PYTHON "Link to Python when building" OFF)
 option(WITH_CUDA "Enable CUDA support" OFF)
@@ -55,6 +56,12 @@ if(BUILD_TEST)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 --coverage")
   endif()
   include(cmake/test.cmake)
+endif()
+
+if(BUILD_BENCHMARK)
+  set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE INTERNAL "Disable benchmarking tool tests")
+  set(COMPILE_HAVE_GNU_POSIX_REGEX OFF CACHE INTERNAL "Disable GNU POSIX regex compilation check")
+  include(cmake/benchmark.cmake)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ cmake .. -GNinja -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DWITH_CUDA=ON -DCMAKE_CUD
 cmake --build .
 ```
 
-If you want to include the test suite or benchmarks, specify `-DBUILD_TEST=ON` or `-DBUILD_BENCHMARK=ON` respectively
+If you want to include the test suite or benchmarks, specify `-DBUILD_TEST=ON` or `-DBUILD_BENCHMARK=ON`, respectively
 (both are `OFF` by default).
 Finally, run tests via:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 ## Build & Test
 
 `pyg-lib` can be built as a standalone C++/CUDA library.
-For this, we adopt [CMake](https://cmake.org/) to build and [GoogleTest](https://github.com/google/googletest) to test.
+For this, we adopt [CMake](https://cmake.org/) to build, [GoogleTest](https://github.com/google/googletest) to test
+and [GoogleBenchmark](https://github.com/google/benchmark) to benchmark.
 
 First, install all requirements:
 
@@ -31,11 +32,12 @@ mkdir build
 cd build
 export Torch_DIR=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
 export CUDA_ARCH_LIST=75
-cmake .. -GNinja -DBUILD_TEST=ON -DWITH_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH_LIST}
+cmake .. -GNinja -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DWITH_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH_LIST}
 cmake --build .
 ```
 
-If you want to include the test suite, specify `-DBUILD_TEST=ON` (`OFF` by default).
+If you want to include the test suite or benchmarks, specify `-DBUILD_TEST=ON` or `-DBUILD_BENCHMARK=ON` respectively
+(both are `OFF` by default).
 Finally, run tests via:
 ```
 ctest --verbose --output-on-failure

--- a/benchmark/csrc/sampler/mapper.cpp
+++ b/benchmark/csrc/sampler/mapper.cpp
@@ -1,0 +1,85 @@
+#include <algorithm>
+#include <random>
+#include <type_traits>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include "pyg_lib/csrc/sampler/cpu/mapper.h"
+
+template <typename node_t, typename scalar_t>
+class BenchmarkMapperCreationAndInsertion : public benchmark::Fixture {
+  static_assert(std::is_integral<node_t>::value &&
+                    std::is_integral<scalar_t>::value,
+                "Integral type required for both node_t and scalar_t");
+
+ protected:
+  void SetUp(const benchmark::State& state) override {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    // fill nodes with whole range two times and shuffle it
+    // this will allow some indices to occur more than once
+    const auto num_nodes = state.range(0);
+    nodes_.resize(num_nodes * 2);
+    std::iota(nodes_.begin(), nodes_.begin() + num_nodes, 0);
+    std::iota(nodes_.begin() + num_nodes, nodes_.end(), 0);
+    std::shuffle(nodes_.begin(), nodes_.end(), gen);
+  }
+
+  void TearDown(const benchmark::State& state) override { nodes_.clear(); }
+
+  void PerformTest(size_t num_nodes, size_t num_entries, size_t samples) {
+    insertion_fail_counter_ = 0;
+    pyg::sampler::Mapper<node_t, scalar_t> mapper(num_nodes, num_entries);
+    for (size_t idx = 0; idx < samples; ++idx) {
+      const auto result = mapper.insert(nodes_[idx]);
+      insertion_fail_counter_ += !result.second;
+    }
+  }
+
+  void Loop(benchmark::State& state) {
+    const auto num_nodes = state.range(0);
+    const auto num_entries = state.range(1);
+    const auto samples = num_entries > 0 ? num_entries : num_nodes;
+    for (auto _ : state) {
+      PerformTest(num_nodes, num_entries, samples);
+    }
+    state.SetComplexityN(samples);
+    state.counters["Insertion Fail Rate [%]"] =
+        100.0 * insertion_fail_counter_ / samples;
+  }
+
+  std::vector<node_t> nodes_{};
+  int64_t insertion_fail_counter_{0};
+};
+
+static void duplicated_range(benchmark::internal::Benchmark* benchmark) {
+  const auto range = benchmark::CreateDenseRange(1024E3, 2048E3, 128E3);
+  for (const auto value : range) {
+    benchmark->Args(std::vector<int64_t>(2, value));
+  }
+}
+
+BENCHMARK_TEMPLATE_DEFINE_F(BenchmarkMapperCreationAndInsertion,
+                            WithFlatHashMap,
+                            int64_t,
+                            int64_t)
+(benchmark::State& state) {
+  Loop(state);
+}
+BENCHMARK_REGISTER_F(BenchmarkMapperCreationAndInsertion, WithFlatHashMap)
+    ->ArgsProduct({benchmark::CreateDenseRange(1024E3, 2048E3, 128E3), {-1}})
+    ->ArgNames({"num_nodes", "num_entries"})
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_TEMPLATE_DEFINE_F(BenchmarkMapperCreationAndInsertion,
+                            WithVector,
+                            int64_t,
+                            int64_t)
+(benchmark::State& state) {
+  Loop(state);
+}
+BENCHMARK_REGISTER_F(BenchmarkMapperCreationAndInsertion, WithVector)
+    ->Apply(duplicated_range)
+    ->ArgNames({"num_nodes", "num_entries"})
+    ->Complexity(benchmark::oN);

--- a/benchmark/csrc/sampler/mapper.cpp
+++ b/benchmark/csrc/sampler/mapper.cpp
@@ -15,8 +15,8 @@ class BenchmarkMapperCreationAndInsertion : public benchmark::Fixture {
 
  protected:
   void SetUp(const benchmark::State& state) override {
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
+    // deterministic draw, default seed is 5489u
+    std::mt19937 gen;
     // fill nodes with whole range two times and shuffle it
     // this will allow some indices to occur more than once
     const auto num_nodes = state.range(0);

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+FetchContent_Declare(
+  googlebenchmark
+  GIT_REPOSITORY https://github.com/google/benchmark
+  GIT_TAG v1.7.0
+)
+FetchContent_MakeAvailable(googlebenchmark)
+
+set(CBENCHMARK benchmark/csrc)
+file(GLOB_RECURSE ALL_BENCHMARKS ${CBENCHMARK}/*.cpp)
+
+foreach(benchmark ${ALL_BENCHMARKS})
+    get_filename_component(name ${benchmark} NAME_WE)
+    add_executable(${name} ${benchmark})
+    target_link_libraries(${name} ${PROJECT_NAME} benchmark::benchmark benchmark::benchmark_main torch)
+    target_include_directories(${name} PRIVATE ${PHMAP_DIR})
+endforeach()

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             '-DBUILD_TEST=OFF',
+            '-DBUILD_BENCHMARK=OFF',
             '-DUSE_PYTHON=ON',
             f'-DWITH_CUDA={"ON" if WITH_CUDA else "OFF"}',
             f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}',


### PR DESCRIPTION
This PR introduces C++ benchmarking infrastructure ([GoogleBenchmark](https://github.com/google/benchmark)). As `pyg-lib` can be used as a standalone C++ library it makes sense to have micro-benchmarks that would benchmark not only pieces of code with a Python binding. Additionally, an exemplary benchmark was provided for `pyg::sampler::Mapper`.

Output for provided benchmark looks like follows:
```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                       Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1024000/num_entries:-1    7394664 ns      7392668 ns           91 Insertion Fail Rate [%]=25.0501
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1152000/num_entries:-1    8760396 ns      8757657 ns           77 Insertion Fail Rate [%]=25.0199
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1280000/num_entries:-1    8948630 ns      8945524 ns           76 Insertion Fail Rate [%]=25.0318
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1408000/num_entries:-1   10103691 ns     10099494 ns           68 Insertion Fail Rate [%]=25.0122
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1536000/num_entries:-1   11302446 ns     11296285 ns           61 Insertion Fail Rate [%]=24.993
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1664000/num_entries:-1   12936696 ns     12929287 ns           54 Insertion Fail Rate [%]=25.0384
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1792000/num_entries:-1   14151064 ns     14144356 ns           49 Insertion Fail Rate [%]=25.0186
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:1920000/num_entries:-1   15588397 ns     15576363 ns           45 Insertion Fail Rate [%]=25.0133
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap/num_nodes:2048000/num_entries:-1   17158246 ns     17144487 ns           41 Insertion Fail Rate [%]=25.007
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap_BigO                                   7.77 N          7.77 N    
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithFlatHashMap_RMS                                       6 %             6 %    
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1024000/num_entries:1024000    6776261 ns      6773525 ns          103 Insertion Fail Rate [%]=25.0364
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1152000/num_entries:1152000    7983127 ns      7979648 ns           89 Insertion Fail Rate [%]=24.9776
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1280000/num_entries:1280000    8971134 ns      8965624 ns           78 Insertion Fail Rate [%]=25.0282
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1408000/num_entries:1408000   10156930 ns     10151395 ns           68 Insertion Fail Rate [%]=25.0169
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1536000/num_entries:1536000   11407066 ns     11399957 ns           61 Insertion Fail Rate [%]=25.004
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1664000/num_entries:1664000   12593205 ns     12587564 ns           55 Insertion Fail Rate [%]=24.9894
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1792000/num_entries:1792000   14226021 ns     14215225 ns           49 Insertion Fail Rate [%]=25.0002
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:1920000/num_entries:1920000   15570986 ns     15562529 ns           44 Insertion Fail Rate [%]=24.9714
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector/num_nodes:2048000/num_entries:2048000   17869559 ns     17851791 ns           39 Insertion Fail Rate [%]=24.996
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector_BigO                                        7.76 N          7.75 N    
BenchmarkMapperCreationAndInsertion<int64_t, int64_t>/WithVector_RMS                                            8 %             8 %
```