### PR TITLE
fix for failing test

### DIFF
--- a/test/ops/test_matmul.py
+++ b/test/ops/test_matmul.py
@@ -59,6 +59,6 @@ def test_grouped_matmul_autograd(device):
         assert torch.allclose(outs[i], inputs[i] @ others[i], atol=1e-6)
 
     if REQ_GRAD:
-        torch.cat([out.mean() for out in outs]).backward()
+        sum([out.sum() for out in outs]).backward()
         for i in range(len(outs)):
             assert others[i].grad.size() == others[i].size()


### PR DESCRIPTION
```
torch.cat([out.mean() for out in outs]).backward()
->
E           RuntimeError: zero-dimensional tensor (at position 0) cannot be concatenated
```

it seems right before merging my [last PR](https://github.com/pyg-team/pyg-lib/pull/137) to pyg-lib, a last minute [change broke the part of the test under if REQ_GRAD](https://github.com/pyg-team/pyg-lib/pull/137/commits/6d0e998fada44f98aceebbce6d805a22d92e1883) and the CI system was on an older version of pytorch so that part of the test wasn't run since `REQ_GRAD = torch.__version__ >= 1.14.0`

original working code [here](https://github.com/pyg-team/pyg-lib/blob/b2b8cdf4603de6b086d39348ead3daf97fbcd456/test/ops/test_matmul_ops.py#L57-L60)
altered broken code [here](https://github.com/puririshi98/pyg-lib/blob/6d0e998fada44f98aceebbce6d805a22d92e1883/test/ops/test_matmul.py#L61-L64)