### PR TITLE
Improve `import pyg_lib` speed

### DIFF
--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple
 import torch
 from torch import Tensor
 
-from .scatter_reduce import fused_scatter_reduce
 import torch.utils._pytree as pytree
 
 
@@ -341,5 +340,4 @@ __all__ = [
     'sampled_mul',
     'sampled_div',
     'index_sort',
-    'fused_scatter_reduce',
 ]

--- a/test/ops/test_scatter_reduce.py
+++ b/test/ops/test_scatter_reduce.py
@@ -1,6 +1,6 @@
 import torch
 
-from pyg_lib.ops.fused_scatter_reduce import fused_scatter_reduce
+from pyg_lib.ops.scatter_reduce import fused_scatter_reduce
 from pyg_lib.testing import onlyCUDA, onlyTriton
 
 

--- a/test/ops/test_scatter_reduce.py
+++ b/test/ops/test_scatter_reduce.py
@@ -1,6 +1,6 @@
 import torch
 
-from pyg_lib.ops import fused_scatter_reduce
+from pyg_lib.ops.fused_scatter_reduce import fused_scatter_reduce
 from pyg_lib.testing import onlyCUDA, onlyTriton
 
 


### PR DESCRIPTION
`import triton` is too slow, so we don't load `fused_scatter_reduce` on import.