### PR TITLE
Require sorted neighborhoods according to time in temporal sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `CMake` support ([#5](https://github.com/pyg-team/pyg-lib/pull/5))
 - Added `pyg.cuda_version()` ([#4](https://github.com/pyg-team/pyg-lib/pull/4))
 ### Changed
+- Refactored temporal sampling with sorted neighborhood ([#108](https://github.com/pyg-team/pyg-lib/pull/108))
 - Only sample neighbors with a strictly earlier timestamp than the seed node ([#104](https://github.com/pyg-team/pyg-lib/pull/104))
 - Prevent absolute paths in wheel ([#75](https://github.com/pyg-team/pyg-lib/pull/75))
 - Improved installation instructions ([#68](https://github.com/pyg-team/pyg-lib/pull/68))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `CMake` support ([#5](https://github.com/pyg-team/pyg-lib/pull/5))
 - Added `pyg.cuda_version()` ([#4](https://github.com/pyg-team/pyg-lib/pull/4))
 ### Changed
-- Refactored temporal sampling with sorted neighborhood ([#108](https://github.com/pyg-team/pyg-lib/pull/108))
+- Require sorted neighborhoods according to time in temporal sampling ([#108](https://github.com/pyg-team/pyg-lib/pull/108))
 - Only sample neighbors with a strictly earlier timestamp than the seed node ([#104](https://github.com/pyg-team/pyg-lib/pull/104))
 - Prevent absolute paths in wheel ([#75](https://github.com/pyg-team/pyg-lib/pull/75))
 - Improved installation instructions ([#68](https://github.com/pyg-team/pyg-lib/pull/68))

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
+#include <algorithm>
 
 #include "parallel_hashmap/phmap.h"
 
@@ -28,17 +29,17 @@ class NeighborSampler {
   NeighborSampler(const scalar_t* rowptr, const scalar_t* col)
       : rowptr_(rowptr), col_(col) {}
 
-  void uniform_sample(const node_t global_src_node,
-                      const scalar_t local_src_node,
-                      const size_t count,
-                      pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
-                      pyg::random::RandintEngine<scalar_t>& generator,
-                      std::vector<node_t>& out_global_dst_nodes) {
+  void sample_helper(const node_t global_src_node,
+                     const scalar_t local_src_node,
+                     const scalar_t row_start,
+                     const scalar_t row_end,
+                     const size_t count,
+                     pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
+                     pyg::random::RandintEngine<scalar_t>& generator,
+                     std::vector<node_t>& out_global_dst_nodes) {
     if (count == 0)
       return;
 
-    const auto row_start = rowptr_[to_scalar_t(global_src_node)];
-    const auto row_end = rowptr_[to_scalar_t(global_src_node) + 1];
     const auto population = row_end - row_start;
 
     if (population == 0)
@@ -77,6 +78,18 @@ class NeighborSampler {
     }
   }
 
+  void uniform_sample(const node_t global_src_node,
+                      const scalar_t local_src_node,
+                      const size_t count,
+                      pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
+                      pyg::random::RandintEngine<scalar_t>& generator,
+                      std::vector<node_t>& out_global_dst_nodes) {
+    const auto row_start = rowptr_[to_scalar_t(global_src_node)];
+    const auto row_end = rowptr_[to_scalar_t(global_src_node) + 1];
+    sample_helper(global_src_node, local_src_node, row_start, row_end, count,
+                  dst_mapper, generator, out_global_dst_nodes);
+  }
+
   void temporal_sample(const node_t global_src_node,
                        const scalar_t local_src_node,
                        const size_t count,
@@ -85,61 +98,17 @@ class NeighborSampler {
                        pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
                        pyg::random::RandintEngine<scalar_t>& generator,
                        std::vector<node_t>& out_global_dst_nodes) {
-    if (count == 0)
-      return;
-
     const auto row_start = rowptr_[to_scalar_t(global_src_node)];
-    const auto row_end = rowptr_[to_scalar_t(global_src_node) + 1];
-    const auto population = row_end - row_start;
+    auto row_end = rowptr_[to_scalar_t(global_src_node) + 1];
 
-    if (population == 0)
-      return;
+    row_end = std::lower_bound(col_ + row_start, col_ + row_end, seed_time,
+                               [&](const scalar_t& a, const scalar_t& b) {
+                                 return time[a] < b;
+                               }) -
+              col_;
 
-    // Case 1: Sample the full neighborhood:
-    if (count < 0 || (!replace && count >= population)) {
-      for (scalar_t edge_id = row_start; edge_id < row_end; ++edge_id) {
-        if (time[col_[edge_id]] >= seed_time)
-          continue;
-        add(edge_id, global_src_node, local_src_node, dst_mapper,
-            out_global_dst_nodes);
-      }
-    }
-
-    // Case 2: Sample with replacement:
-    else if (replace) {
-      for (size_t i = 0; i < count; ++i) {
-        const auto edge_id = generator(row_start, row_end);
-        // TODO (matthias) Improve temporal sampling logic. Currently, we sample
-        // `count` many random neighbors, and filter them based on temporal
-        // constraints afterwards. Ideally, we only sample exactly `count`
-        // neighbors which fullfill the time constraint.
-        if (time[col_[edge_id]] >= seed_time)
-          continue;
-        add(edge_id, global_src_node, local_src_node, dst_mapper,
-            out_global_dst_nodes);
-      }
-    }
-
-    // Case 3: Sample without replacement:
-    else {
-      std::unordered_set<scalar_t> rnd_indices;
-      for (size_t i = population - count; i < population; ++i) {
-        auto rnd = generator(0, i + 1);
-        if (!rnd_indices.insert(rnd).second) {
-          rnd = i;
-          rnd_indices.insert(i);
-        }
-        const auto edge_id = row_start + rnd;
-        // TODO (matthias) Improve temporal sampling logic. Currently, we sample
-        // `count` many random neighbors, and filter them based on temporal
-        // constraints afterwards. Ideally, we only sample exactly `count`
-        // neighbors which fullfill the time constraint.
-        if (time[col_[edge_id]] >= seed_time)
-          continue;
-        add(edge_id, global_src_node, local_src_node, dst_mapper,
-            out_global_dst_nodes);
-      }
-    }
+    sample_helper(global_src_node, local_src_node, row_start, row_end, count,
+                  dst_mapper, generator, out_global_dst_nodes);
   }
 
   std::tuple<at::Tensor, at::Tensor, c10::optional<at::Tensor>>

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -1,6 +1,5 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
-#include <algorithm>
 
 #include "parallel_hashmap/phmap.h"
 

--- a/pyg_lib/sampler/__init__.py
+++ b/pyg_lib/sampler/__init__.py
@@ -23,6 +23,12 @@ def neighbor_sample(
     r"""Recursively samples neighbors from all node indices in :obj:`seed`
     in the graph given by :obj:`(rowptr, col)`.
 
+    .. note::
+
+        For temporal sampling, the :obj:`col` vector needs to be sorted
+        according to :obj:`time` within individual neighborhoods since we use
+        binary search to find neighbors that fulfill temporal constraints.
+
     Args:
         rowptr (torch.Tensor): Compressed source node indices.
         col (torch.Tensor): Target node indices.
@@ -34,7 +40,9 @@ def neighbor_sample(
             If set, temporal sampling will be used such that neighbors are
             guaranteed to fulfill temporal constraints, *i.e.* neighbors have
             an earlier timestamp than the seed node.
-            Requires :obj:`disjoint=True`. (default: :obj:`None`)
+            If used, the :obj:`col` vector needs to be sorted according to time
+            within individual neighborhoods. Requires :obj:`disjoint=True`.
+            (default: :obj:`None`)
         csc (bool, optional): If set to :obj:`True`, assumes that the graph is
             given in CSC format :obj:`(colptr, row)`. (default: :obj:`False`)
         replace (bool, optional): If set to :obj:`True`, will sample with

--- a/test/csrc/sampler/test_neighbor.cpp
+++ b/test/csrc/sampler/test_neighbor.cpp
@@ -50,6 +50,40 @@ TEST(DisjointNeighborTest, BasicAssertions) {
   EXPECT_TRUE(at::equal(std::get<3>(out).value(), expected_edges));
 }
 
+TEST(TemporalNeighborTest, BasicAssertions) {
+  auto options = at::TensorOptions().dtype(at::kLong);
+
+  auto graph = cycle_graph(/*num_nodes=*/6, options);
+  auto rowptr = std::get<0>(graph);
+  auto col = std::get<1>(graph);
+
+  // Sort the col by time.
+  col = col.reshape({col.size(0) / 2, 2});
+  col = std::get<0>(at::sort(col, /*dim=*/1));
+  col = col.flatten();
+
+  auto seed = at::arange(2, 4, options);
+
+  // Time is equal to node id.
+  auto time = at::arange(6, options);
+  std::vector<int64_t> num_neighbors = {2};
+
+  auto out = pyg::sampler::neighbor_sample(
+      /*rowptr=*/rowptr,
+      /*col=*/col, seed, num_neighbors, /*time=*/time,
+      /*csc=*/false, /*replace=*/false, /*directed=*/true, /*disjoint=*/true);
+
+  // Expect only the first neighbor to be sampled (< seed node time).
+  auto expected_row = at::tensor({0, 1}, options);
+  EXPECT_TRUE(at::equal(std::get<0>(out), expected_row));
+  auto expected_col = at::tensor({2, 3}, options);
+  EXPECT_TRUE(at::equal(std::get<1>(out), expected_col));
+  auto expected_nodes = at::tensor({0, 2, 1, 3, 0, 1, 1, 2}, options);
+  EXPECT_TRUE(at::equal(std::get<2>(out), expected_nodes.view({4, 2})));
+  auto expected_edges = at::tensor({4, 6}, options);
+  EXPECT_TRUE(at::equal(std::get<3>(out).value(), expected_edges));
+}
+
 TEST(HeteroNeighborTest, BasicAssertions) {
   auto options = at::TensorOptions().dtype(at::kLong);
 


### PR DESCRIPTION
As discussed offline, we need to unify the implementation for temporal and non-temporal sampling.
This PR updates the neighbor sampling kernel by deciding the range of sampling based on seed node time. We assume we have sorted each neighborhood by time. This assumption will be guaranteed on pyg side in the follow-up PRs.