### PR TITLE
Enable to benchmark neighbor sampler on temporal graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `bias` term to `grouped_matmul` and `segment_matmul` ([#161](https://github.com/pyg-team/pyg-lib/pull/161))
 - Added `sampled_op` impementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
+- Enable benchmarking of neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))
 - Improved `[segment|grouped]_matmul` CPU implementation via `at::matmul_out` and MKL BLAS `gemm_batch` ([#146](https://github.com/pyg-team/pyg-lib/pull/146))
-- Enabled to benchmark neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))
 ### Removed
 
 ## [0.1.0] - 2022-11-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `sampled_op` impementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
 - Improved `[segment|grouped]_matmul` CPU implementation via `at::matmul_out` and MKL BLAS `gemm_batch` ([#146](https://github.com/pyg-team/pyg-lib/pull/146))
+- Enabled to benchmark neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))
 ### Removed
 
 ## [0.1.0] - 2022-11-28

--- a/benchmark/sampler/hetero_neighbor.py
+++ b/benchmark/sampler/hetero_neighbor.py
@@ -77,6 +77,8 @@ def test_hetero_neighbor(dataset, **kwargs):
                     False,  # replace
                     True,  # directed
                     disjoint=args.disjoint,
+                    temporal_strategy=args.temporal_strategy,
+                    return_edge_id=True,
                 )
             pyg_lib_duration = time.perf_counter() - t
 


### PR DESCRIPTION
- Enabled for both homo and hetero samplers
- For pyg-lib only
- Added arguments: disjoint, temporal, temporal-strategy
- Timestamps are randomly generated