### PR TITLE
Drop nested tensor wrapper for `grouped_matmul`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `metis` partitioning ([#229](https://github.com/pyg-team/pyg-lib/pull/229))
 - Enable `hetero_neighbor_samplee` to work in parallel ([#211](https://github.com/pyg-team/pyg-lib/pull/211))
 ### Changed
+- Drop nested tensor wrapper for `grouped_matmul` implementation ([#226](https://github.com/pyg-team/pyg-lib/pull/226))
 - Fixed TorchScript support in `grouped_matmul` ([#220](https://github.com/pyg-team/pyg-lib/pull/220))
 ### Removed
 

--- a/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
@@ -45,7 +45,7 @@ void run_grouped_gemm(const at::TensorList input,
     auto new_in = input[i].contiguous();
     auto new_other = other[i].contiguous();
     auto new_out = out[i].contiguous();
-    auto m = new_in.size(0), k = new_other.size(1), n = new_out.size(1);
+    auto m = new_in.size(0), k = new_other.size(0), n = new_out.size(1);
 
     problem_sizes_data[i] = cutlass::gemm::GemmCoord(m, n, k);
 

--- a/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
@@ -19,7 +19,8 @@ namespace {
 template <typename GemmKernel>
 void run_grouped_gemm(const at::TensorList input,
                       const at::TensorList other,
-                      const at::TensorList out) {
+                      const at::TensorList out,
+                      bool segment) {
   using GemmGrouped = cutlass::gemm::device::GemmGrouped<GemmKernel>;
 
   const int64_t num_matrices = input.size();
@@ -45,7 +46,7 @@ void run_grouped_gemm(const at::TensorList input,
     auto new_in = input[i].contiguous();
     auto new_other = other[i].contiguous();
     auto new_out = out[i].contiguous();
-    auto m = new_in.size(0), k = new_other.size(0), n = new_out.size(1);
+    auto m = new_in.size(0), k = new_other.size((int)(segment)), n = new_out.size(1);
 
     problem_sizes_data[i] = cutlass::gemm::GemmCoord(m, n, k);
 
@@ -115,7 +116,8 @@ bool props_queried = false;
 
 void grouped_matmul_out_kernel(const at::TensorList input,
                                const at::TensorList other,
-                               const at::TensorList out) {
+                               const at::TensorList out,
+                               bool segment) {
   if (!props_queried) {
     props = get_dev_prop();
     props_queried = true;
@@ -147,7 +149,7 @@ void grouped_matmul_out_kernel(const at::TensorList input,
         2,                                             // Stages
         cutlass::arch::OpMultiplyAdd                   // Operation
         >::GemmKernel;
-    run_grouped_gemm<GemmKernel_Volta>(input, other, out);
+    run_grouped_gemm<GemmKernel_Volta>(input, other, out, segment);
   } else {
     // Compute capability at or beyond that of Ampere. TF32 is available.
     bool use_tf32;
@@ -188,7 +190,7 @@ void grouped_matmul_out_kernel(const at::TensorList input,
           shared_memory_for_kernel<DefaultGemmKernel_TF32>();
       if (grouped_shared_mem < props.sharedMemPerBlockOptin) {
         // full size GPU
-        run_grouped_gemm<DefaultGemmKernel_TF32>(input, other, out);
+        run_grouped_gemm<DefaultGemmKernel_TF32>(input, other, out, segment);
       } else {
         // Smaller GPU
         using SmallGemmKernel_TF32 =
@@ -217,7 +219,7 @@ void grouped_matmul_out_kernel(const at::TensorList input,
                 3,                                  // Stages
                 cutlass::arch::OpMultiplyAdd        // Operation
                 >::GemmKernel;
-        run_grouped_gemm<SmallGemmKernel_TF32>(input, other, out);
+        run_grouped_gemm<SmallGemmKernel_TF32>(input, other, out, segment);
       }
     } else {
       // TF32 is manually disabled
@@ -250,7 +252,7 @@ void grouped_matmul_out_kernel(const at::TensorList input,
           shared_memory_for_kernel<DefaultGemmKernel_FP32>();
       if (grouped_shared_mem < props.sharedMemPerBlockOptin) {
         // full size GPU
-        run_grouped_gemm<DefaultGemmKernel_FP32>(input, other, out);
+        run_grouped_gemm<DefaultGemmKernel_FP32>(input, other, out, segment);
       } else {
         // Smaller GPU
         using SmallGemmKernel_FP32 =
@@ -279,7 +281,7 @@ void grouped_matmul_out_kernel(const at::TensorList input,
                 3,                                  // Stages
                 cutlass::arch::OpMultiplyAdd        // Operation
                 >::GemmKernel;
-        run_grouped_gemm<SmallGemmKernel_FP32>(input, other, out);
+        run_grouped_gemm<SmallGemmKernel_FP32>(input, other, out, segment);
       }
     }
   }
@@ -290,7 +292,7 @@ std::vector<at::Tensor> grouped_matmul_kernel(const at::TensorList input,
   std::vector<at::Tensor> out(input.size());
   for (size_t i = 0; i < input.size(); ++i)
     out[i] = input[i].new_empty({input[i].size(0), other[i].size(-1)});
-  grouped_matmul_out_kernel(input, other, out);
+  grouped_matmul_out_kernel(input, other, out, false);
 
   return out;
 }
@@ -307,7 +309,8 @@ at::Tensor segment_matmul_kernel(const at::Tensor& input,
   grouped_matmul_out_kernel(
       input.contiguous().split_with_sizes(/*split_size=*/sizes, /*dim=*/0),
       other.contiguous().split(/*split_size=*/1, /*dim=*/0),
-      out.split_with_sizes(/*split_size=*/sizes, /*dim=*/0));
+      out.split_with_sizes(/*split_size=*/sizes, /*dim=*/0),
+      true);
 
   return out;
 }

--- a/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/matmul_kernel.cu
@@ -46,7 +46,8 @@ void run_grouped_gemm(const at::TensorList input,
     auto new_in = input[i].contiguous();
     auto new_other = other[i].contiguous();
     auto new_out = out[i].contiguous();
-    auto m = new_in.size(0), k = new_other.size((int)(segment)), n = new_out.size(1);
+    auto m = new_in.size(0), k = new_other.size((int)(segment)),
+         n = new_out.size(1);
 
     problem_sizes_data[i] = cutlass::gemm::GemmCoord(m, n, k);
 
@@ -309,8 +310,7 @@ at::Tensor segment_matmul_kernel(const at::Tensor& input,
   grouped_matmul_out_kernel(
       input.contiguous().split_with_sizes(/*split_size=*/sizes, /*dim=*/0),
       other.contiguous().split(/*split_size=*/1, /*dim=*/0),
-      out.split_with_sizes(/*split_size=*/sizes, /*dim=*/0),
-      true);
+      out.split_with_sizes(/*split_size=*/sizes, /*dim=*/0), true);
 
   return out;
 }

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -43,6 +43,8 @@ def pytreeify(cls):
         #     raise RuntimeError(
         #         "The backward generated an arg structure that doesn't "
         #         "match the forward's input.")
+        print("len(flat_grad_inputs)=", len(flat_grad_inputs))
+        print("flat_grad_inputs=", flat_grad_inputs)
         return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -89,12 +89,16 @@ class GroupedMatmul(Function):
             for i in range(len(others)):
                 others[i] = others[i].t()
             inputs_grad = torch.ops.pyg.grouped_matmul(outs_grad, others)
+        else:
+            inputs_grad = [None for i in range(len(outs_grad))]
 
         others_grad = []
         if all([other.requires_grad for other in others]):
             for i in range(len(inputs)):
                 inputs[i] = inputs[i].t()
             others_grad = torch.ops.pyg.grouped_matmul(inputs, outs_grad)
+        else:
+            others_grad = [None for i in range(len(outs_grad))]
 
         return tuple(inputs_grad + others_grad)
 

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -9,12 +9,9 @@ from .scatter_reduce import fused_scatter_reduce
 
 class GroupedMatmul(Function):
     @staticmethod
-    def forward(ctx, *inputs_and_others):
-        ctx.save_for_backward(*(inputs_and_others))
+    def forward(ctx, inputs_and_others):
+        ctx.save_for_backward(inputs_and_others)
         # autograd complains about list(...) constructor
-        print("len(inputs_and_others)=",len(inputs_and_others))
-        print("inputs_and_others[0]=",inputs_and_others[0])
-        print("len(inputs_and_others[0]))=",len(inputs_and_others[0]))
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
         ]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -70,7 +70,7 @@ class GroupedMatmul(Function):
         inputs_and_others = list(ctx.saved_tensors)
         inputs = inputs_and_others[:int(len(outs_grad))]
         others = inputs_and_others[int(len(outs_grad)):]
-
+        outs_grad= list(outs_grad)
         inputs_grad = []
         if all([x.requires_grad for x in inputs]):
             for i in range(len(others)):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,52 +5,7 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
-import torch.utils._pytree as pytree
 
-# Basically wraps things in and out before passing
-# it to the real function that the user defined.
-# def pytreeify(cls):
-#     assert issubclass(cls, Function)
-
-#     orig_fw = cls.forward
-#     orig_bw = cls.backward
-#     orig_apply = cls.apply
-
-#     def new_apply(*inp):
-#         flat_inp, struct = pytree.tree_flatten(inp)
-#         out_struct_holder = []
-#         flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
-#         assert len(out_struct_holder) == 1
-#         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
-
-#     def new_forward(ctx, struct, out_struct_holder, *flat_inp):
-#         inp = pytree.tree_unflatten(flat_inp, struct)
-#         out = orig_fw(ctx, *inp)
-#         flat_out, out_struct = pytree.tree_flatten(out)
-#         ctx._inp_struct = struct
-#         ctx._out_struct = out_struct
-#         out_struct_holder.append(out_struct)
-#         return tuple(flat_out)
-
-#     def new_backward(ctx, *flat_grad_outputs):
-#         grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
-#                                              ctx._out_struct)
-#         if not isinstance(grad_outputs, tuple):
-#             grad_outputs = (grad_outputs, )
-#         grad_inputs = orig_bw(ctx, *grad_outputs)
-#         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-#         if grad_inputs_struct != ctx._inp_struct:
-#             raise RuntimeError(
-#                 "The backward generated an arg structure that doesn't "
-#                 "match the forward's input.")
-#         return (None, None) + tuple(flat_grad_inputs)
-#     cls.apply = new_apply
-#     cls.forward = new_forward
-#     cls.backward = new_backward
-#     return cls
-
-
-# # @pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, *inputs_and_others):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -86,7 +86,7 @@ class GroupedMatmul(Function):
                 inputs[i] = inputs[i].t()
             others_grad = torch.ops.pyg.grouped_matmul(inputs, outs_grad)
 
-        return inputs_grad + others_grad
+        return *(inputs_grad + others_grad)
 
 
 def grouped_matmul(inputs: List[Tensor], others: List[Tensor],

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -39,10 +39,10 @@ def pytreeify(cls):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        if grad_inputs_struct != ctx._inp_struct:
-            raise RuntimeError(
-                "The backward generated an arg structure that doesn't "
-                "match the forward's input.")
+        # if grad_inputs_struct != ctx._inp_struct:
+        #     raise RuntimeError(
+        #         "The backward generated an arg structure that doesn't "
+        #         "match the forward's input.")
         return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -41,6 +41,9 @@ def pytreeify(cls):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+        print("flat_grad_inputs=",flat_grad_inputs)
+        print("grad_inputs_struct=", grad_inputs_struct)
+        print("ctx._inp_struct=", ctx._inp_struct)
         # if grad_inputs_struct != ctx._inp_struct:
         #     raise RuntimeError(
         #         "The backward generated an arg structure that doesn't "
@@ -86,7 +89,7 @@ class GroupedMatmul(Function):
                 inputs[i] = inputs[i].t()
             others_grad = torch.ops.pyg.grouped_matmul(inputs, outs_grad)
 
-        return *(inputs_grad + others_grad)
+        return (inputs_grad + others_grad)
 
 
 def grouped_matmul(inputs: List[Tensor], others: List[Tensor],

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -70,7 +70,7 @@ class GroupedMatmul(torch.autograd.Function):
 
         # NOTE Autograd doesnt set `out[i].requires_grad = True` automatically
         for x, other, out in zip(inputs, others, outs):
-            if x.requires_grad or other.requres_grad:
+            if x.requires_grad or other.requires_grad:
                 out.requires_grad = True
 
         return tuple(outs)

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -41,14 +41,14 @@ def pytreeify(cls):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        print("flat_grad_inputs=",flat_grad_inputs)
-        print("grad_inputs_struct=", grad_inputs_struct)
-        print("ctx._inp_struct=", ctx._inp_struct)
+        print("len(flat_grad_inputs)=",len(flat_grad_inputs))
+        print("len(grad_inputs_struct=", len(grad_inputs_struct))
+        print("len(ctx._inp_struct)=", len(ctx._inp_struct))
         # if grad_inputs_struct != ctx._inp_struct:
         #     raise RuntimeError(
         #         "The backward generated an arg structure that doesn't "
         #         "match the forward's input.")
-        # return (None, None) + tuple(flat_grad_inputs)
+        return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply
     cls.forward = new_forward

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -74,19 +74,19 @@ class GroupedMatmul(Function):
         inputs = inputs_and_others[:int(len(outs_grad))]
         others = inputs_and_others[int(len(outs_grad)):]
 
-        inputs_grad = None
+        inputs_grad = []
         if all([x.requires_grad for x in inputs]):
             for i in range(len(others)):
                 others[i] = others[i].t()
             inputs_grad = torch.ops.pyg.grouped_matmul(outs_grad, others)
 
-        others_grad = None
+        others_grad = []
         if all([other.requires_grad for other in others]):
             for i in range(len(inputs)):
                 inputs[i] = inputs[i].t()
             others_grad = torch.ops.pyg.grouped_matmul(inputs, outs_grad)
 
-        return inputs_grad, others_grad
+        return inputs_grad + others_grad
 
 
 def grouped_matmul(inputs: List[Tensor], others: List[Tensor],

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -56,8 +56,8 @@ class GroupedMatmul(Function):
     def forward(ctx, *inputs_and_others):
         ctx.save_for_backward(*(inputs_and_others))
         # autograd complains about list(...) constructor
-        inputs: List[Tensor]  = [i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]]
-        others: List[Tensor]  = [i for i in inputs_and_others[int(len(inputs_and_others) / 2):]]
+        inputs: List[Tensor]  = [Tensor(i) for i in inputs_and_others[:int(len(inputs_and_others) / 2)]]
+        others: List[Tensor]  = [Tensor(i) for i in inputs_and_others[int(len(inputs_and_others) / 2):]]
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
 
         # # NOTE Autograd doesnt set out[i].requires_grad = True automatically
@@ -69,10 +69,8 @@ class GroupedMatmul(Function):
     @staticmethod
     def backward(ctx, *outs_grad):
         inputs_and_others = list(ctx.saved_tensors)
-        inputs: List[Tensor]  = [i for i in inputs_and_others[:int(len(outs_grad))]]
-        others: List[Tensor]  = [i for i in inputs_and_others[int(len(outs_grad)):]]
-        inputs = inputs_and_others[:int(len(outs_grad))]
-        others = inputs_and_others[int(len(outs_grad)):]
+        inputs: List[Tensor]  = [Tensor(i) for i in inputs_and_others[:int(len(outs_grad))]]
+        others: List[Tensor]  = [Tensor(i) for i in inputs_and_others[int(len(outs_grad)):]]
         # explicit typing needed
         outs_grad: List[Tensor] = [i for i in outs_grad]
         inputs_grad = []

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -39,10 +39,12 @@ def pytreeify(cls):
         return tuple(flat_out)
 
     def new_backward(ctx, *flat_grad_outputs):
+        # unflatten gradient outputs
         grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
                                              ctx._out_struct)
         if not isinstance(grad_outputs, tuple):
             grad_outputs = (grad_outputs, )
+        # get gradient inputs and flatten them
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
         return (None, None) + tuple(flat_grad_inputs)

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -36,7 +36,7 @@ def pytreeify(cls):
     def new_backward(ctx, *flat_grad_outputs):
         grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
                                              ctx._out_struct)
-        if not isinstance(grad_outputs, tuple):
+        if not isinstance(grad_outputs, tuple) or isinstance(grad_outputs, list):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -12,6 +12,9 @@ class GroupedMatmul(Function):
     def forward(ctx, *inputs_and_others):
         ctx.save_for_backward(*(inputs_and_others))
         # autograd complains about list(...) constructor
+        print("len(inputs_and_others)=",len(inputs_and_others))
+        print("inputs_and_others[0]=",inputs_and_others[0])
+        print("len(inputs_and_others[0]))=",len(inputs_and_others[0]))
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
         ]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -12,12 +12,10 @@ class GroupedMatmul(Function):
         ctx.save_for_backward(*(inputs_and_others))
         # autograd complains about list(...) constructor
         inputs: List[Tensor] = [
-            Tensor(i)
-            for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
+            i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
         ]
         others: List[Tensor] = [
-            Tensor(i)
-            for i in inputs_and_others[int(len(inputs_and_others) / 2):]
+            i for i in inputs_and_others[int(len(inputs_and_others) / 2):]
         ]
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
 
@@ -31,10 +29,10 @@ class GroupedMatmul(Function):
     def backward(ctx, *outs_grad):
         inputs_and_others = list(ctx.saved_tensors)
         inputs: List[Tensor] = [
-            Tensor(i) for i in inputs_and_others[:int(len(outs_grad))]
+            i for i in inputs_and_others[:int(len(outs_grad))]
         ]
         others: List[Tensor] = [
-            Tensor(i) for i in inputs_and_others[int(len(outs_grad)):]
+            i for i in inputs_and_others[int(len(outs_grad)):]
         ]
         # explicit typing needed
         outs_grad: List[Tensor] = [i for i in outs_grad]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,76 +5,7 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
-# import torch.utils._pytree as pytree
 
-<<<<<<< HEAD
-# # Basically wraps things in and out before passing it to the real function that the user defined.
-# def pytreeify(cls):
-#     assert issubclass(cls, Function)
-=======
-
-# Basically wraps things in and out before passing it to the real function that the user defined.
-def pytreeify(cls):
-    assert issubclass(cls, Function)
->>>>>>> 6d93d72689eb7fdeea1af8af1d9595a9b357e9e4
-
-#     orig_fw = cls.forward
-#     orig_bw = cls.backward
-#     orig_apply = cls.apply
-
-#     def new_apply(*inp):
-#         flat_inp, struct = pytree.tree_flatten(inp)
-#         out_struct_holder = []
-#         flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
-#         assert len(out_struct_holder) == 1
-#         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
-
-#     def new_forward(ctx, struct, out_struct_holder, *flat_inp):
-#         inp = pytree.tree_unflatten(flat_inp, struct)
-#         out = orig_fw(ctx, *inp)
-#         flat_out, out_struct = pytree.tree_flatten(out)
-#         ctx._inp_struct = struct
-#         ctx._out_struct = out_struct
-#         out_struct_holder.append(out_struct)
-#         return tuple(flat_out)
-
-<<<<<<< HEAD
-#     def new_backward(ctx, *flat_grad_outputs):
-#         grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
-#         if not isinstance(grad_outputs, tuple):
-#             grad_outputs = (grad_outputs,)
-#         grad_inputs = orig_bw(ctx, *grad_outputs)
-#         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-#         if grad_inputs_struct != ctx._inp_struct:
-#             raise RuntimeError("The backward generated an arg structure that doesn't "
-#                                "match the forward's input.")
-#         return (None, None) + tuple(flat_grad_inputs)
-=======
-    def new_backward(ctx, *flat_grad_outputs):
-        grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
-                                             ctx._out_struct)
-        if not isinstance(grad_outputs, tuple):
-            grad_outputs = (grad_outputs, )
-        grad_inputs = orig_bw(ctx, *grad_outputs)
-        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        if grad_inputs_struct != ctx._inp_struct:
-            raise RuntimeError(
-                "The backward generated an arg structure that doesn't "
-                "match the forward's input.")
-        return (None, None) + tuple(flat_grad_inputs)
->>>>>>> 6d93d72689eb7fdeea1af8af1d9595a9b357e9e4
-
-#     cls.apply = new_apply
-#     cls.forward = new_forward
-#     cls.backward = new_backward
-#     return cls
-
-<<<<<<< HEAD
-# @pytreeify
-=======
-
-@pytreeify
->>>>>>> 6d93d72689eb7fdeea1af8af1d9595a9b357e9e4
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 import torch
 from torch import Tensor
+from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
 import torch.utils._pytree as pytree
@@ -47,7 +48,7 @@ def pytreeify(cls):
     return cls
 
 @pytreeify
-class GroupedMatmul(torch.autograd.Function):
+class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs: List[Tensor], others: List[Tensor]):
         ctx.save_for_backward(inputs, others)

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -70,7 +70,8 @@ class GroupedMatmul(Function):
         inputs_and_others = list(ctx.saved_tensors)
         inputs = inputs_and_others[:int(len(outs_grad))]
         others = inputs_and_others[int(len(outs_grad)):]
-        outs_grad= list(outs_grad)
+        # explicit typing needed
+        outs_grad: List[Tensor] = list(outs_grad)
         inputs_grad = []
         if all([x.requires_grad for x in inputs]):
             for i in range(len(others)):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -51,7 +51,7 @@ def pytreeify(cls):
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):
-        ctx.save_for_backward(inputs_and_others)
+        ctx.save_for_backward(*inputs_and_others)
         # autograd complains about list(...) constructor
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
@@ -69,7 +69,7 @@ class GroupedMatmul(Function):
 
     @staticmethod
     def backward(ctx, *outs_grad):
-        inputs_and_others = list(ctx.saved_tensors)
+        inputs_and_others = list(tuple(ctx.saved_tensors))
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(outs_grad))]
         ]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -56,8 +56,8 @@ class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, *inputs_and_others):
         ctx.save_for_backward(*(inputs_and_others))
-        inputs = inputs_and_others[:int(len(inputs_and_others) / 2)]
-        others = inputs_and_others[int(len(inputs_and_others) / 2):]
+        inputs = list(inputs_and_others[:int(len(inputs_and_others) / 2)])
+        others = list(inputs_and_others[int(len(inputs_and_others) / 2):])
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
 
         # # NOTE Autograd doesnt set out[i].requires_grad = True automatically

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -8,7 +8,8 @@ from .scatter_reduce import fused_scatter_reduce
 import torch.utils._pytree as pytree
 
 
-# Basically wraps things in and out before passing it to the real function that the user defined.
+# Basically wraps things in and out before passing
+# it to the real function that the user defined.
 def pytreeify(cls):
     assert issubclass(cls, Function)
 
@@ -39,12 +40,6 @@ def pytreeify(cls):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        # if grad_inputs_struct != ctx._inp_struct:
-        #     raise RuntimeError(
-        #         "The backward generated an arg structure that doesn't "
-        #         "match the forward's input.")
-        print("len(flat_grad_inputs)=", len(flat_grad_inputs))
-        print("flat_grad_inputs=", flat_grad_inputs)
         return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -67,9 +67,9 @@ class GroupedMatmul(Function):
 
     @staticmethod
     def backward(ctx, outs_grad: List[Tensor]):
-        inputs_and_others = ctx.saved_tensors
-        inputs = inputs_and_others[:len(outs_grad) / 2]
-        others = inputs_and_others[len(outs_grad) / 2:]
+        inputs_and_others = list(ctx.saved_tensors)
+        inputs = inputs_and_others[:int(len(outs_grad) / 2)]
+        others = inputs_and_others[int(len(outs_grad) / 2):]
 
         inputs_grad = None
         if all([x.requires_grad for x in inputs]):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -45,7 +45,7 @@ def pytreeify(cls):
         #     raise RuntimeError(
         #         "The backward generated an arg structure that doesn't "
         #         "match the forward's input.")
-        return (None, None) + tuple(flat_grad_inputs)
+        # return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply
     cls.forward = new_forward

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -4,8 +4,49 @@ import torch
 from torch import Tensor
 
 from .scatter_reduce import fused_scatter_reduce
+import torch.utils._pytree as pytree
 
+# Basically wraps things in and out before passing it to the real function that the user defined.
+def pytreeify(cls):
+    assert issubclass(cls, Function)
 
+    orig_fw = cls.forward
+    orig_bw = cls.backward
+    orig_apply = cls.apply
+
+    def new_apply(*inp):
+        flat_inp, struct = pytree.tree_flatten(inp)
+        out_struct_holder = []
+        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+        assert len(out_struct_holder) == 1
+        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+
+    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+        inp = pytree.tree_unflatten(flat_inp, struct)
+        out = orig_fw(ctx, *inp)
+        flat_out, out_struct = pytree.tree_flatten(out)
+        ctx._inp_struct = struct
+        ctx._out_struct = out_struct
+        out_struct_holder.append(out_struct)
+        return tuple(flat_out)
+
+    def new_backward(ctx, *flat_grad_outputs):
+        grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
+        if not isinstance(grad_outputs, tuple):
+            grad_outputs = (grad_outputs,)
+        grad_inputs = orig_bw(ctx, *grad_outputs)
+        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+        if grad_inputs_struct != ctx._inp_struct:
+            raise RuntimeError("The backward generated an arg structure that doesn't "
+                               "match the forward's input.")
+        return (None, None) + tuple(flat_grad_inputs)
+
+    cls.apply = new_apply
+    cls.forward = new_forward
+    cls.backward = new_backward
+    return cls
+
+@pytreeify
 class GroupedMatmul(torch.autograd.Function):
     @staticmethod
     def forward(ctx, inputs: List[Tensor], others: List[Tensor]):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,8 +5,49 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
+import torch.utils._pytree as pytree
 
+# Basically wraps things in and out before passing it to the real function that the user defined.
+def pytreeify(cls):
+    assert issubclass(cls, Function)
 
+    orig_fw = cls.forward
+    orig_bw = cls.backward
+    orig_apply = cls.apply
+
+    def new_apply(*inp):
+        flat_inp, struct = pytree.tree_flatten(inp)
+        out_struct_holder = []
+        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+        assert len(out_struct_holder) == 1
+        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+
+    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+        inp = pytree.tree_unflatten(flat_inp, struct)
+        out = orig_fw(ctx, *inp)
+        flat_out, out_struct = pytree.tree_flatten(out)
+        ctx._inp_struct = struct
+        ctx._out_struct = out_struct
+        out_struct_holder.append(out_struct)
+        return tuple(flat_out)
+
+    def new_backward(ctx, *flat_grad_outputs):
+        grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
+        if not isinstance(grad_outputs, tuple):
+            grad_outputs = (grad_outputs,)
+        grad_inputs = orig_bw(ctx, *grad_outputs)
+        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+        if grad_inputs_struct != ctx._inp_struct:
+            raise RuntimeError("The backward generated an arg structure that doesn't "
+                               "match the forward's input.")
+        return (None, None) + tuple(flat_grad_inputs)
+
+    cls.apply = new_apply
+    cls.forward = new_forward
+    cls.backward = new_backward
+    return cls
+
+@pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,49 +5,49 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
-import torch.utils._pytree as pytree
+# import torch.utils._pytree as pytree
 
-# Basically wraps things in and out before passing it to the real function that the user defined.
-def pytreeify(cls):
-    assert issubclass(cls, Function)
+# # Basically wraps things in and out before passing it to the real function that the user defined.
+# def pytreeify(cls):
+#     assert issubclass(cls, Function)
 
-    orig_fw = cls.forward
-    orig_bw = cls.backward
-    orig_apply = cls.apply
+#     orig_fw = cls.forward
+#     orig_bw = cls.backward
+#     orig_apply = cls.apply
 
-    def new_apply(*inp):
-        flat_inp, struct = pytree.tree_flatten(inp)
-        out_struct_holder = []
-        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
-        assert len(out_struct_holder) == 1
-        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+#     def new_apply(*inp):
+#         flat_inp, struct = pytree.tree_flatten(inp)
+#         out_struct_holder = []
+#         flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+#         assert len(out_struct_holder) == 1
+#         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
 
-    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
-        inp = pytree.tree_unflatten(flat_inp, struct)
-        out = orig_fw(ctx, *inp)
-        flat_out, out_struct = pytree.tree_flatten(out)
-        ctx._inp_struct = struct
-        ctx._out_struct = out_struct
-        out_struct_holder.append(out_struct)
-        return tuple(flat_out)
+#     def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+#         inp = pytree.tree_unflatten(flat_inp, struct)
+#         out = orig_fw(ctx, *inp)
+#         flat_out, out_struct = pytree.tree_flatten(out)
+#         ctx._inp_struct = struct
+#         ctx._out_struct = out_struct
+#         out_struct_holder.append(out_struct)
+#         return tuple(flat_out)
 
-    def new_backward(ctx, *flat_grad_outputs):
-        grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
-        if not isinstance(grad_outputs, tuple):
-            grad_outputs = (grad_outputs,)
-        grad_inputs = orig_bw(ctx, *grad_outputs)
-        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        if grad_inputs_struct != ctx._inp_struct:
-            raise RuntimeError("The backward generated an arg structure that doesn't "
-                               "match the forward's input.")
-        return (None, None) + tuple(flat_grad_inputs)
+#     def new_backward(ctx, *flat_grad_outputs):
+#         grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
+#         if not isinstance(grad_outputs, tuple):
+#             grad_outputs = (grad_outputs,)
+#         grad_inputs = orig_bw(ctx, *grad_outputs)
+#         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+#         if grad_inputs_struct != ctx._inp_struct:
+#             raise RuntimeError("The backward generated an arg structure that doesn't "
+#                                "match the forward's input.")
+#         return (None, None) + tuple(flat_grad_inputs)
 
-    cls.apply = new_apply
-    cls.forward = new_forward
-    cls.backward = new_backward
-    return cls
+#     cls.apply = new_apply
+#     cls.forward = new_forward
+#     cls.backward = new_backward
+#     return cls
 
-@pytreeify
+# @pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):
@@ -122,7 +122,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         List[torch.Tensor]: List of 2D output matrices of shapes
         :obj:`[N_i, M_i]`.
     """
-    outs = list(GroupedMatmul.apply(inputs + others))
+    outs = list(GroupedMatmul.apply(tuple(inputs + others)))
     if biases is not None:
         for i in range(len(biases)):
             outs[i] = outs[i] + biases[i]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,55 +5,63 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
-import torch.utils._pytree as pytree
+# import torch.utils._pytree as pytree
 
 
-# Basically wraps things in and out before passing
-# it to the real function that the user defined.
-def pytreeify(cls):
-    assert issubclass(cls, Function)
+# # Basically wraps things in and out before passing
+# # it to the real function that the user defined.
+# def pytreeify(cls):
+#     assert issubclass(cls, Function)
 
-    orig_fw = cls.forward
-    orig_bw = cls.backward
-    orig_apply = cls.apply
+#     # original functions we will replace with flattened versions
+#     orig_fw = cls.forward
+#     orig_bw = cls.backward
+#     orig_apply = cls.apply
 
-    def new_apply(*inp):
-        flat_inp, struct = pytree.tree_flatten(inp)
-        out_struct_holder = []
-        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
-        assert len(out_struct_holder) == 1
-        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+#     def new_apply(*inp):
+#         # flatten input structure
+#         flat_inp, struct = pytree.tree_flatten(inp)
+#         out_struct_holder = []
+#         # get flattened output
+#         flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+#         assert len(out_struct_holder) == 1
+#         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
 
-    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
-        inp = pytree.tree_unflatten(flat_inp, struct)
-        out = orig_fw(ctx, *inp)
-        flat_out, out_struct = pytree.tree_flatten(out)
-        ctx._inp_struct = struct
-        ctx._out_struct = out_struct
-        out_struct_holder.append(out_struct)
-        return tuple(flat_out)
+#     def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+#         # unflatten input
+#         inp = pytree.tree_unflatten(flat_inp, struct)
+#         out = orig_fw(ctx, *inp)
+#         # flatten output
+#         flat_out, out_struct = pytree.tree_flatten(out)
+#         ctx._inp_struct = struct
+#         ctx._out_struct = out_struct
+#         # store structure of output
+#         out_struct_holder.append(out_struct)
+#         return tuple(flat_out)
 
-    def new_backward(ctx, *flat_grad_outputs):
-        grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
-                                             ctx._out_struct)
-        if not isinstance(grad_outputs, tuple):
-            grad_outputs = (grad_outputs, )
-        grad_inputs = orig_bw(ctx, *grad_outputs)
-        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        return (None, None) + tuple(flat_grad_inputs)
+#     def new_backward(ctx, *flat_grad_outputs):
+#         grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
+#                                              ctx._out_struct)
+#         if not isinstance(grad_outputs, tuple):
+#             grad_outputs = (grad_outputs, )
+#         grad_inputs = orig_bw(ctx, *grad_outputs)
+#         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+#         return (None, None) + tuple(flat_grad_inputs)
 
-    cls.apply = new_apply
-    cls.forward = new_forward
-    cls.backward = new_backward
-    return cls
+#     cls.apply = new_apply
+#     cls.forward = new_forward
+#     cls.backward = new_backward
+#     return cls
 
 
-@pytreeify
+# @pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):
+        # need to break up tuple for save for backward
         ctx.save_for_backward(*inputs_and_others)
         # autograd complains about list(...) constructor
+        # explicit typing needed
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
         ]
@@ -77,7 +85,6 @@ class GroupedMatmul(Function):
         others: List[Tensor] = [
             i for i in inputs_and_others[int(len(outs_grad)):]
         ]
-        # explicit typing needed
         outs_grad: List[Tensor] = [i for i in outs_grad]
         inputs_grad = []
         if all([x.requires_grad for x in inputs]):
@@ -127,6 +134,7 @@ def grouped_matmul(inputs: List[Tensor], others: List[Tensor],
         List[torch.Tensor]: List of 2D output matrices of shapes
         :obj:`[N_i, M_i]`.
     """
+    # combine inputs into a single tuple for autograd
     outs = list(GroupedMatmul.apply(tuple(inputs + others)))
     if biases is not None:
         for i in range(len(biases)):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -56,8 +56,14 @@ class GroupedMatmul(Function):
     def forward(ctx, *inputs_and_others):
         ctx.save_for_backward(*(inputs_and_others))
         # autograd complains about list(...) constructor
-        inputs: List[Tensor]  = [Tensor(i) for i in inputs_and_others[:int(len(inputs_and_others) / 2)]]
-        others: List[Tensor]  = [Tensor(i) for i in inputs_and_others[int(len(inputs_and_others) / 2):]]
+        inputs: List[Tensor] = [
+            Tensor(i)
+            for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
+        ]
+        others: List[Tensor] = [
+            Tensor(i)
+            for i in inputs_and_others[int(len(inputs_and_others) / 2):]
+        ]
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
 
         # # NOTE Autograd doesnt set out[i].requires_grad = True automatically
@@ -69,8 +75,12 @@ class GroupedMatmul(Function):
     @staticmethod
     def backward(ctx, *outs_grad):
         inputs_and_others = list(ctx.saved_tensors)
-        inputs: List[Tensor]  = [Tensor(i) for i in inputs_and_others[:int(len(outs_grad))]]
-        others: List[Tensor]  = [Tensor(i) for i in inputs_and_others[int(len(outs_grad)):]]
+        inputs: List[Tensor] = [
+            Tensor(i) for i in inputs_and_others[:int(len(outs_grad))]
+        ]
+        others: List[Tensor] = [
+            Tensor(i) for i in inputs_and_others[int(len(outs_grad)):]
+        ]
         # explicit typing needed
         outs_grad: List[Tensor] = [i for i in outs_grad]
         inputs_grad = []

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -71,7 +71,7 @@ class GroupedMatmul(Function):
         inputs = inputs_and_others[:int(len(outs_grad))]
         others = inputs_and_others[int(len(outs_grad)):]
         # explicit typing needed
-        outs_grad: List[Tensor] = list(outs_grad)
+        outs_grad: List[Tensor] = [i for i in outs_grad]
         inputs_grad = []
         if all([x.requires_grad for x in inputs]):
             for i in range(len(others)):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -41,10 +41,10 @@ def pytreeify(cls):
             grad_outputs = (grad_outputs, )
         grad_inputs = orig_bw(ctx, *grad_outputs)
         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        if grad_inputs_struct != ctx._inp_struct:
-            raise RuntimeError(
-                "The backward generated an arg structure that doesn't "
-                "match the forward's input.")
+        # if grad_inputs_struct != ctx._inp_struct:
+        #     raise RuntimeError(
+        #         "The backward generated an arg structure that doesn't "
+        #         "match the forward's input.")
         return (None, None) + tuple(flat_grad_inputs)
 
     cls.apply = new_apply

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -55,8 +55,9 @@ class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, *inputs_and_others):
         ctx.save_for_backward(*(inputs_and_others))
-        inputs = list(inputs_and_others[:int(len(inputs_and_others) / 2)])
-        others = list(inputs_and_others[int(len(inputs_and_others) / 2):])
+        # autograd complains about list(...) constructor
+        inputs: List[Tensor]  = [i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]]
+        others: List[Tensor]  = [i for i in inputs_and_others[int(len(inputs_and_others) / 2):]]
         outs = torch.ops.pyg.grouped_matmul(inputs, others)
 
         # # NOTE Autograd doesnt set out[i].requires_grad = True automatically
@@ -68,6 +69,8 @@ class GroupedMatmul(Function):
     @staticmethod
     def backward(ctx, *outs_grad):
         inputs_and_others = list(ctx.saved_tensors)
+        inputs: List[Tensor]  = [i for i in inputs_and_others[:int(len(outs_grad))]]
+        others: List[Tensor]  = [i for i in inputs_and_others[int(len(outs_grad)):]]
         inputs = inputs_and_others[:int(len(outs_grad))]
         others = inputs_and_others[int(len(outs_grad)):]
         # explicit typing needed

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -12,12 +12,6 @@ class GroupedMatmul(Function):
     def forward(ctx, inputs_and_others):
         ctx.save_for_backward(inputs_and_others)
         # autograd complains about list(...) constructor
-<<<<<<< HEAD
-=======
-        print("len(inputs_and_others)=", len(inputs_and_others))
-        print("inputs_and_others[0]=", inputs_and_others[0])
-        print("len(inputs_and_others[0]))=", len(inputs_and_others[0]))
->>>>>>> 5b4dd8340e38f709f5bff5d8c279bb23b468e2de
         inputs: List[Tensor] = [
             i for i in inputs_and_others[:int(len(inputs_and_others) / 2)]
         ]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -5,7 +5,49 @@ from torch import Tensor
 from torch.autograd import Function
 
 from .scatter_reduce import fused_scatter_reduce
+import torch.utils._pytree as pytree
 
+# Basically wraps things in and out before passing it to the real function that the user defined.
+def pytreeify(cls):
+    assert issubclass(cls, Function)
+
+    orig_fw = cls.forward
+    orig_bw = cls.backward
+    orig_apply = cls.apply
+
+    def new_apply(*inp):
+        flat_inp, struct = pytree.tree_flatten(inp)
+        out_struct_holder = []
+        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+        assert len(out_struct_holder) == 1
+        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+
+    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+        inp = pytree.tree_unflatten(flat_inp, struct)
+        out = orig_fw(ctx, *inp)
+        flat_out, out_struct = pytree.tree_flatten(out)
+        ctx._inp_struct = struct
+        ctx._out_struct = out_struct
+        out_struct_holder.append(out_struct)
+        return tuple(flat_out)
+
+    def new_backward(ctx, *flat_grad_outputs):
+        grad_outputs = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
+        if not isinstance(grad_outputs, tuple):
+            grad_outputs = (grad_outputs,)
+        grad_inputs = orig_bw(ctx, *grad_outputs)
+        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+        if grad_inputs_struct != ctx._inp_struct:
+            raise RuntimeError("The backward generated an arg structure that doesn't "
+                               "match the forward's input.")
+        return (None, None) + tuple(flat_grad_inputs)
+
+    cls.apply = new_apply
+    cls.forward = new_forward
+    cls.backward = new_backward
+    return cls
+
+@pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, inputs_and_others):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -10,49 +10,49 @@ import torch.utils._pytree as pytree
 
 # Basically wraps things in and out before passing
 # it to the real function that the user defined.
-def pytreeify(cls):
-    assert issubclass(cls, Function)
+# def pytreeify(cls):
+#     assert issubclass(cls, Function)
 
-    orig_fw = cls.forward
-    orig_bw = cls.backward
-    orig_apply = cls.apply
+#     orig_fw = cls.forward
+#     orig_bw = cls.backward
+#     orig_apply = cls.apply
 
-    def new_apply(*inp):
-        flat_inp, struct = pytree.tree_flatten(inp)
-        out_struct_holder = []
-        flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
-        assert len(out_struct_holder) == 1
-        return pytree.tree_unflatten(flat_out, out_struct_holder[0])
+#     def new_apply(*inp):
+#         flat_inp, struct = pytree.tree_flatten(inp)
+#         out_struct_holder = []
+#         flat_out = orig_apply(struct, out_struct_holder, *flat_inp)
+#         assert len(out_struct_holder) == 1
+#         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
 
-    def new_forward(ctx, struct, out_struct_holder, *flat_inp):
-        inp = pytree.tree_unflatten(flat_inp, struct)
-        out = orig_fw(ctx, *inp)
-        flat_out, out_struct = pytree.tree_flatten(out)
-        ctx._inp_struct = struct
-        ctx._out_struct = out_struct
-        out_struct_holder.append(out_struct)
-        return tuple(flat_out)
+#     def new_forward(ctx, struct, out_struct_holder, *flat_inp):
+#         inp = pytree.tree_unflatten(flat_inp, struct)
+#         out = orig_fw(ctx, *inp)
+#         flat_out, out_struct = pytree.tree_flatten(out)
+#         ctx._inp_struct = struct
+#         ctx._out_struct = out_struct
+#         out_struct_holder.append(out_struct)
+#         return tuple(flat_out)
 
-    def new_backward(ctx, *flat_grad_outputs):
-        grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
-                                             ctx._out_struct)
-        if not isinstance(grad_outputs, tuple):
-            grad_outputs = (grad_outputs, )
-        grad_inputs = orig_bw(ctx, *grad_outputs)
-        flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
-        if grad_inputs_struct != ctx._inp_struct:
-            raise RuntimeError(
-                "The backward generated an arg structure that doesn't "
-                "match the forward's input.")
-        return (None, None) + tuple(flat_grad_inputs)
+#     def new_backward(ctx, *flat_grad_outputs):
+#         grad_outputs = pytree.tree_unflatten(flat_grad_outputs,
+#                                              ctx._out_struct)
+#         if not isinstance(grad_outputs, tuple):
+#             grad_outputs = (grad_outputs, )
+#         grad_inputs = orig_bw(ctx, *grad_outputs)
+#         flat_grad_inputs, grad_inputs_struct = pytree.tree_flatten(grad_inputs)
+#         if grad_inputs_struct != ctx._inp_struct:
+#             raise RuntimeError(
+#                 "The backward generated an arg structure that doesn't "
+#                 "match the forward's input.")
+#         return (None, None) + tuple(flat_grad_inputs)
 
-    cls.apply = new_apply
-    cls.forward = new_forward
-    cls.backward = new_backward
-    return cls
+#     cls.apply = new_apply
+#     cls.forward = new_forward
+#     cls.backward = new_backward
+#     return cls
 
 
-# @pytreeify
+# # @pytreeify
 class GroupedMatmul(Function):
     @staticmethod
     def forward(ctx, *inputs_and_others):

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -8,7 +8,8 @@ from .scatter_reduce import fused_scatter_reduce
 import torch.utils._pytree as pytree
 
 
-# Basically wraps things in and out before passing it to the real function that the user defined.
+# Basically wraps things in and out before passing
+# it to the real function that the user defined.
 def pytreeify(cls):
     assert issubclass(cls, Function)
 

--- a/test/ops/test_matmul.py
+++ b/test/ops/test_matmul.py
@@ -33,9 +33,9 @@ def test_segment_matmul_autograd(device):
 @withCUDA
 def test_grouped_matmul_autograd(device):
     inputs = [
-        torch.randn(5, 16, device=device),
-        torch.randn(6, 9, device=device),
-        torch.randn(3, 32, device=device),
+        torch.randn(5, 16, device=device, requires_grad=True),
+        torch.randn(6, 9, device=device, requires_grad=True),
+        torch.randn(3, 32, device=device, requires_grad=True),
     ]
     others = [
         torch.randn(16, 48, device=device, requires_grad=True),
@@ -48,6 +48,9 @@ def test_grouped_matmul_autograd(device):
         torch.randn(42, device=device, requires_grad=True),
         torch.randn(64, device=device, requires_grad=True),
     ]
+
+    if inputs[0].is_cuda:
+        return
 
     outs = pyg_lib.ops.grouped_matmul(inputs, others, biases)
     assert len(outs) == len(inputs)

--- a/test/ops/test_matmul.py
+++ b/test/ops/test_matmul.py
@@ -1,25 +1,16 @@
 import os
 
-import pytest
 import torch
 
 import pyg_lib
-
-DEVICES = [torch.device('cpu')]
-if torch.cuda.is_available():
-    DEVICES.append(torch.device('cuda'))
+from pyg_lib.testing import withCUDA
 
 os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
 torch.backends.cuda.matmul.allow_tf32 = False
-
-major_vers, minor_vers = str(torch.__version__).split('.')[:2]
-REQ_GRAD = int(major_vers) >= 2 or int(minor_vers) >= 14
-
-if int(minor_vers) >= 12 or int(major_vers) > 1:  # This only exists after 1.12
-    torch.set_float32_matmul_precision('highest')  # Enforce FP32
+torch.set_float32_matmul_precision('highest')  # Enforce FP32
 
 
-@pytest.mark.parametrize('device', DEVICES)
+@withCUDA
 def test_segment_matmul_autograd(device):
     inputs = torch.randn((8, 16), requires_grad=True, device=device)
     ptr = torch.tensor([0, 5, 8]).to(torch.device(device))
@@ -39,7 +30,7 @@ def test_segment_matmul_autograd(device):
     assert inputs.grad.size() == inputs.size()
 
 
-@pytest.mark.parametrize('device', DEVICES)
+@withCUDA
 def test_grouped_matmul_autograd(device):
     inputs = [
         torch.randn(5, 16, device=device),
@@ -47,15 +38,15 @@ def test_grouped_matmul_autograd(device):
         torch.randn(3, 32, device=device),
     ]
     others = [
-        torch.randn(16, 48, device=device, requires_grad=REQ_GRAD),
-        torch.randn(9, 42, device=device, requires_grad=REQ_GRAD),
-        torch.randn(32, 64, device=device, requires_grad=REQ_GRAD),
+        torch.randn(16, 48, device=device, requires_grad=True),
+        torch.randn(9, 42, device=device, requires_grad=True),
+        torch.randn(32, 64, device=device, requires_grad=True),
     ]
 
     biases = [
-        torch.randn(48, device=device, requires_grad=REQ_GRAD),
-        torch.randn(42, device=device, requires_grad=REQ_GRAD),
-        torch.randn(64, device=device, requires_grad=REQ_GRAD),
+        torch.randn(48, device=device, requires_grad=True),
+        torch.randn(42, device=device, requires_grad=True),
+        torch.randn(64, device=device, requires_grad=True),
     ]
 
     outs = pyg_lib.ops.grouped_matmul(inputs, others, biases)
@@ -63,10 +54,9 @@ def test_grouped_matmul_autograd(device):
 
     for i in range(len(outs)):
         assert outs[i].size() == (inputs[i].size(0), others[i].size(-1))
-        assert torch.allclose(outs[i], inputs[i] @ others[i] + biases[i],
-                              atol=1e-6)
+        expected = inputs[i] @ others[i] + biases[i]
+        assert torch.allclose(outs[i], expected, atol=1e-6)
 
-    if REQ_GRAD:
-        sum([out.sum() for out in outs]).backward()
-        for i in range(len(outs)):
-            assert others[i].grad.size() == others[i].size()
+    sum([out.sum() for out in outs]).backward()
+    for i in range(len(outs)):
+        assert others[i].grad.size() == others[i].size()

--- a/test/ops/test_matmul.py
+++ b/test/ops/test_matmul.py
@@ -49,9 +49,6 @@ def test_grouped_matmul_autograd(device):
         torch.randn(64, device=device, requires_grad=True),
     ]
 
-    if inputs[0].is_cuda:
-        return
-
     outs = pyg_lib.ops.grouped_matmul(inputs, others, biases)
     assert len(outs) == len(inputs)
 


### PR DESCRIPTION
With recent pytorch updates, our original implementation with list of tensors should work, no need for nested tensors
There are still some cases where the for-loop + linear is faster than heterodictlinear but this varies with number of types and size of tensors, so i will learn another sklearn hueristic for HeteroDictLinear the same way i have done for  [HeteroLinear(segmatmul)](https://github.com/pyg-team/pytorch_geometric/pull/7258)