### PR TITLE
triton2 support + torch >= 1.14 gmm bias support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.2.0] - 2023-MM-DD
 ### Added
+- Added `triton>=2.0` support ([#171](https://github.com/pyg-team/pyg-lib/pull/171))
 - Added `bias` term to `grouped_matmul` and `segment_matmul` ([#161](https://github.com/pyg-team/pyg-lib/pull/161))
 - Added `sampled_op` impementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -42,9 +42,6 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         others = torch.nested.as_nested_tensor(others).contiguous()
         outs = torch.bmm(inputs, others).contiguous()
         outs = list(outs.unbind())
-        if biases is not None:
-            for i in range(len(biases)):
-                outs[i] = outs[i] + biases[i]
     else:
         input_req_grad = any([i.requires_grad for i in inputs])
         other_req_grad = any([i.requires_grad for i in others])
@@ -54,9 +51,9 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
                              "input tensors before calling this function.")
 
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
-        if biases is not None:
-            for i in range(len(biases)):
-                outs[i] += biases[i]
+    if biases is not None:
+        for i in range(len(biases)):
+            outs[i] += biases[i]
     return outs
 
 

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -42,7 +42,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         others = torch.nested.as_nested_tensor(others).contiguous()
         outs = torch.bmm(inputs, others).contiguous()
         if biases is not None:
-           for i in range(len(biases)):
+            for i in range(len(biases)):
                 outs[i] += biases[i]
         outs = list(outs.unbind())
     else:

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -42,7 +42,8 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         others = torch.nested.as_nested_tensor(others).contiguous()
         outs = torch.bmm(inputs, others).contiguous()
         if biases is not None:
-            outs += torch.nested.as_nested_tensor(biases)
+           for i in range(len(biases)):
+                outs[i] += biases[i]
         outs = list(outs.unbind())
     else:
         input_req_grad = any([i.requires_grad for i in inputs])

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -53,7 +53,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
     if biases is not None:
         for i in range(len(biases)):
-            outs[i] += biases[i]
+            outs[i] = outs[i] + biases[i]
     return outs
 
 

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -41,10 +41,10 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         inputs = torch.nested.as_nested_tensor(inputs).contiguous()
         others = torch.nested.as_nested_tensor(others).contiguous()
         outs = torch.bmm(inputs, others).contiguous()
+        outs = list(outs.unbind())
         if biases is not None:
             for i in range(len(biases)):
-                outs[i] += biases[i]
-        outs = list(outs.unbind())
+                outs[i] += biases[i] 
     else:
         input_req_grad = any([i.requires_grad for i in inputs])
         other_req_grad = any([i.requires_grad for i in others])

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -44,7 +44,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         outs = list(outs.unbind())
         if biases is not None:
             for i in range(len(biases)):
-                outs[i] += biases[i]
+                outs[i] = outs[i] + biases[i]
     else:
         input_req_grad = any([i.requires_grad for i in inputs])
         other_req_grad = any([i.requires_grad for i in others])

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -44,7 +44,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         outs = list(outs.unbind())
         if biases is not None:
             for i in range(len(biases)):
-                outs[i] += biases[i] 
+                outs[i] += biases[i]
     else:
         input_req_grad = any([i.requires_grad for i in inputs])
         other_req_grad = any([i.requires_grad for i in others])

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,8 +12,8 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0, REDUCE1,
-                                REDUCE2, REDUCE3, BLOCK_SIZE):
+                                num_reductions, numel, REDUCE0: int, REDUCE1: int,
+                                REDUCE2: int, REDUCE3: int, BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -133,16 +133,17 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
+
     def to_int(reduction_str):
-      if reduction_str == 'sum':
-        return 0
-      if reduction_str == 'mean':
-        return 1
-      if reduction_str == 'min':
-        return 2
-      if reduction_str == 'max':
-        return 3
-      
+        if reduction_str == 'sum':
+            return 0
+        if reduction_str == 'mean':
+            return 1
+        if reduction_str == 'min':
+            return 2
+        if reduction_str == 'max':
+            return 3
+
     fused_scatter_reduce_kernel[grid](
         inputs,
         index,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -30,55 +30,59 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # TODO (matthias) Try to clean this up.
 
     reduce = REDUCE0
-    out_offsets = (num_feats * num_reductions) * index
-    out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0:  # sum
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1:  # mean
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2:  # min
-        tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3:  # max
-        tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4: # none
+      out_offsets = (num_feats * num_reductions) * index
+      out_offsets = out_offsets + (offsets % num_feats)
+      if reduce == 0:  # sum
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 1:  # mean
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 2:  # min
+          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 3:  # max
+          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE1
-    out_offsets = (num_feats * num_reductions) * index
-    out_offsets = out_offsets + num_feats
-    out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0:  # sum
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1:  # mean
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2:  # min
-        tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3:  # max
-        tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4: # none
+      out_offsets = (num_feats * num_reductions) * index
+      out_offsets = out_offsets + num_feats
+      out_offsets = out_offsets + (offsets % num_feats)
+      if reduce == 0:  # sum
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 1:  # mean
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 2:  # min
+          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 3:  # max
+          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE2
-    out_offsets = (num_feats * num_reductions) * index
-    out_offsets = out_offsets + (2 * num_feats)
-    out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0:  # sum
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1:  # mean
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2:  # min
-        tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3:  # max
-        tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4: # none
+      out_offsets = (num_feats * num_reductions) * index
+      out_offsets = out_offsets + (2 * num_feats)
+      out_offsets = out_offsets + (offsets % num_feats)
+      if reduce == 0:  # sum
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 1:  # mean
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 2:  # min
+          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 3:  # max
+          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE3
-    out_offsets = (num_feats * num_reductions) * index
-    out_offsets = out_offsets + (3 * num_feats)
-    out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0:  # sum
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1:  # mean
-        tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2:  # min
-        tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3:  # max
-        tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4: # none
+      out_offsets = (num_feats * num_reductions) * index
+      out_offsets = out_offsets + (3 * num_feats)
+      out_offsets = out_offsets + (offsets % num_feats)
+      if reduce == 0:  # sum
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 1:  # mean
+          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 2:  # min
+          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+      elif reduce == 3:  # max
+          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
 
 def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -27,7 +27,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # NOTE Triton does not support for-loops. As such, we cap the maximum
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
-    reduction_from_int = lambda r_int: REDUCTIONS[r_int] if r_int != -1 else NONE
+    reduction_from_int = lambda r_int: REDUCTIONS[r_int
+                                                  ] if r_int != -1 else NONE
     reduce = reduction_from_int(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
@@ -132,7 +133,8 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[r_idx]) if r_idx != NONE else -1
+    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[r_idx]
+                                                   ) if r_idx != NONE else -1
     meta = [
         reduction_int(0),  # cannot pass str such as 'sum'
         reduction_int(1),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,7 +12,8 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE_LIST: List, **meta):
+                                num_reductions, numel, REDUCE_LIST: List,
+                                **meta):
     pid = tl.program_id(axis=0)
     block_start = pid * meta['BLOCK_SIZE']
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -142,7 +142,12 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
         256  # BLOCK_SIZE
     ]
     fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
-                                      num_reductions, inputs.numel(), *meta)
+                                      num_reductions, inputs.numel(), REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
+        REDUCTIONS.index(reduce_list[1]),
+        REDUCTIONS.index(reduce_list[2]),
+        REDUCTIONS.index(reduce_list[3]),
+        256  # BLOCK_SIZE
+    )
 
     # Post-processing:
     if 'mean' in reduce_slice_dict:

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -141,7 +141,8 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
         num_feats,
         num_reductions,
         inputs.numel(),
-        REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum' or lists
+        REDUCTIONS.index(
+            reduce_list[0]),  # cannot pass str such as 'sum' or lists
         REDUCTIONS.index(reduce_list[1]),
         REDUCTIONS.index(reduce_list[2]),
         REDUCTIONS.index(reduce_list[3]),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -132,7 +132,7 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
     meta = {'REDUCE_LIST': reduce_list, 'BLOCK_SIZE': 256}
     fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
-                                      num_reductions, inputs.numel(), meta)
+                                      num_reductions, inputs.numel(), **meta)
 
     # Post-processing:
     if 'mean' in reduce_slice_dict:

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,9 +12,9 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int,
-                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
-                                BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0='',
+                                REDUCE1='', REDUCE2='', REDUCE3='',
+                                BLOCK_SIZE=''):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -136,7 +136,7 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
         reduce_list[1],
         reduce_list[2],
         reduce_list[3],
-        256 # BLOCK_SIZE
+        256  # BLOCK_SIZE
     ]
     fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
                                       num_reductions, inputs.numel(), *meta)

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -132,7 +132,7 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
     meta = [
-        REDUCTIONS.index(reduce_list[0]), # cannot pass str such as 'sum'
+        REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
         REDUCTIONS.index(reduce_list[1]),
         REDUCTIONS.index(reduce_list[2]),
         REDUCTIONS.index(reduce_list[3]),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -13,11 +13,11 @@ NONE = 'none'
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
                                 num_reductions, numel, REDUCE_LIST: List,
-                                **meta):
+                                BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
-    block_start = pid * meta['BLOCK_SIZE']
+    block_start = pid * BLOCK_SIZE
 
-    offsets = block_start + tl.arange(0, meta['BLOCK_SIZE'])
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < numel
     inputs = tl.load(inputs_ptr + offsets, mask=mask)
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,8 +12,9 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int, REDUCE1: int,
-                                REDUCE2: int, REDUCE3: int, BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0: int,
+                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
+                                BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 
@@ -28,7 +29,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
     def reduction_from_int(r_int):
-      return REDUCTIONS[r_int] if r_int != -1 else NONE
+        return REDUCTIONS[r_int] if r_int != -1 else NONE
+
     reduce = reduction_from_int(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
@@ -133,8 +135,11 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
+
     def reduction_int(r_idx):
-      REDUCTIONS.index(reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
+        REDUCTIONS.index(
+            reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
+
     meta = [
         reduction_int(0),  # cannot pass str such as 'sum'
         reduction_int(1),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,9 +12,8 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int,
-                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
-                                BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0: int, REDUCE1: int,
+                                REDUCE2: int, REDUCE3: int, BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 
@@ -28,8 +27,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # NOTE Triton does not support for-loops. As such, we cap the maximum
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
-    reduction_from_int = lambda r_int: REDUCTIONS[r_int
-                                                  ] if r_int != -1 else NONE
+    def reduction_from_int(r_int):
+      return REDUCTIONS[r_int] if r_int != -1 else NONE
     reduce = reduction_from_int(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
@@ -134,8 +133,8 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[
-        r_idx]) if reduce_list[r_idx] != NONE else -1
+    def reduction_int(r_idx):
+      REDUCTIONS.index(reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
     meta = [
         reduction_int(0),  # cannot pass str such as 'sum'
         reduction_int(1),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -7,6 +7,7 @@ from pyg_lib._triton import tl, triton
 
 REDUCTIONS = ['sum', 'mean', 'min', 'max', 'none']
 NUM_REDUCTIONS = len(REDUCTIONS) - 1
+NONE = 'none'
 
 
 @triton.jit

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -141,8 +141,14 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
         REDUCTIONS.index(reduce_list[3]),
         256  # BLOCK_SIZE
     ]
-    fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
-                                      num_reductions, inputs.numel(), REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
+    fused_scatter_reduce_kernel[grid](
+        inputs,
+        index,
+        out,
+        num_feats,
+        num_reductions,
+        inputs.numel(),
+        REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
         REDUCTIONS.index(reduce_list[1]),
         REDUCTIONS.index(reduce_list[2]),
         REDUCTIONS.index(reduce_list[3]),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,9 +12,8 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0='',
-                                REDUCE1='', REDUCE2='', REDUCE3='',
-                                BLOCK_SIZE=''):
+                                num_reductions, numel, REDUCE0='', REDUCE1='',
+                                REDUCE2='', REDUCE3='', BLOCK_SIZE=''):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,7 +12,7 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, meta):
+                                num_reductions, numel, **meta):
     pid = tl.program_id(axis=0)
     block_start = pid * meta['BLOCK_SIZE']
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -130,16 +130,9 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    meta = {'REDUCE_LIST':reduce_list, 'BLOCK_SIZE': 256}
-    fused_scatter_reduce_kernel[grid](
-        inputs,
-        index,
-        out,
-        num_feats,
-        num_reductions,
-        inputs.numel(),
-        meta
-    )
+    meta = {'REDUCE_LIST': reduce_list, 'BLOCK_SIZE': 256}
+    fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
+                                      num_reductions, inputs.numel(), meta)
 
     # Post-processing:
     if 'mean' in reduce_slice_dict:

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -30,59 +30,59 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # TODO (matthias) Try to clean this up.
 
     reduce = REDUCE0
-    if reduce != 4: # none
-      out_offsets = (num_feats * num_reductions) * index
-      out_offsets = out_offsets + (offsets % num_feats)
-      if reduce == 0:  # sum
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 1:  # mean
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 2:  # min
-          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 3:  # max
-          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4:  # none
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (offsets % num_feats)
+        if reduce == 0:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 1:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 2:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 3:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE1
-    if reduce != 4: # none
-      out_offsets = (num_feats * num_reductions) * index
-      out_offsets = out_offsets + num_feats
-      out_offsets = out_offsets + (offsets % num_feats)
-      if reduce == 0:  # sum
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 1:  # mean
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 2:  # min
-          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 3:  # max
-          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4:  # none
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + num_feats
+        out_offsets = out_offsets + (offsets % num_feats)
+        if reduce == 0:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 1:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 2:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 3:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE2
-    if reduce != 4: # none
-      out_offsets = (num_feats * num_reductions) * index
-      out_offsets = out_offsets + (2 * num_feats)
-      out_offsets = out_offsets + (offsets % num_feats)
-      if reduce == 0:  # sum
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 1:  # mean
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 2:  # min
-          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 3:  # max
-          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4:  # none
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (2 * num_feats)
+        out_offsets = out_offsets + (offsets % num_feats)
+        if reduce == 0:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 1:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 2:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 3:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE3
-    if reduce != 4: # none
-      out_offsets = (num_feats * num_reductions) * index
-      out_offsets = out_offsets + (3 * num_feats)
-      out_offsets = out_offsets + (offsets % num_feats)
-      if reduce == 0:  # sum
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 1:  # mean
-          tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 2:  # min
-          tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-      elif reduce == 3:  # max
-          tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+    if reduce != 4:  # none
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (3 * num_feats)
+        out_offsets = out_offsets + (offsets % num_feats)
+        if reduce == 0:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 1:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 2:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif reduce == 3:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
 
 def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -27,8 +27,7 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # NOTE Triton does not support for-loops. As such, we cap the maximum
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
-    reduction_from_int = lambda r_int: REDUCTIONS[r_int
-                                                  ] if r_int != -1 else NONE
+    reduction_from_int = lambda r_int: REDUCTIONS[r_int] if r_int != -1 else NONE
     reduce = reduction_from_int(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
@@ -133,8 +132,7 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[r_idx]
-                                                   ) if r_idx != NONE else -1
+    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
     meta = [
         reduction_int(0),  # cannot pass str such as 'sum'
         reduction_int(1),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional
+from typing import List
 
 from torch import Tensor
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -27,7 +27,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # NOTE Triton does not support for-loops. As such, we cap the maximum
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
-    reduction_from_int = lambda r_int: REDUCTIONS[r_int] if r_int != -1 else NONE
+    reduction_from_int = lambda r_int: REDUCTIONS[r_int
+                                                  ] if r_int != -1 else NONE
     reduce = reduction_from_int(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
@@ -132,7 +133,8 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
+    reduction_int = lambda r_idx: REDUCTIONS.index(reduce_list[
+        r_idx]) if reduce_list[r_idx] != NONE else -1
     meta = [
         reduction_int(0),  # cannot pass str such as 'sum'
         reduction_int(1),

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,8 +12,9 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int, REDUCE1: int,
-                                REDUCE2: int, REDUCE3: int, BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0: int,
+                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
+                                BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -12,7 +12,9 @@ NONE = 'none'
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int, REDUCE1: int, REDUCE2: int, REDUCE3: int, BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0: int,
+                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
+                                BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -130,7 +130,13 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
-    meta = {'REDUCE0': reduce_list[0], 'REDUCE1': reduce_list[1], 'REDUCE2': reduce_list[2], 'REDUCE3': reduce_list[3], 'BLOCK_SIZE': 256}
+    meta = {
+        'REDUCE0': reduce_list[0],
+        'REDUCE1': reduce_list[1],
+        'REDUCE2': reduce_list[2],
+        'REDUCE3': reduce_list[3],
+        'BLOCK_SIZE': 256
+    }
     fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
                                       num_reductions, inputs.numel(), **meta)
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -30,58 +30,58 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # TODO (matthias) Try to clean this up.
 
     reduce = REDUCTIONS(REDUCE0)
-    if reduce != 4: # none
+    if reduce != 4:  # none
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0: # sum
+    if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1: # mean
+    elif reduce == 1:  # mean
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2: # min
+    elif reduce == 2:  # min
         tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3: # max
+    elif reduce == 3:  # max
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCTIONS(REDUCE1)
-    if reduce != 4: # none
+    if reduce != 4:  # none
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + num_feats
         out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0: # sum
+    if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1: # mean
+    elif reduce == 1:  # mean
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2: # min
+    elif reduce == 2:  # min
         tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3: # max
+    elif reduce == 3:  # max
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCTIONS(REDUCE2)
-    if reduce != 4: # none
+    if reduce != 4:  # none
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (2 * num_feats)
         out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0: # sum
+    if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1: # mean
+    elif reduce == 1:  # mean
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2: # min
+    elif reduce == 2:  # min
         tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3: # max
+    elif reduce == 3:  # max
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCTIONS(REDUCE3)
-    if reduce != 4: # none
+    if reduce != 4:  # none
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (3 * num_feats)
         out_offsets = out_offsets + (offsets % num_feats)
-    if reduce == 0: # sum
+    if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 1: # mean
+    elif reduce == 1:  # mean
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 2: # min
+    elif reduce == 2:  # min
         tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-    elif reduce == 3: # max
+    elif reduce == 3:  # max
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
 
@@ -134,14 +134,19 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
 
-    fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,
-                                      num_reductions, inputs.numel(),
-                                      REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
-                                      REDUCTIONS.index(reduce_list[1]),
-                                      REDUCTIONS.index(reduce_list[2]),
-                                      REDUCTIONS.index(reduce_list[3]),
-                                      256  # BLOCK_SIZE
-                                     )
+    fused_scatter_reduce_kernel[grid](
+        inputs,
+        index,
+        out,
+        num_feats,
+        num_reductions,
+        inputs.numel(),
+        REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
+        REDUCTIONS.index(reduce_list[1]),
+        REDUCTIONS.index(reduce_list[2]),
+        REDUCTIONS.index(reduce_list[3]),
+        256  # BLOCK_SIZE
+    )
 
     # Post-processing:
     if 'mean' in reduce_slice_dict:

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -5,9 +5,8 @@ from torch import Tensor
 
 from pyg_lib._triton import tl, triton
 
-REDUCTIONS = ['sum', 'mean', 'min', 'max']
-NUM_REDUCTIONS = len(REDUCTIONS)
-NONE = 'none'
+REDUCTIONS = ['sum', 'mean', 'min', 'max', 'none']
+NUM_REDUCTIONS = len(REDUCTIONS) - 1
 
 
 @triton.jit
@@ -28,10 +27,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # NOTE Triton does not support for-loops. As such, we cap the maximum
     # number of fused operations to `4` and unroll the loop.
     # TODO (matthias) Try to clean this up.
-    def reduction_from_int(r_int):
-        return REDUCTIONS[r_int] if r_int != -1 else NONE
 
-    reduce = reduction_from_int(REDUCE0)
+    reduce = REDUCTIONS(REDUCE0)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (offsets % num_feats)
@@ -44,7 +41,7 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     elif reduce == 'max':
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
-    reduce = reduction_from_int(REDUCE1)
+    reduce = REDUCTIONS(REDUCE1)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + num_feats
@@ -58,7 +55,7 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     elif reduce == 'max':
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
-    reduce = reduction_from_int(REDUCE2)
+    reduce = REDUCTIONS(REDUCE2)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (2 * num_feats)
@@ -72,7 +69,7 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     elif reduce == 'max':
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
-    reduce = reduction_from_int(REDUCE3)
+    reduce = REDUCTIONS(REDUCE3)
     if reduce != NONE:
         out_offsets = (num_feats * num_reductions) * index
         out_offsets = out_offsets + (3 * num_feats)
@@ -136,15 +133,11 @@ def fused_scatter_reduce(inputs: Tensor, index: Tensor, dim_size: int,
 
     grid = lambda meta: (triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']), )
 
-    def reduction_int(r_idx):
-        REDUCTIONS.index(
-            reduce_list[r_idx]) if reduce_list[r_idx] != NONE else -1
-
     meta = [
-        reduction_int(0),  # cannot pass str such as 'sum'
-        reduction_int(1),
-        reduction_int(2),
-        reduction_int(3),
+        REDUCTIONS.index(reduce_list[0]),  # cannot pass str such as 'sum'
+        REDUCTIONS.index(reduce_list[1]),
+        REDUCTIONS.index(reduce_list[2]),
+        REDUCTIONS.index(reduce_list[3]),
         256  # BLOCK_SIZE
     ]
     fused_scatter_reduce_kernel[grid](inputs, index, out, num_feats,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -14,9 +14,8 @@ OPT_REDUCTIONS = [NONE] + REDUCTIONS
 
 @triton.jit
 def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
-                                num_reductions, numel, REDUCE0: int,
-                                REDUCE1: int, REDUCE2: int, REDUCE3: int,
-                                BLOCK_SIZE: int):
+                                num_reductions, numel, REDUCE0, REDUCE1,
+                                REDUCE2, REDUCE3, BLOCK_SIZE):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -30,9 +30,8 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
     # TODO (matthias) Try to clean this up.
 
     reduce = REDUCE0
-    if reduce != 4:  # none
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (offsets % num_feats)
+    out_offsets = (num_feats * num_reductions) * index
+    out_offsets = out_offsets + (offsets % num_feats)
     if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
     elif reduce == 1:  # mean
@@ -43,10 +42,9 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE1
-    if reduce != 4:  # none
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + num_feats
-        out_offsets = out_offsets + (offsets % num_feats)
+    out_offsets = (num_feats * num_reductions) * index
+    out_offsets = out_offsets + num_feats
+    out_offsets = out_offsets + (offsets % num_feats)
     if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
     elif reduce == 1:  # mean
@@ -57,10 +55,9 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE2
-    if reduce != 4:  # none
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (2 * num_feats)
-        out_offsets = out_offsets + (offsets % num_feats)
+    out_offsets = (num_feats * num_reductions) * index
+    out_offsets = out_offsets + (2 * num_feats)
+    out_offsets = out_offsets + (offsets % num_feats)
     if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
     elif reduce == 1:  # mean
@@ -71,10 +68,9 @@ def fused_scatter_reduce_kernel(inputs_ptr, index_ptr, out_ptr, num_feats,
         tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     reduce = REDUCE3
-    if reduce != 4:  # none
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (3 * num_feats)
-        out_offsets = out_offsets + (offsets % num_feats)
+    out_offsets = (num_feats * num_reductions) * index
+    out_offsets = out_offsets + (3 * num_feats)
+    out_offsets = out_offsets + (offsets % num_feats)
     if reduce == 0:  # sum
         tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
     elif reduce == 1:  # mean

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ install_requires = []
 maybe_append_with_mkl(install_requires)
 
 triton_requires = [
-    'triton==1.1.1',
+    'triton',
 ]
 
 test_requires = [

--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -6,7 +6,7 @@ from pyg_lib.testing import onlyCUDA, onlyTriton
 
 
 @triton.jit
-def add_kernel(x_ptr, y_ptr, out_ptr, numel, BLOCK_SIZE: int):
+def add_kernel(x_ptr, y_ptr, out_ptr, numel, BLOCK_SIZE):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
 

--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -24,7 +24,7 @@ def add_kernel(x_ptr, y_ptr, out_ptr, numel, BLOCK_SIZE: int):
 def add(x: Tensor, y: Tensor) -> Tensor:
     out = torch.empty_like(x)
     assert x.is_cuda and y.is_cuda and out.is_cuda
-    grid = lambda BLOCK_SIZE: (triton.cdiv(x.numel(), BLOCK_SIZE), )
+    grid = lambda meta: (triton.cdiv(x.numel(), meta['BLOCK_SIZE']), )
     add_kernel[grid](x, y, out, x.numel(), BLOCK_SIZE=1024)
     return out
 

--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -1,5 +1,6 @@
 import torch
 from torch import Tensor
+
 from pyg_lib._triton import tl, triton
 from pyg_lib.testing import onlyCUDA, onlyTriton
 

--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -1,16 +1,15 @@
 import torch
 from torch import Tensor
-
 from pyg_lib._triton import tl, triton
 from pyg_lib.testing import onlyCUDA, onlyTriton
 
 
 @triton.jit
-def add_kernel(x_ptr, y_ptr, out_ptr, numel, **meta):
+def add_kernel(x_ptr, y_ptr, out_ptr, numel, BLOCK_SIZE: int):
     pid = tl.program_id(axis=0)
-    block_start = pid * meta['BLOCK_SIZE']
+    block_start = pid * BLOCK_SIZE
 
-    offsets = block_start + tl.arange(0, meta['BLOCK_SIZE'])
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < numel
 
     x = tl.load(x_ptr + offsets, mask=mask)
@@ -24,7 +23,7 @@ def add_kernel(x_ptr, y_ptr, out_ptr, numel, **meta):
 def add(x: Tensor, y: Tensor) -> Tensor:
     out = torch.empty_like(x)
     assert x.is_cuda and y.is_cuda and out.is_cuda
-    grid = lambda meta: (triton.cdiv(x.numel(), meta['BLOCK_SIZE']), )
+    grid = lambda BLOCK_SIZE: (triton.cdiv(x.numel(), BLOCK_SIZE), )
     add_kernel[grid](x, y, out, x.numel(), BLOCK_SIZE=1024)
     return out
 


### PR DESCRIPTION
triton 2.0 issues:

```
_________________________________ test_triton __________________________________
203    @onlyCUDA
204    @onlyTriton
205    def test_triton():
206        x = torch.rand(100, device='cuda')
207        y = torch.rand(100, device='cuda')
208>       assert torch.allclose(x + y, add(x, y))
209test/test_triton.py:37: 
210_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
211test/test_triton.py:28: in add
212    add_kernel[grid](x, y, out, x.numel(), BLOCK_SIZE=1024)
213_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
214args = (tensor([0.6357, 0.4071, 0.4647, 0.2352, 0.8715, 0.7922, 0.7041, 0.1047, 0.1574,
215        0.3703, 0.3483, 0.2265, 0.943...0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
216        0., 0., 0., 0.], device='cuda:0'), 100)
217kwargs = {'BLOCK_SIZE': 1024}
218    def launcher(*args, **kwargs):
219>       return self.run(*args, grid=grid, **kwargs)
220E       TypeError: add_kernel() got an unexpected keyword argument 'BLOCK_SIZE'


__________________________ test_fused_scatter_reduce ___________________________
    @onlyCUDA
    @onlyTriton
    def test_fused_scatter_reduce():
        x = torch.randn(5, 4, device='cuda')
        index = torch.tensor([0, 1, 0, 1, 0], device='cuda')
    
>       out = fused_scatter_reduce(x, index, dim_size=2,
                                   reduce_list=['sum', 'mean'])
test/ops/test_scatter_reduce.py:13: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.8/dist-packages/pyg_lib-0.1.0-py3.8-linux-x86_64.egg/pyg_lib/ops/scatter_reduce.py:133: in fused_scatter_reduce
    fused_scatter_reduce_kernel[grid](
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
args = (tensor([[-0.1390, -0.5071,  0.1290, -0.1594],
        [-1.2358, -0.3644, -0.5571, -0.9715],
        [-0.3111, -0.7264...a:0'), tensor([[0., 0., 0., 0., 0., 0., 0., 0.],
        [0., 0., 0., 0., 0., 0., 0., 0.]], device='cuda:0'), 4, 2, 20)
kwargs = {'BLOCK_SIZE': 256, 'REDUCE_LIST': ['sum', 'mean', 'none', 'none']}
    def launcher(*args, **kwargs):
>       return self.run(*args, grid=grid, **kwargs)
E       TypeError: fused_scatter_reduce_kernel() got an unexpected keyword argument 'REDUCE_LIST'
```

torch >= 1.14 issue:
```
            if biases is not None:
>               outs += torch.nested.as_nested_tensor(biases)
E               RuntimeError: add_ does not support broadcasting when given a NestedTensor
```