### PR TITLE
Change the type of `count` in neighbor sampling

### DIFF
--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -36,7 +36,7 @@ class NeighborSampler {
 
   void uniform_sample(const node_t global_src_node,
                       const scalar_t local_src_node,
-                      const size_t count,
+                      const int64_t count,
                       pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
                       pyg::random::RandintEngine<scalar_t>& generator,
                       std::vector<node_t>& out_global_dst_nodes) {
@@ -48,7 +48,7 @@ class NeighborSampler {
 
   void temporal_sample(const node_t global_src_node,
                        const scalar_t local_src_node,
-                       const size_t count,
+                       const int64_t count,
                        const scalar_t seed_time,
                        const scalar_t* time,
                        pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
@@ -111,7 +111,7 @@ class NeighborSampler {
                const scalar_t local_src_node,
                const scalar_t row_start,
                const scalar_t row_end,
-               const size_t count,
+               const int64_t count,
                pyg::sampler::Mapper<node_t, scalar_t>& dst_mapper,
                pyg::random::RandintEngine<scalar_t>& generator,
                std::vector<node_t>& out_global_dst_nodes) {


### PR DESCRIPTION
Currently we cast `count` in sampler from `int64_t`
https://github.com/pyg-team/pyg-lib/blob/9f51c5b514ba47008683aef68f0ca8620e5b07be/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp#L302
to `size_t`
https://github.com/pyg-team/pyg-lib/blob/9f51c5b514ba47008683aef68f0ca8620e5b07be/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp#L114
But it's possible that `count` is equal to `-1`. In this case casting to `size_t` will "overflow" to a very large value (18446744073709551615).
Though now there is not much influence (because the very large number almost means that to sample all) but it will be better to fix that if we want to compute on `count` or check whether `count < 0`
https://github.com/pyg-team/pyg-lib/blob/9f51c5b514ba47008683aef68f0ca8620e5b07be/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp#L127