### PR TITLE
Update CXX_STANDARD to 17 to align with PyTorch master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(pyg)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(PYG_VERSION 0.2.0)
 
 option(BUILD_TEST "Enable testing" OFF)


### PR DESCRIPTION
PyTorch master has updated to `CXX_STANDARD 17` since 5/19/2023. `pyg-lib` needs to update accordingly to avoid build failure.