### PR TITLE
chore: move `yamllint` config to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
-        args: [-c=.yamllint.yml]
+        name: Lint yaml
+        args: [-d, '{extends: default, rules: {line-length: disable, document-start: disable, truthy: {level: error}, braces: {max-spaces-inside: 1}}}']
 
   - repo: https://github.com/regebro/pyroma
     rev: "4.1"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,9 +1,0 @@
-extends: default
-
-rules:
-  line-length: disable
-  document-start: disable
-  truthy:
-    level: error
-  braces:
-    max-spaces-inside: 1


### PR DESCRIPTION
@rusty1s This PR aims to further improve the overall structure of the repository by moving the yamllint configuration within the `pre-commit-config.yaml` file.

The only snippet in which the `.yamllint.yml` file was being used was the pre-commit config file. yamllint [allows to have a custom configuration without a config file](https://yamllint.readthedocs.io/en/stable/configuration.html#custom-configuration-without-a-config-file) by using the `-d` flag. Using this feature, we add a serialized version of the config in the args parameter of the pre-commit config.

Similar to https://github.com/pyg-team/pytorch_geometric/pull/6776