### PR TITLE
Add `neighbor_kernel.h`, remove anonymous namespace

### DIFF
--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -9,11 +9,10 @@
 #include "pyg_lib/csrc/sampler/subgraph.h"
 #include "pyg_lib/csrc/utils/cpu/convert.h"
 #include "pyg_lib/csrc/utils/types.h"
+#include "pyg_lib/csrc/sampler/cpu/neighbor_kernel.h"
 
 namespace pyg {
 namespace sampler {
-
-namespace {
 
 // Helper classes for bipartite neighbor sampling //////////////////////////////
 
@@ -553,8 +552,6 @@ hetero_neighbor_sample_kernel(
                   num_neighbors_dict, time_dict, seed_time_dict, csc,
                   temporal_strategy);
 }
-
-}  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::neighbor_sample"),

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -14,6 +14,8 @@
 namespace pyg {
 namespace sampler {
 
+namespace {
+
 // Helper classes for bipartite neighbor sampling //////////////////////////////
 
 // `node_t` is either a scalar or a pair of scalars (example_id, node_id):
@@ -510,6 +512,8 @@ sample(const std::vector<node_type>& node_types,
     return sample<false, false, false, true>(__VA_ARGS__);                \
   if (!replace && !directed && !disjoint && !return_edge_id)              \
     return sample<false, false, false, false>(__VA_ARGS__);
+
+} // namespace
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, c10::optional<at::Tensor>>
 neighbor_sample_kernel(const at::Tensor& rowptr,

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -513,7 +513,7 @@ sample(const std::vector<node_type>& node_types,
   if (!replace && !directed && !disjoint && !return_edge_id)              \
     return sample<false, false, false, false>(__VA_ARGS__);
 
-} // namespace
+}  // namespace
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, c10::optional<at::Tensor>>
 neighbor_sample_kernel(const at::Tensor& rowptr,

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.h
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.h
@@ -1,0 +1,51 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "parallel_hashmap/phmap.h"
+
+#include "pyg_lib/csrc/random/cpu/rand_engine.h"
+#include "pyg_lib/csrc/sampler/cpu/index_tracker.h"
+#include "pyg_lib/csrc/sampler/cpu/mapper.h"
+#include "pyg_lib/csrc/sampler/subgraph.h"
+#include "pyg_lib/csrc/utils/cpu/convert.h"
+#include "pyg_lib/csrc/utils/types.h"
+
+namespace pyg {
+namespace sampler {
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, c10::optional<at::Tensor>>
+neighbor_sample_kernel(const at::Tensor& rowptr,
+                       const at::Tensor& col,
+                       const at::Tensor& seed,
+                       const std::vector<int64_t>& num_neighbors,
+                       const c10::optional<at::Tensor>& time,
+                       const c10::optional<at::Tensor>& seed_time,
+                       bool csc,
+                       bool replace,
+                       bool directed,
+                       bool disjoint,
+                       std::string temporal_strategy,
+                       bool return_edge_id);
+
+std::tuple<c10::Dict<rel_type, at::Tensor>,
+           c10::Dict<rel_type, at::Tensor>,
+           c10::Dict<node_type, at::Tensor>,
+           c10::optional<c10::Dict<rel_type, at::Tensor>>>
+hetero_neighbor_sample_kernel(
+    const std::vector<node_type>& node_types,
+    const std::vector<edge_type>& edge_types,
+    const c10::Dict<rel_type, at::Tensor>& rowptr_dict,
+    const c10::Dict<rel_type, at::Tensor>& col_dict,
+    const c10::Dict<node_type, at::Tensor>& seed_dict,
+    const c10::Dict<rel_type, std::vector<int64_t>>& num_neighbors_dict,
+    const c10::optional<c10::Dict<node_type, at::Tensor>>& time_dict,
+    const c10::optional<c10::Dict<node_type, at::Tensor>>& seed_time_dict,
+    bool csc,
+    bool replace,
+    bool directed,
+    bool disjoint,
+    std::string temporal_strategy,
+    bool return_edge_id);
+
+}  // namespace sampler
+}  // namespace pyg

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.h
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.h
@@ -1,13 +1,5 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
-
-#include "parallel_hashmap/phmap.h"
-
-#include "pyg_lib/csrc/random/cpu/rand_engine.h"
-#include "pyg_lib/csrc/sampler/cpu/index_tracker.h"
-#include "pyg_lib/csrc/sampler/cpu/mapper.h"
-#include "pyg_lib/csrc/sampler/subgraph.h"
-#include "pyg_lib/csrc/utils/cpu/convert.h"
 #include "pyg_lib/csrc/utils/types.h"
 
 namespace pyg {


### PR DESCRIPTION
It seems that the PyTorch register / dispatching logic is not fully reliable, which causes problems when depending on `neighbor.h` from external libraries. Until this is resolved in a more principled way, we introduce `neighbor_kernel.h` here for external libraries that wish to depend directly on `*_kernel` implementations, that avoid that logic.