### PR TITLE
Add `softmax_csr` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.4.0] - 2023-MM-DD
 ### Added
+- Added `softmax_csr` implementation ([#264](https://github.com/pyg-team/pyg-lib/pull/264))
 - Added support for edge-level sampling ([#280](https://github.com/pyg-team/pyg-lib/pull/280))
 - Added support for `bfloat16` data type in `segment_matmul` and `grouped_matmul` (CPU only) ([#272](https://github.com/pyg-team/pyg-lib/pull/272))
 ### Changed

--- a/benchmark/ops/softmax.py
+++ b/benchmark/ops/softmax.py
@@ -1,0 +1,69 @@
+import argparse
+
+import torch
+import pyg_lib
+
+from time import perf_counter as timestamp
+from torch_geometric.utils import scatter, segment
+
+
+def softmax_reference(src, ptr, dim=0):
+    dim = dim + src.dim() if dim < 0 else dim
+    size = ([1] * dim) + [-1]
+    count = ptr[1:] - ptr[:-1]
+    ptr = ptr.view(size)
+    src_max = segment(src.detach(), ptr, reduce='max')
+    src_max = src_max.repeat_interleave(count, dim=dim)
+    out = (src - src_max).exp()
+    out_sum = segment(out, ptr, reduce='sum') + 1e-16
+    out_sum = out_sum.repeat_interleave(count, dim=dim)
+
+    return out / out_sum
+
+
+def measure_perf(impl_func, ptr, out_grad, num_warmups, num_steps, backward):
+    t_fwd = t_bwd = 0
+    for i in range(num_warmups + num_steps):
+        src = torch.randn(num_rows, num_heads)
+        src.requires_grad = backward
+
+        t_start = timestamp()
+        out = impl_func(src=src, ptr=ptr)
+        if i >= num_warmups:
+            t_fwd += timestamp() - t_start
+
+        if backward:
+            t_start = timestamp()
+            out.backward(out_grad)
+            if i >= num_warmups:
+                t_bwd += timestamp() - t_start
+
+    return t_fwd, t_bwd
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--backward', action='store_true')
+    parser.add_argument('--num-heads', type=int, default=4)
+    args = parser.parse_args()
+
+    num_rows, num_heads = 50000, args.num_heads
+    num_warmups, num_steps = 100, 500
+    group_size = 100
+
+    ptr = torch.arange(0, num_rows + 1, group_size)
+    out_grad = torch.randn(num_rows, num_heads)
+
+    func_args = [ptr, out_grad, num_warmups, num_steps, args.backward]
+
+    t_fwd, t_bwd = measure_perf(softmax_reference, *func_args)
+    print(f'Vanilla forward: {t_fwd:.4f}s')
+    if args.backward:
+        print(f'Vanilla backward: {t_bwd:.4f}s')
+    print('=========================')
+
+    t_fwd, t_bwd = measure_perf(pyg_lib.ops.softmax, *func_args)
+    print(f'pyg_lib forward:  {t_fwd:.4f}s')
+    if args.backward:
+        print(f'pyg_lib backward: {t_bwd:.4f}s')
+

--- a/benchmark/ops/softmax.py
+++ b/benchmark/ops/softmax.py
@@ -4,10 +4,10 @@ import torch
 import pyg_lib
 
 from time import perf_counter as timestamp
-from torch_geometric.utils import scatter, segment
+from torch_geometric.utils import segment
 
 
-def softmax_reference(src, ptr, dim=0):
+def softmax_reference_ptr(src, ptr, dim=0):
     dim = dim + src.dim() if dim < 0 else dim
     size = ([1] * dim) + [-1]
     count = ptr[1:] - ptr[:-1]
@@ -56,7 +56,7 @@ if __name__ == '__main__':
 
     func_args = [ptr, out_grad, num_warmups, num_steps, args.backward]
 
-    t_fwd, t_bwd = measure_perf(softmax_reference, *func_args)
+    t_fwd, t_bwd = measure_perf(softmax_reference_ptr, *func_args)
     print(f'Vanilla forward: {t_fwd:.4f}s')
     if args.backward:
         print(f'Vanilla backward: {t_bwd:.4f}s')

--- a/benchmark/ops/softmax.py
+++ b/benchmark/ops/softmax.py
@@ -1,10 +1,10 @@
 import argparse
+from time import perf_counter as timestamp
 
 import torch
-import pyg_lib
-
-from time import perf_counter as timestamp
 from torch_geometric.utils import segment
+
+import pyg_lib
 
 
 def softmax_reference_ptr(src, ptr, dim=0):
@@ -66,4 +66,3 @@ if __name__ == '__main__':
     print(f'pyg_lib forward:  {t_fwd:.4f}s')
     if args.backward:
         print(f'pyg_lib backward: {t_bwd:.4f}s')
-

--- a/benchmark/ops/softmax.py
+++ b/benchmark/ops/softmax.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         print(f'Vanilla backward: {t_bwd:.4f}s')
     print('=========================')
 
-    t_fwd, t_bwd = measure_perf(pyg_lib.ops.softmax, *func_args)
+    t_fwd, t_bwd = measure_perf(pyg_lib.ops.softmax_csr, *func_args)
     print(f'pyg_lib forward:  {t_fwd:.4f}s')
     if args.backward:
         print(f'pyg_lib backward: {t_bwd:.4f}s')

--- a/pyg_lib/csrc/ops/cpu/softmax_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/softmax_kernel.cpp
@@ -1,0 +1,159 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+void check_arguments(const at::Tensor& values,
+                     const at::optional<at::Tensor> ptr,
+                     const int64_t dim) {
+  TORCH_CHECK(values.dim() == 2, "Only 2D `values` are currently supported.");
+  TORCH_CHECK(ptr.has_value(),
+              "`ptr` is currently only way to specify groups.");
+  TORCH_CHECK(dim == 0, "Only first dimension is currently supported.");
+}
+
+void check_arguments(const at::Tensor& values,
+                     const at::Tensor& values_grad,
+                     const at::optional<at::Tensor> ptr,
+                     const int64_t dim) {
+  TORCH_CHECK(values_grad.dim() == 2,
+              "Only 2D `values_grad` is currently supported.");
+  check_arguments(values, ptr, dim);
+}
+
+std::vector<int64_t> create_per_thread_groups(const int64_t* groups_ptr,
+                                              const int64_t n_groups,
+                                              const int64_t n_rows) {
+  std::vector<int64_t> new_groups = {0};
+  const auto avg_work_per_thread = at::divup(n_rows, at::get_num_threads());
+  int64_t cur_work = 0;
+  for (int64_t i = 0; i < n_groups; ++i) {
+    cur_work += groups_ptr[i + 1] - groups_ptr[i];
+    if (cur_work >= avg_work_per_thread) {
+      new_groups.push_back(i + 1);
+      cur_work = 0;
+    }
+  }
+  new_groups.push_back(n_groups);
+
+  return new_groups;
+}
+
+at::Tensor softmax_forward_kernel_ptr_dim0_impl(const at::Tensor& src,
+                                                const at::Tensor& groups) {
+  auto out = at::zeros_like(src);
+
+  AT_DISPATCH_FLOATING_TYPES(
+      src.scalar_type(), "softmax_forward_kernel_ptr_dim0_impl", [&] {
+        const auto n_groups = groups.size(0) - 1;
+        const auto n_heads = src.size(-1);
+        auto max = at::full({n_groups, n_heads},
+                            std::numeric_limits<scalar_t>::lowest());
+        auto sum = at::zeros({n_groups, n_heads});
+
+        const auto src_ptr = src.data_ptr<scalar_t>();
+        const auto groups_ptr = groups.data_ptr<int64_t>();
+        auto out_ptr = out.data_ptr<scalar_t>();
+        auto max_ptr = max.data_ptr<scalar_t>();
+        auto sum_ptr = sum.data_ptr<scalar_t>();
+        const auto new_groups = std::move(
+            create_per_thread_groups(groups_ptr, n_groups, src.size(0)));
+
+        at::parallel_for(
+            0, new_groups.size() - 1, 1, [&](int64_t beg, int64_t end) {
+              // each thread may cover several groups
+              for (auto group_id = new_groups[beg]; group_id < new_groups[end];
+                   ++group_id) {
+                const auto row_beg = groups_ptr[group_id];
+                const auto row_end = groups_ptr[group_id + 1];
+                const auto rows_in_group = row_end - row_beg;
+                const auto inout_offset = row_beg * n_heads;
+                const auto aux_offset = group_id * n_heads;
+                const auto src_beg_ptr = src_ptr + inout_offset;
+                auto out_beg_ptr = out_ptr + inout_offset;
+                auto max_beg_ptr = max_ptr + aux_offset;
+                auto sum_beg_ptr = sum_ptr + aux_offset;
+
+                if (rows_in_group == 1) {
+                  std::fill(out_beg_ptr, out_beg_ptr + n_heads,
+                            static_cast<scalar_t>(1.0));
+                } else {
+                  // calculate max
+                  for (int64_t i = 0; i < rows_in_group * n_heads; ++i) {
+                    const auto aux_id = i % n_heads;
+                    max_beg_ptr[aux_id] =
+                        std::max(max_beg_ptr[aux_id], src_beg_ptr[i]);
+                  }
+                  // calculate sum
+                  for (int64_t i = 0; i < rows_in_group * n_heads; ++i) {
+                    const auto aux_id = i % n_heads;
+                    const auto value =
+                        std::exp(src_beg_ptr[i] - max_beg_ptr[aux_id]);
+                    sum_beg_ptr[aux_id] += value;
+                    out_beg_ptr[i] = value;
+                  }
+                  // unify
+                  for (int64_t i = 0; i < rows_in_group * n_heads; ++i) {
+                    const auto aux_id = i % n_heads;
+                    out_beg_ptr[i] /= sum_beg_ptr[aux_id];
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+at::Tensor softmax_forward_kernel(const at::Tensor& src,
+                                  const at::optional<at::Tensor> index,
+                                  const at::optional<at::Tensor> ptr,
+                                  const at::optional<int64_t> num_nodes,
+                                  const int64_t dim) {
+  check_arguments(src, ptr, dim);
+
+  return softmax_forward_kernel_ptr_dim0_impl(src, ptr.value());
+}
+
+at::Tensor softmax_backward_kernel_ptr_dim0_impl(const at::Tensor& out,
+                                                 const at::Tensor& out_grad,
+                                                 const at::Tensor& ptr) {
+  auto in_grad = at::zeros_like(out);
+
+  // TODO: not implemented yet
+
+  return in_grad;
+}
+
+at::Tensor softmax_backward_kernel(const at::Tensor& out,
+                                   const at::Tensor& out_grad,
+                                   const at::optional<at::Tensor> index,
+                                   const at::optional<at::Tensor> ptr,
+                                   const at::optional<int64_t> num_nodes,
+                                   const int64_t dim) {
+  check_arguments(out, out_grad, ptr, dim);
+
+  return softmax_backward_kernel_ptr_dim0_impl(out, out_grad, ptr.value());
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::softmax_forward"),
+         TORCH_FN(softmax_forward_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::softmax_backward"),
+         TORCH_FN(softmax_backward_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/softmax.cpp
+++ b/pyg_lib/csrc/ops/softmax.cpp
@@ -1,0 +1,78 @@
+#include "softmax.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+// Performs softmax operations for each group.
+PYG_API at::Tensor softmax_forward(const at::Tensor& src,
+                                   const at::optional<at::Tensor> index,
+                                   const at::optional<at::Tensor> ptr,
+                                   const at::optional<int64_t> num_nodes,
+                                   const int64_t dim) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::CheckedFrom c{"softmax_forward"};
+
+  at::checkAllDefined(c, {src_arg});
+  at::checkContiguous(c, src_arg);
+
+  if (index.has_value()) {
+    at::TensorArg index_arg{index.value(), "index", 1};
+    at::checkContiguous(c, index_arg);
+  }
+
+  if (ptr.has_value()) {
+    at::TensorArg ptr_arg{ptr.value(), "ptr", 2};
+    at::checkContiguous(c, ptr_arg);
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::softmax_forward", "")
+                       .typed<decltype(softmax_forward)>();
+  return op.call(src, index, ptr, num_nodes, dim);
+}
+
+// Computes gradient for grouped softmax operation.
+PYG_API at::Tensor softmax_backward(const at::Tensor& out,
+                                    const at::Tensor& out_grad,
+                                    const at::optional<at::Tensor> index,
+                                    const at::optional<at::Tensor> ptr,
+                                    const at::optional<int64_t> num_nodes,
+                                    const int64_t dim) {
+  at::TensorArg out_arg{out, "out", 0};
+  at::TensorArg out_grad_arg{out_grad, "out_grad", 1};
+  at::CheckedFrom c{"softmax_backward"};
+
+  at::checkAllDefined(c, {out_arg, out_grad_arg});
+  at::checkContiguous(c, out_arg);
+  at::checkContiguous(c, out_grad_arg);
+
+  if (index.has_value()) {
+    at::TensorArg index_arg{index.value(), "index", 2};
+    at::checkContiguous(c, index_arg);
+  }
+
+  if (ptr.has_value()) {
+    at::TensorArg ptr_arg{ptr.value(), "ptr", 3};
+    at::checkContiguous(c, ptr_arg);
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::softmax_backward", "")
+                       .typed<decltype(softmax_backward)>();
+  return op.call(out, out_grad, index, ptr, num_nodes, dim);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::softmax_forward(Tensor src, Tensor? index, Tensor? ptr, "
+      "int? num_nodes, int dim=0) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::softmax_backward(Tensor out, Tensor out_grad, Tensor? index, "
+      "Tensor? ptr, int? num_nodes, int dim=0) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/softmax.cpp
+++ b/pyg_lib/csrc/ops/softmax.cpp
@@ -7,71 +7,51 @@ namespace pyg {
 namespace ops {
 
 // Performs softmax operations for each group.
-PYG_API at::Tensor softmax_forward(const at::Tensor& src,
-                                   const at::optional<at::Tensor> index,
-                                   const at::optional<at::Tensor> ptr,
-                                   const at::optional<int64_t> num_nodes,
-                                   const int64_t dim) {
+PYG_API at::Tensor softmax_csr_forward(const at::Tensor& src,
+                                       const at::Tensor& ptr,
+                                       const int64_t dim) {
   at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg ptr_arg{ptr, "ptr", 1};
   at::CheckedFrom c{"softmax_forward"};
 
-  at::checkAllDefined(c, {src_arg});
+  at::checkAllDefined(c, {src_arg, ptr_arg});
   at::checkContiguous(c, src_arg);
-
-  if (index.has_value()) {
-    at::TensorArg index_arg{index.value(), "index", 1};
-    at::checkContiguous(c, index_arg);
-  }
-
-  if (ptr.has_value()) {
-    at::TensorArg ptr_arg{ptr.value(), "ptr", 2};
-    at::checkContiguous(c, ptr_arg);
-  }
+  at::checkContiguous(c, ptr_arg);
 
   static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("pyg::softmax_forward", "")
-                       .typed<decltype(softmax_forward)>();
-  return op.call(src, index, ptr, num_nodes, dim);
+                       .findSchemaOrThrow("pyg::softmax_csr_forward", "")
+                       .typed<decltype(softmax_csr_forward)>();
+  return op.call(src, ptr, dim);
 }
 
 // Computes gradient for grouped softmax operation.
-PYG_API at::Tensor softmax_backward(const at::Tensor& out,
-                                    const at::Tensor& out_grad,
-                                    const at::optional<at::Tensor> index,
-                                    const at::optional<at::Tensor> ptr,
-                                    const at::optional<int64_t> num_nodes,
-                                    const int64_t dim) {
+PYG_API at::Tensor softmax_csr_backward(const at::Tensor& out,
+                                        const at::Tensor& out_grad,
+                                        const at::Tensor& ptr,
+                                        const int64_t dim) {
   at::TensorArg out_arg{out, "out", 0};
   at::TensorArg out_grad_arg{out_grad, "out_grad", 1};
+  at::TensorArg ptr_arg{ptr, "ptr", 2};
   at::CheckedFrom c{"softmax_backward"};
 
-  at::checkAllDefined(c, {out_arg, out_grad_arg});
+  at::checkAllDefined(c, {out_arg, out_grad_arg, ptr_arg});
   at::checkContiguous(c, out_arg);
   at::checkContiguous(c, out_grad_arg);
-
-  if (index.has_value()) {
-    at::TensorArg index_arg{index.value(), "index", 2};
-    at::checkContiguous(c, index_arg);
-  }
-
-  if (ptr.has_value()) {
-    at::TensorArg ptr_arg{ptr.value(), "ptr", 3};
-    at::checkContiguous(c, ptr_arg);
-  }
+  at::checkContiguous(c, ptr_arg);
 
   static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("pyg::softmax_backward", "")
-                       .typed<decltype(softmax_backward)>();
-  return op.call(out, out_grad, index, ptr, num_nodes, dim);
+                       .findSchemaOrThrow("pyg::softmax_csr_backward", "")
+                       .typed<decltype(softmax_csr_backward)>();
+  return op.call(out, out_grad, ptr, dim);
 }
 
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::softmax_csr_forward(Tensor src, Tensor ptr, "
+                             "int dim=0) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "pyg::softmax_forward(Tensor src, Tensor? index, Tensor? ptr, "
-      "int? num_nodes, int dim=0) -> Tensor"));
-  m.def(TORCH_SELECTIVE_SCHEMA(
-      "pyg::softmax_backward(Tensor out, Tensor out_grad, Tensor? index, "
-      "Tensor? ptr, int? num_nodes, int dim=0) -> Tensor"));
+      "pyg::softmax_csr_backward(Tensor out, Tensor out_grad, "
+      "Tensor ptr, int dim=0) -> Tensor"));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/softmax.h
+++ b/pyg_lib/csrc/ops/softmax.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Performs softmax operations for each group.
+PYG_API at::Tensor softmax_forward(const at::Tensor& src,
+                                   const at::optional<at::Tensor> index,
+                                   const at::optional<at::Tensor> ptr,
+                                   const at::optional<int64_t> num_nodes,
+                                   const int64_t dim = 0);
+
+// Computes gradient for grouped softmax operations.
+PYG_API at::Tensor softmax_backward(const at::Tensor& out,
+                                    const at::Tensor& out_grad,
+                                    const at::optional<at::Tensor> index,
+                                    const at::optional<at::Tensor> ptr,
+                                    const at::optional<int64_t> num_nodes,
+                                    const int64_t dim = 0);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/softmax.h
+++ b/pyg_lib/csrc/ops/softmax.h
@@ -7,19 +7,15 @@ namespace pyg {
 namespace ops {
 
 // Performs softmax operations for each group.
-PYG_API at::Tensor softmax_forward(const at::Tensor& src,
-                                   const at::optional<at::Tensor> index,
-                                   const at::optional<at::Tensor> ptr,
-                                   const at::optional<int64_t> num_nodes,
-                                   const int64_t dim = 0);
+PYG_API at::Tensor softmax_csr_forward(const at::Tensor& src,
+                                       const at::Tensor& ptr,
+                                       const int64_t dim = 0);
 
 // Computes gradient for grouped softmax operations.
-PYG_API at::Tensor softmax_backward(const at::Tensor& out,
-                                    const at::Tensor& out_grad,
-                                    const at::optional<at::Tensor> index,
-                                    const at::optional<at::Tensor> ptr,
-                                    const at::optional<int64_t> num_nodes,
-                                    const int64_t dim = 0);
+PYG_API at::Tensor softmax_csr_backward(const at::Tensor& out,
+                                        const at::Tensor& out_grad,
+                                        const at::Tensor& ptr,
+                                        const int64_t dim = 0);
 
 }  // namespace ops
 }  // namespace pyg

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -372,6 +372,12 @@ def softmax(
     :attr:`index`, and then proceeds to compute the softmax individually for
     each group.
 
+    .. note::
+
+        This operation is currently implemented only for 2D data, where
+        segments are created along the first dimension and are defined using
+        ptr.
+
     Args:
         src (Tensor): The source tensor.
         index (LongTensor, optional): The indices of elements for applying the

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -332,6 +332,52 @@ def index_sort(
     return torch.ops.pyg.index_sort(inputs, max_value)
 
 
+def softmax(
+    src: Tensor,
+    index: Optional[Tensor] = None,
+    ptr: Optional[Tensor] = None,
+    num_nodes: Optional[int] = None,
+    dim: int = 0,
+) -> Tensor:
+    r"""Computes a sparsely evaluated softmax.
+    Given a value tensor :attr:`src`, this function first groups the values
+    along the given dimension :attr:`dim`, based on the indices specified in
+    :attr:`index`, and then proceeds to compute the softmax individually for
+    each group.
+
+    Args:
+        src (Tensor): The source tensor.
+        index (LongTensor, optional): The indices of elements for applying the
+            softmax. (default: :obj:`None`)
+        ptr (LongTensor, optional): If given, computes the softmax based on
+            sorted inputs in CSR representation. (default: :obj:`None`)
+        num_nodes (int, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`index`. (default: :obj:`None`)
+        dim (int, optional): The dimension in which to normalize.
+            (default: :obj:`0`)
+
+    :rtype: :class:`Tensor`
+
+    Examples:
+
+        >>> src = torch.randn(4, 4)
+        >>> ptr = torch.tensor([0, 4])
+        >>> softmax(src, None, ptr)
+        tensor([[0.0157, 0.0984, 0.1250, 0.4523],
+                [0.1453, 0.2591, 0.5907, 0.2410],
+                [0.0598, 0.2923, 0.1206, 0.0921],
+                [0.7792, 0.3502, 0.1638, 0.2145]])
+    """
+    if src.dim() != 2 or not src.is_cpu or ptr is None or dim != 0:
+        # currently softmax is implemented for GAT cases:
+        # - src is of shape(X, num_heads) and associated with CPU device
+        # - ptr is given
+        # - dim is 0
+        raise NotImplementedError
+
+    return torch.ops.pyg.softmax_forward(src, index, ptr, num_nodes, dim)
+
+
 __all__ = [
     'grouped_matmul',
     'segment_matmul',
@@ -340,4 +386,5 @@ __all__ = [
     'sampled_mul',
     'sampled_div',
     'index_sort',
+    'softmax',
 ]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -352,9 +352,8 @@ class Softmax(torch.autograd.Function):
     @staticmethod
     def backward(ctx, out_grad: Tensor) -> Tuple[Union[Tensor, int]]:
         out, index, ptr = ctx.saved_tensors
-        in_grad = torch.ops.pyg.softmax_backward(
-            out, out_grad, index, ptr, ctx.num_nodes, ctx.dim
-        )
+        in_grad = torch.ops.pyg.softmax_backward(out, out_grad, index, ptr,
+                                                 ctx.num_nodes, ctx.dim)
 
         return in_grad, None, None, None, None
 

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -383,6 +383,7 @@ def softmax_csr(
                 [0.0598, 0.2923, 0.1206, 0.0921],
                 [0.7792, 0.3502, 0.1638, 0.2145]])
     """
+    dim = dim + src.dim() if dim < 0 else dim
     return Softmax.apply(src, ptr, dim)
 
 

--- a/test/csrc/ops/test_softmax.cpp
+++ b/test/csrc/ops/test_softmax.cpp
@@ -1,0 +1,61 @@
+#include <ATen/ATen.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "pyg_lib/csrc/ops/softmax.h"
+
+using namespace at::indexing;
+
+at::Tensor softmax2D_ref_impl(const at::Tensor& src,
+                              const at::Tensor& ptr,
+                              const int64_t dim) {
+  auto out = at::zeros_like(src);
+
+  for (int64_t i = 0; i < src.size(1 - dim); ++i) {
+    for (int64_t j = 0; j < ptr.size(0) - 1; ++j) {
+      const auto beg = ptr[j].item<int64_t>();
+      const auto end = ptr[j + 1].item<int64_t>();
+      const auto row_slice = (dim == 0) ? Slice(beg, end) : Slice(i, i + 1);
+      const auto col_slice = (dim == 0) ? Slice(i, i + 1) : Slice(beg, end);
+      out.index_put_({row_slice, col_slice},
+                     src.index({row_slice, col_slice}).softmax(dim));
+    }
+  }
+
+  return out;
+}
+
+class CPUTest : public testing::TestWithParam<int64_t> {};
+
+TEST_P(CPUTest, SoftmaxCSRForward) {
+  const auto dim = ::testing::TestWithParam<int64_t>::GetParam();
+  const auto src = at::rand({8, 8});
+  const auto ptr = at::tensor({0, 3, 4, 7, 8}, at::kLong);
+  const auto expected_out = softmax2D_ref_impl(src, ptr, dim);
+
+  const auto out = pyg::ops::softmax_csr_forward(src, ptr, dim);
+  EXPECT_EQ(expected_out.size(0), out.size(0));
+  EXPECT_EQ(expected_out.size(1), out.size(1));
+  EXPECT_TRUE(at::allclose(expected_out, out, 1e-04, 1e-04));
+}
+
+TEST_P(CPUTest, SoftmaxCSRBackward) {
+  const auto dim = ::testing::TestWithParam<int64_t>::GetParam();
+  const auto src = at::rand({8, 8});
+  src.set_requires_grad(true);
+  const auto ptr = at::tensor({0, 3, 4, 7, 8}, at::kLong);
+  const auto out = softmax2D_ref_impl(src, ptr, dim);
+  const auto out_grad = at::rand({8, 8});
+
+  const auto in_grad = pyg::ops::softmax_csr_backward(out, out_grad, ptr, dim);
+  out.backward(out_grad);
+  EXPECT_EQ(src.grad().size(0), in_grad.size(0));
+  EXPECT_EQ(src.grad().size(1), in_grad.size(1));
+  EXPECT_TRUE(at::allclose(src.grad(), in_grad, 1e-04, 1e-04));
+}
+
+INSTANTIATE_TEST_SUITE_P(OpsTest,
+                         CPUTest,
+                         // dim
+                         testing::Values(0, 1));

--- a/test/ops/test_softmax.py
+++ b/test/ops/test_softmax.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn.functional as F
+
+import pyg_lib
+
+
+def softmax_reference_ptr_dim0(src, ptr):
+    out = torch.empty_like(src)
+    for beg, end in zip(ptr[:-1], ptr[1:]):
+        for col in range(src.size(-1)):
+            out[beg:end, col] = F.softmax(src[beg:end, col], dim=0)
+    return out
+
+
+def test_softmax_ptr_dim0_autograd():
+    src1 = torch.rand((16, 2), requires_grad=True)
+    src2 = src1.detach().clone()
+    src2.requires_grad = True
+    ptr = torch.tensor([0, 7, 15, 16])
+    out_grad = torch.randn((16, 2))
+
+    expected_out = softmax_reference_ptr_dim0(src1, ptr)
+    out = pyg_lib.ops.softmax(src=src2, ptr=ptr)
+    assert torch.allclose(expected_out, out, atol=1e-6)
+
+    expected_out.backward(out_grad)
+    out.backward(out_grad)
+    assert torch.allclose(src1.grad, src2.grad, atol=1e-6)


### PR DESCRIPTION
This PR adds forward and backward implementation of sparse softmax operation as defined [here](https://github.com/pyg-team/pytorch_geometric/blob/master/torch_geometric/utils/softmax.py#L9).

In the `pytorch_geometric` implementation we cannot take advantage of model compilation when groups are defined via `ptr`. `softmax_csr` introduced here provides a well-performing kernel for such a scenario.

Performance boost (achieved on 28C, single socket machine):
~7x for forward pass
~8x for backward pass
Additionally, GAT training time was reduced by ~5%.