### PR TITLE
Benchmarks for biased sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [0.4.0] - 2023-MM-DD
 ### Added
 ### Changed
+- Added `--biased` parameter to run benchmarks for biased sampling ([#267](https://github.com/pyg-team/pyg-lib/pull/267))
 ### Removed
 
 ## [0.3.0] - 2023-10-11

--- a/benchmark/sampler/hetero_neighbor.py
+++ b/benchmark/sampler/hetero_neighbor.py
@@ -65,7 +65,7 @@ def test_hetero_neighbor(dataset, **kwargs):
     if args.biased:
         ones = torch.ones(num_edges_dict['paper']).view(-1, 1)
         zeros = torch.zeros(num_edges_dict['paper']).view(-1, 1)
-        edge_weights_dict = {k: torch.cat([ones, zeros], -1).view(-1) for k, v in row_dict.items()}
+        edge_weights_dict = {k: torch.cat([ones, zeros], -1).view(-1) for k in row_dict.keys()}
     else:
         edge_weights_dict = None
 

--- a/benchmark/sampler/hetero_neighbor.py
+++ b/benchmark/sampler/hetero_neighbor.py
@@ -65,7 +65,10 @@ def test_hetero_neighbor(dataset, **kwargs):
     if args.biased:
         ones = torch.ones(num_edges_dict['paper']).view(-1, 1)
         zeros = torch.zeros(num_edges_dict['paper']).view(-1, 1)
-        edge_weights_dict = {k: torch.cat([ones, zeros], -1).view(-1) for k in row_dict.keys()}
+        edge_weights_dict = {
+            k: torch.cat([ones, zeros], -1).view(-1)
+            for k in row_dict.keys()
+        }
     else:
         edge_weights_dict = None
 

--- a/benchmark/sampler/hetero_neighbor.py
+++ b/benchmark/sampler/hetero_neighbor.py
@@ -52,7 +52,7 @@ def test_hetero_neighbor(dataset, **kwargs):
 
     colptr_dict, row_dict = dataset
     num_nodes_dict = {k[-1]: v.size(0) - 1 for k, v in colptr_dict.items()}
-    num_edges_dict = {k[-1]: v.size(0) for k, v in row_dict.items()}
+    num_edges_dict = {k: v.size(0) for k, v in row_dict.items()}
 
     if args.temporal:
         # generate random timestamps
@@ -62,15 +62,12 @@ def test_hetero_neighbor(dataset, **kwargs):
     else:
         node_time_dict = None
 
+    edge_weight_dict = None
     if args.biased:
-        ones = torch.ones(num_edges_dict['paper']).view(-1, 1)
-        zeros = torch.zeros(num_edges_dict['paper']).view(-1, 1)
-        edge_weights_dict = {
-            k: torch.cat([ones, zeros], -1).view(-1)
-            for k in row_dict.keys()
+        edge_weight_dict = {
+            edge_type: torch.rand(num_edges)
+            for edge_type, num_edges in num_edges_dict.items()
         }
-    else:
-        edge_weights_dict = None
 
     if args.shuffle:
         node_perm = torch.randperm(num_nodes_dict['paper'])
@@ -98,7 +95,7 @@ def test_hetero_neighbor(dataset, **kwargs):
                     num_neighbors_dict,
                     node_time_dict,
                     seed_time_dict=None,
-                    edge_weight_dict=edge_weights_dict,
+                    edge_weight_dict=edge_weight_dict,
                     csc=True,
                     replace=False,
                     directed=True,

--- a/benchmark/sampler/neighbor.py
+++ b/benchmark/sampler/neighbor.py
@@ -46,9 +46,9 @@ def test_neighbor(dataset, **kwargs):
         raise ValueError(
             "Temporal sampling needs to create disjoint subgraphs")
 
-    (rowptr, col) = dataset
-    num_nodes = dataset[0].size(0) - 1
-    num_edges = col.size(0)
+    rowptr, col = dataset
+    num_nodes = rowptr.numel() - 1
+    num_edges = col.numel()
 
     if 'dgl' in args.libraries:
         import dgl
@@ -61,12 +61,9 @@ def test_neighbor(dataset, **kwargs):
     else:
         node_time = None
 
+    edge_weight = None
     if args.biased:
-        ones = torch.ones(num_edges).view(-1, 1)
-        zeros = torch.zeros(num_edges).view(-1, 1)
-        edge_weights = torch.cat([ones, zeros], -1).view(-1)
-    else:
-        edge_weights = None
+        edge_weight = torch.rand(num_edges)
 
     if args.shuffle:
         node_perm = torch.randperm(num_nodes)
@@ -91,7 +88,7 @@ def test_neighbor(dataset, **kwargs):
                     num_neighbors,
                     time=node_time,
                     seed_time=None,
-                    edge_weight=edge_weights,
+                    edge_weight=edge_weight,
                     replace=args.replace,
                     directed=args.directed,
                     disjoint=args.disjoint,

--- a/benchmark/sampler/neighbor.py
+++ b/benchmark/sampler/neighbor.py
@@ -46,10 +46,10 @@ def test_neighbor(dataset, **kwargs):
         raise ValueError(
             "Temporal sampling needs to create disjoint subgraphs")
 
-    (rowptr, col), num_nodes = dataset, dataset[0].size(0) - 1
+    (rowptr, col) = dataset
+    num_nodes = dataset[0].size(0) - 1
     num_edges = col.size(0)
-    
-    print(rowptr, col)
+
     if 'dgl' in args.libraries:
         import dgl
         dgl_graph = dgl.graph(

--- a/benchmark/sampler/neighbor.py
+++ b/benchmark/sampler/neighbor.py
@@ -46,7 +46,10 @@ def test_neighbor(dataset, **kwargs):
         raise ValueError(
             "Temporal sampling needs to create disjoint subgraphs")
 
-    (rowptr, col), num_nodes, num_edges = dataset, dataset[0].size(0) - 1, dataset[1].size(0) - 1
+    (rowptr, col), num_nodes = dataset, dataset[0].size(0) - 1
+    num_edges = col.size(0)
+    
+    print(rowptr, col)
     if 'dgl' in args.libraries:
         import dgl
         dgl_graph = dgl.graph(


### PR DESCRIPTION
Added `--biased` parameter to `neighbor.py` and `hetero_neighbor.py` to run benchmarks for biased sampling.
Output for command python neighbor.py --biased --libraries pyg-lib --write-csv :
![image](https://github.com/pyg-team/pyg-lib/assets/57872493/d5d01246-a368-4768-ad34-fda415ce2733)
Output for command python hetero_neighbor.py --biased --libraries pyg-lib --write-csv :
![image](https://github.com/pyg-team/pyg-lib/assets/57872493/7dbd2d68-9709-4259-a1f7-bf880bec5330)