### PR TITLE
MKL RandIntEngine

### DIFF
--- a/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/neighbor_kernel.cpp
@@ -10,7 +10,6 @@
 #include "pyg_lib/csrc/sampler/subgraph.h"
 #include "pyg_lib/csrc/utils/cpu/convert.h"
 #include "pyg_lib/csrc/utils/types.h"
-#include "pyg_lib/csrc/config.h"
 
 namespace pyg {
 namespace sampler {
@@ -134,11 +133,10 @@ class NeighborSampler {
     }
 
     // Case 2: Sample with replacement:
-    // Case 2: Sample with replacement:
     else if (replace) {
-      if (row_end < (1 << 16) && WITH_MKL_BLAS()) {
+      if (row_end < (1 << 16)) {
         int arr[count];
-        generator.generate_ints(row_start, row_end, count, &arr[0]);
+        generator.fill_with_ints(row_start, row_end, count, &arr[0]);
         for (size_t i = 0; i < count; ++i) {
           const auto edge_id = arr[i];
           add(edge_id, global_src_node, local_src_node, dst_mapper,
@@ -156,9 +154,9 @@ class NeighborSampler {
     // Case 3: Sample without replacement:
     else {
       auto index_tracker = IndexTracker<scalar_t>(population);
-      if (population < (1 << 16) && WITH_MKL_BLAS()) {
+      if (population < (1 << 16)) {
         int arr[count];
-        generator.generate_ints(0, population-count, count, &arr[0]);
+        generator.fill_with_ints(0, population-count, count, &arr[0]);
         for (size_t i = 0; i < count; ++i) {
           auto rnd = arr[i];
           if (!index_tracker.try_insert(rnd)) {


### PR DESCRIPTION
- Added fill_with_ints function (it uses mkl library in order to generate ints) to RandintEngine class
Results obtained using neighbor.py benchmark (average time from 15 runs):

Results for changed code:

With mkl:
![image](https://user-images.githubusercontent.com/57872493/229899660-ed0f1b0e-776c-4f48-8ce5-8b86f06caf64.png)

Without mkl:
![image](https://user-images.githubusercontent.com/57872493/229899977-f4984f47-64bc-4e03-be67-953cbbcff413.png)

Results for original code:
![image](https://user-images.githubusercontent.com/57872493/229900137-800d8be7-39cf-4600-9ec7-71c6059a49c2.png)
