### PR TITLE
Hetero neighbor sampler multithreading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `sampled_op` implementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
 - Improved `[segment|grouped]_matmul` GPU implementation by reducing launch overheads ([#213](https://github.com/pyg-team/pyg-lib/pull/213))
+- Enable hetero neighbor sampler to work in parallel ([#211](https://github.com/pyg-team/pyg-lib/pull/211))
 - Sample the nodes with the same timestamp as seed nodes ([#187](https://github.com/pyg-team/pyg-lib/pull/187))
 - Added `write-csv` (saves benchmark results as csv file) and `libraries` (determines which libraries will be used in benchmark) parameters ([#167](https://github.com/pyg-team/pyg-lib/pull/167))
 - Enable benchmarking of neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.3.0] - 2023-MM-DD
 ### Added
+- Enable `hetero_neighbor_samplee` to work in parallel ([#211](https://github.com/pyg-team/pyg-lib/pull/211))
 ### Changed
 - Fixed TorchScript support in `grouped_matmul` ([#220](https://github.com/pyg-team/pyg-lib/pull/220))
 ### Removed
@@ -19,7 +20,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `sampled_op` implementation ([#156](https://github.com/pyg-team/pyg-lib/pull/156), [#159](https://github.com/pyg-team/pyg-lib/pull/159), [#160](https://github.com/pyg-team/pyg-lib/pull/160))
 ### Changed
 - Improved `[segment|grouped]_matmul` GPU implementation by reducing launch overheads ([#213](https://github.com/pyg-team/pyg-lib/pull/213))
-- Enable hetero neighbor sampler to work in parallel ([#211](https://github.com/pyg-team/pyg-lib/pull/211))
 - Sample the nodes with the same timestamp as seed nodes ([#187](https://github.com/pyg-team/pyg-lib/pull/187))
 - Added `write-csv` (saves benchmark results as csv file) and `libraries` (determines which libraries will be used in benchmark) parameters ([#167](https://github.com/pyg-team/pyg-lib/pull/167))
 - Enable benchmarking of neighbor sampler on temporal graphs ([#165](https://github.com/pyg-team/pyg-lib/pull/165))

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -435,8 +435,7 @@ sample(const std::vector<node_type>& node_types,
           threads_edge_types.push_back({k});
       }
     }
-    if (!parallel) {
-      // If not parallel then one thread handles all edge types
+    if (!parallel) {  // If not parallel then one thread handles all edge types.
       threads_edge_types.push_back({edge_types});
     }
 
@@ -483,10 +482,8 @@ sample(const std::vector<node_type>& node_types,
       phmap::flat_hash_map<node_type, std::vector<node_t>>
           dst_sampled_nodes_dict;
       if (parallel) {
-        for (const auto& k : threads_edge_types) {
-          dst_sampled_nodes_dict[!csc ? std::get<2>(k[0])
-                                      : std::get<0>(
-                                            k[0])];  // initialize empty vector
+        for (const auto& k : threads_edge_types) {  // Intialize empty vectors.
+          dst_sampled_nodes_dict[!csc ? std::get<2>(k[0]) : std::get<0>(k[0])];
         }
       }
       at::parallel_for(

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -538,15 +538,12 @@ sample(const std::vector<node_type>& node_types,
                     std::back_inserter(sampled_nodes_dict[dst_sampled.first]));
         }
       }
-      at::parallel_for(0, node_types.size(), 1, [&](size_t _s, size_t _e) {
-        for (auto j = _s; j < _e; j++) {
-          const auto& k = node_types[j];
-          slice_dict[k] = {slice_dict.at(k).second,
-                           sampled_nodes_dict.at(k).size()};
-          num_sampled_nodes_per_hop_map.at(k).push_back(
-              slice_dict.at(k).second - slice_dict.at(k).first);
-        }
-      });
+      for (const auto& k : node_types) {
+        slice_dict[k] = {slice_dict.at(k).second,
+                         sampled_nodes_dict.at(k).size()};
+        num_sampled_nodes_per_hop_map.at(k).push_back(slice_dict.at(k).second -
+                                                      slice_dict.at(k).first);
+      }
     }
 
     for (const auto& k : node_types) {

--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/Parallel.h>
 #include <torch/library.h>
 
 #include "parallel_hashmap/phmap.h"
@@ -406,6 +407,9 @@ sample(const std::vector<node_type>& node_types,
       slice_dict[k] = {0, 0};
     }
 
+    const bool parallel = at::get_num_threads() > 1 && edge_types.size() > 1;
+    std::vector<std::vector<edge_type>> threads_edge_types;
+
     for (const auto& k : edge_types) {
       L = std::max(L, num_neighbors_dict.at(to_rel_type(k)).size());
       sampler_dict.insert(
@@ -413,6 +417,27 @@ sample(const std::vector<node_type>& node_types,
                   rowptr_dict.at(to_rel_type(k)).data_ptr<scalar_t>(),
                   col_dict.at(to_rel_type(k)).data_ptr<scalar_t>(),
                   temporal_strategy)});
+
+      if (parallel) {
+        // Each thread is assigned edge types that have the same dst node type.
+        // Thanks to this, each thread will operate on a separate mapper and
+        // separate sampler.
+        bool added = false;
+        const auto dst = !csc ? std::get<2>(k) : std::get<0>(k);
+        for (auto& e : threads_edge_types) {
+          if ((!csc ? std::get<2>(e[0]) : std::get<0>(e[0])) == dst) {
+            e.push_back(k);
+            added = true;
+            break;
+          }
+        }
+        if (!added)
+          threads_edge_types.push_back({k});
+      }
+    }
+    if (!parallel) {
+      // If not parallel then one thread handles all edge types
+      threads_edge_types.push_back({edge_types});
     }
 
     scalar_t batch_idx = 0;
@@ -435,12 +460,14 @@ sample(const std::vector<node_type>& node_types,
         if (seed_time_dict.has_value()) {
           const at::Tensor& seed_time = seed_time_dict.value().at(kv.key());
           const auto seed_time_data = seed_time.data_ptr<scalar_t>();
+          seed_times.reserve(seed_times.size() + seed.numel());
           for (size_t i = 0; i < seed.numel(); ++i) {
             seed_times.push_back(seed_time_data[i]);
           }
         } else if (time_dict.has_value()) {
           const at::Tensor& time = time_dict.value().at(kv.key());
           const auto time_data = time.data_ptr<scalar_t>();
+          seed_times.reserve(seed_times.size() + seed.numel());
           for (size_t i = 0; i < seed.numel(); ++i) {
             seed_times.push_back(time_data[seed_data[i]]);
           }
@@ -453,42 +480,73 @@ sample(const std::vector<node_type>& node_types,
 
     size_t begin, end;
     for (size_t ell = 0; ell < L; ++ell) {
-      for (const auto& k : edge_types) {
-        const auto& src = !csc ? std::get<0>(k) : std::get<2>(k);
-        const auto& dst = !csc ? std::get<2>(k) : std::get<0>(k);
-        const auto count = num_neighbors_dict.at(to_rel_type(k))[ell];
-        auto& src_sampled_nodes = sampled_nodes_dict.at(src);
-        auto& dst_sampled_nodes = sampled_nodes_dict.at(dst);
-        auto& dst_mapper = mapper_dict.at(dst);
-        auto& sampler = sampler_dict.at(k);
-        std::tie(begin, end) = slice_dict.at(src);
-
-        sampler.num_sampled_edges_per_hop.push_back(0);
-
-        if (!time_dict.has_value() || !time_dict.value().contains(dst)) {
-          for (size_t i = begin; i < end; ++i) {
-            sampler.uniform_sample(/*global_src_node=*/src_sampled_nodes[i],
-                                   /*local_src_node=*/i, count, dst_mapper,
-                                   generator, dst_sampled_nodes);
-          }
-        } else if constexpr (!std::is_scalar<node_t>::value) {  // Temporal:
-          const at::Tensor& dst_time = time_dict.value().at(dst);
-          const auto dst_time_data = dst_time.data_ptr<temporal_t>();
-          for (size_t i = begin; i < end; ++i) {
-            batch_idx = src_sampled_nodes[i].first;
-            sampler.temporal_sample(/*global_src_node=*/src_sampled_nodes[i],
-                                    /*local_src_node=*/i, count,
-                                    seed_times[batch_idx], dst_time_data,
-                                    dst_mapper, generator, dst_sampled_nodes);
-          }
+      phmap::flat_hash_map<node_type, std::vector<node_t>>
+          dst_sampled_nodes_dict;
+      if (parallel) {
+        for (const auto& k : threads_edge_types) {
+          dst_sampled_nodes_dict[!csc ? std::get<2>(k[0])
+                                      : std::get<0>(
+                                            k[0])];  // initialize empty vector
         }
       }
-      for (const auto& k : node_types) {
-        slice_dict[k] = {slice_dict.at(k).second,
-                         sampled_nodes_dict.at(k).size()};
-        num_sampled_nodes_per_hop_map.at(k).push_back(slice_dict.at(k).second -
-                                                      slice_dict.at(k).first);
+      at::parallel_for(
+          0, threads_edge_types.size(), 1, [&](size_t _s, size_t _e) {
+            for (auto j = _s; j < _e; j++) {
+              for (const auto& k : threads_edge_types[j]) {
+                const auto src = !csc ? std::get<0>(k) : std::get<2>(k);
+                const auto dst = !csc ? std::get<2>(k) : std::get<0>(k);
+                const auto count = num_neighbors_dict.at(to_rel_type(k))[ell];
+                auto& src_sampled_nodes = sampled_nodes_dict.at(src);
+                auto& dst_sampled_nodes = parallel
+                                              ? dst_sampled_nodes_dict.at(dst)
+                                              : sampled_nodes_dict.at(dst);
+                auto& dst_mapper = mapper_dict.at(dst);
+                auto& sampler = sampler_dict.at(k);
+                size_t begin, end;
+                std::tie(begin, end) = slice_dict.at(src);
+
+                sampler.num_sampled_edges_per_hop.push_back(0);
+
+                if (!time_dict.has_value() ||
+                    !time_dict.value().contains(dst)) {
+                  for (size_t i = begin; i < end; ++i) {
+                    sampler.uniform_sample(
+                        /*global_src_node=*/src_sampled_nodes[i],
+                        /*local_src_node=*/i, count, dst_mapper, generator,
+                        dst_sampled_nodes);
+                  }
+                } else if constexpr (!std::is_scalar<
+                                         node_t>::value) {  // Temporal:
+                  const at::Tensor& dst_time = time_dict.value().at(dst);
+                  const auto dst_time_data = dst_time.data_ptr<temporal_t>();
+                  for (size_t i = begin; i < end; ++i) {
+                    const auto batch_idx = src_sampled_nodes[i].first;
+                    sampler.temporal_sample(
+                        /*global_src_node=*/src_sampled_nodes[i],
+                        /*local_src_node=*/i, count, seed_times[batch_idx],
+                        dst_time_data, dst_mapper, generator,
+                        dst_sampled_nodes);
+                  }
+                }
+              }
+            }
+          });
+
+      if (parallel) {
+        for (auto& dst_sampled : dst_sampled_nodes_dict) {
+          std::copy(dst_sampled.second.begin(), dst_sampled.second.end(),
+                    std::back_inserter(sampled_nodes_dict[dst_sampled.first]));
+        }
       }
+      at::parallel_for(0, node_types.size(), 1, [&](size_t _s, size_t _e) {
+        for (auto j = _s; j < _e; j++) {
+          const auto& k = node_types[j];
+          slice_dict[k] = {slice_dict.at(k).second,
+                           sampled_nodes_dict.at(k).size()};
+          num_sampled_nodes_per_hop_map.at(k).push_back(
+              slice_dict.at(k).second - slice_dict.at(k).first);
+        }
+      });
     }
 
     for (const auto& k : node_types) {


### PR DESCRIPTION
The main roadblocks in the context of sampler parallelization is the mapper and the sampler. However, in the case of hetero sampling, there are separate mappers for each dst node type and separate samplers for each edge type. Therefore, to avoid race condition we can use parallelization per dst node type, i.e. each thread is assigned an edge types with unique dst node type that it is working on.

Example sampling times obtained using  [hetero_neighbor.py](https://github.com/pyg-team/pyg-lib/blob/master/benchmark/sampler/hetero_neighbor.py) benchmark:

<img width="524" alt="hetero-sampler-icx" src="https://user-images.githubusercontent.com/58218729/225766473-b36a4515-7651-411f-95c3-5f11d5c7c55c.png">

Example end-to-end times obtained using [inference_benchmark.py](https://github.com/pyg-team/pytorch_geometric/blob/master/benchmark/inference/inference_benchmark.py):

<img width="1018" alt="e2e-icx" src="https://user-images.githubusercontent.com/58218729/225765780-646f2208-4fa2-4e5b-8067-e87327621868.png">

