### PR TITLE
for pyg-lib  to_hetero to work

### DIFF
--- a/pyg_lib/csrc/ops/autograd/matmul_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/matmul_kernel.cpp
@@ -97,9 +97,9 @@ class SegmentMatmul : public torch::autograd::Function<SegmentMatmul> {
       auto sizes = at::IntArrayRef(size.data_ptr<int64_t>(), size.numel());
       auto input_t = input.transpose(-2, -1);
       variable_list split_input_t =
-          input_t.split_with_sizes(/*split_size=*/sizes, /*dim=*/1);
+          input_t.split_with_sizes_copy(/*split_size=*/sizes, /*dim=*/1);
       variable_list grad_out_split =
-          grad_out.split_with_sizes(/*split_size=*/sizes, /*dim=*/0);
+          grad_out.split_with_sizes_copy(/*split_size=*/sizes, /*dim=*/0);
       variable_list others_grad;
       for (size_t i = 0; i < split_input_t.size(); ++i)
         others_grad.push_back(


### PR DESCRIPTION
```
        model = Net1()
        model = to_hetero(model, metadata, debug=False)
        out = model(x_dict, edge_attr_dict)
        assert isinstance(out, tuple) and len(out) == 2
        assert isinstance(out[0], dict) and len(out[0]) == 2
        assert out[0]['paper'].size() == (100, 32)
        assert out[0]['author'].size() == (100, 32)
        assert isinstance(out[1], dict) and len(out[1]) == 3
        assert out[1][('paper', 'cites', 'paper')].size() == (200, 16)
        assert out[1][('paper', 'written_by', 'author')].size() == (200, 16)
        assert out[1][('author', 'writes', 'paper')].size() == (200, 16)
        assert sum(p.numel() for p in model.parameters()) == 1520
    
        for aggr in ['sum', 'mean', 'min', 'max', 'mul']:
            model = Net2()
            model = to_hetero(model, metadata, aggr='mean', debug=False)
            assert sum(p.numel() for p in model.parameters()) == 5824
    
>           out1 = model(x_dict, edge_index_dict)

test/nn/test_to_hetero_transformer.py:190: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.8/dist-packages/torch/fx/graph_module.py:660: in call_wrapped
    return self._wrapped_call(self, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch.fx.graph_module._WrappedCall object at 0x7f05c02188e0>
obj = GraphModule(
  (lin1): ToHeteroLinear(
    (hetero_module): HeteroLinear(16, 16, num_types=2, bias=True)
  )
  (conv1)...6, 32, aggr=mean)
  )
  (lin2): ToHeteroLinear(
    (hetero_module): HeteroLinear(32, 32, num_types=2, bias=True)
  )
)
args = ({'author': tensor([[-2.2203,  0.7839, -0.2461,  ..., -1.2004, -0.3178, -0.7617],
        [-0.9344, -0.2121,  0.8133, ..., 21, 46, 98, 82,
         82, 80, 58, 35,  8, 39, 26, 40, 33, 25, 60, 80, 35, 21, 40, 34, 37, 99,
         57, 22]])})
kwargs = {}, topmost_framesummary = <FrameSummary file <eval_with_key>.3, line 15 in forward>

    def __call__(self, obj, *args, **kwargs):
        try:
            if self.cls_call is not None:
                return self.cls_call(obj, *args, **kwargs)
            else:
                return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
        except Exception as e:
            assert e.__traceback__
            topmost_framesummary: traceback.FrameSummary = \
                traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]  # type: ignore[arg-type]
            if "eval_with_key" in topmost_framesummary.filename:
                print(_WrappedCall._generate_error_message(topmost_framesummary),
                      file=sys.stderr)
>               raise e.with_traceback(None)
E               RuntimeError: Output 0 of SplitWithSizesBackward0 is a view and is being modified inplace. This view is the output of a function that returns multiple views. Such functions do not allow the output views to be modified inplace. You should replace the inplace operation by an out-of-place one.
```