### PR TITLE
`(segment|grouped)_matmul` improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ alpha/
 .venv
 *.out
 *.pt
+pyg_lib/csrc/config.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `sampled_op` impementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
 - Enable benchmarking of neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))
-- Improved `[segment|grouped]_matmul` CPU implementation via `at::matmul_out` and MKL BLAS `gemm_batch` ([#146](https://github.com/pyg-team/pyg-lib/pull/146))
+- Improved `[segment|grouped]_matmul` CPU implementation via `at::matmul_out` and MKL BLAS `gemm_batch` ([#146](https://github.com/pyg-team/pyg-lib/pull/146), [#172](https://github.com/pyg-team/pyg-lib/pull/172))
 ### Removed
 
 ## [0.1.0] - 2022-11-28

--- a/pyg_lib/csrc/config.h
+++ b/pyg_lib/csrc/config.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define WITH_MKL_BLAS() 0


### PR DESCRIPTION
Added several fixes and improvements for `(segment|grouped)_matmul`:
* PyTorch stores shape information in `int64_t` variables, whereas MKL uses regular `int`. This means that tensor size can exceed the maximum value acceptable by MKL - in that case we need to use the ATen execution path.
* `config.h` file was removed and added to the .gitignore list - it is automatically generated during the build from the `config.h.in`.
* grain size in MKL sequential execution path was improved, resulting in an average 53% speedup.
