### PR TITLE
feat(pre-commit): add `clang-format` config to pre-commit-config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,0 @@
-BasedOnStyle: Chromium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,4 @@ repos:
     hooks:
       - id: clang-format
         name: Format C++ code
+        args: [--style, "{BasedOnStyle: Chromium}"]


### PR DESCRIPTION
This PR aims to cleanup the repository structure by moving the `.clang-format` file into the `pre-commit-config.yaml`.