### PR TITLE
fix(sampling): modify time satisfaction constraints to support equality

### DIFF
--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -59,7 +59,7 @@ class NeighborSampler {
     // Find new `row_end` such that all neighbors fulfill temporal constraints:
     auto it = std::lower_bound(
         col_ + row_start, col_ + row_end, seed_time,
-        [&](const scalar_t& a, const scalar_t& b) { return time[a] < b; });
+        [&](const scalar_t& a, const scalar_t& b) { return time[a] <= b; });
     row_end = it - col_;
 
     if (temporal_strategy_ == "last") {


### PR DESCRIPTION
This may be a misunderstanding on my part regarding temporal sampling logic, but it seems that destination nodes which have the same node time as the source node should satisfy the temporal constraint. This modification supports this, aligning with the corresponding logic in `torch_sparse` [here](https://github.com/rusty1s/pytorch_sparse/blob/master/csrc/cpu/neighbor_sample_cpu.cpp#L119-L130). 

If the `<` is intended, I'd be happy to understand more about why.