### PR TITLE
Build `*.so` extension on Mac instead of `*.dylib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,4 +39,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Optional return types in `pyg.subgraph()` ([#40](https://github.com/pyg-team/pyg-lib/pull/40))
 - Absolute headers ([#30](https://github.com/pyg-team/pyg-lib/pull/30))
 - Use `at::equal` rather than `at::all` in tests ([#37](https://github.com/pyg-team/pyg-lib/pull/37))
+- Build `*.so` extension on Mac instead of `*.dylib`([#107](https://github.com/pyg-team/pyg-lib/pull/107))
 ### Removed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,3 +60,8 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES
   EXPORT_NAME PyG
   INSTALL_RPATH ${TORCH_INSTALL_PREFIX}/lib)
+
+# Cmake creates *.dylib by default, but python expects *.so by default
+if (APPLE)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY SUFFIX .so)
+endif()


### PR DESCRIPTION
By default, cmake created *.dylib, but python uses *.so. We either need to change cmake to write *.so, or change python to use *.dylib. I couldn't figure out how torch-sparse/scatter solve this problem (they seem to be creating *.so files), but happy to change the approach to align with the other projects, if you know.