### PR TITLE
[Performance] Improve segment_matmul by reducing launching overheads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `bias` term to `grouped_matmul` and `segment_matmul` ([#161](https://github.com/pyg-team/pyg-lib/pull/161))
 - Added `sampled_op` implementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
+- Improved `[segment|grouped]_matmul` GPU implementation by reducing launch overheads ([#213](https://github.com/pyg-team/pyg-lib/pull/213))
 - Sample the nodes with the same timestamp as seed nodes ([#187](https://github.com/pyg-team/pyg-lib/pull/187))
 - Added `write-csv` (saves benchmark results as csv file) and `libraries` (determines which libraries will be used in benchmark) parameters ([#167](https://github.com/pyg-team/pyg-lib/pull/167))
 - Enable benchmarking of neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))

--- a/pyg_lib/csrc/ops/cuda/sampled_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/sampled_kernel.cu
@@ -99,6 +99,8 @@ at::Tensor sampled_op_kernel(const at::Tensor& left,
             left_data, right_data, out_data, left_index_data, right_index_data,
             to_fn_type.at(fn), left_index.has_value(), right_index.has_value(),
             num_feats, numel);
+
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   });
   return out;
 }

--- a/pyg_lib/csrc/sampler/cuda/random_walk_kernel.cu
+++ b/pyg_lib/csrc/sampler/cuda/random_walk_kernel.cu
@@ -77,6 +77,8 @@ at::Tensor random_walk_kernel(const at::Tensor& rowptr,
     random_walk_kernel_impl<<<blocks(seed.size(0)), threads(), 0, stream>>>(
         rowptr_data, col_data, seed_data, rand_data, out_data, seed.size(0),
         walk_length);
+
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   });
 
   return out.t().contiguous();


### PR DESCRIPTION
CUTLASS grouped gemm requires copying matrix pointers and layouts to the device memory, which brings significant "launch" overheads, more concretely, 7 pageable H2D copies. This PR sets up the arguments for grouped gemm in a CPU pinned buffer manually and copy it to the device memory at once to reduce such overheads.

Other changes include setting CUDA stream for the grouped gemm, adding proper `C10_CUDA_CHECK` and `C10_CUDA_KERNEL_LAUNCH_CHECK`.

## Performance

Benchmarking with the following script, this PR reduces the op time from 0.29 ms to 0.05 ms on my desktop (RTX 3090).
```python
import torch
import time
import pyg_lib

def bench_pyg(a, b, seg):

    seg = torch.tensor(seg)
    pyg_lib.ops.segment_matmul(a, seg, b)
    torch.cuda.synchronize()

    tic = time.time()
    for _ in range(10):
        pyg_lib.ops.segment_matmul(a, seg, b)
    torch.cuda.synchronize()
    print(f"{(time.time() - tic) * 100:.2f} ms")

if __name__ == "__main__":
    num_seg = 20
    hid_dim = 64
    num_ele = 10000

    torch.manual_seed(42)
    device = torch.device("cuda:0")

    a = torch.rand((num_ele, hid_dim), device=device)
    b = torch.rand((num_seg, hid_dim, hid_dim), device=device)

    seg = torch.randint(num_ele, (num_seg - 1,)).sort()[0].tolist()
    seg = [0] + seg + [num_ele]

    bench_pyg(a, b, seg)
```

cc @rusty1s @puririshi98 