### PR TITLE
Update hetero dist relabel

### DIFF
--- a/pyg_lib/csrc/sampler/cpu/dist_merge_outputs_kernel.cpp
+++ b/pyg_lib/csrc/sampler/cpu/dist_merge_outputs_kernel.cpp
@@ -58,7 +58,7 @@ merge_outputs(
   }
 
   const auto p_size = partition_ids.size();
-  std::vector<int64_t> sampled_neighbors_per_node(p_size);
+  std::vector<int64_t> num_sampled_neighbors_per_node(p_size);
 
   const auto scalar_type = node_ids[0].scalar_type();
   AT_DISPATCH_INTEGRAL_TYPES(scalar_type, "merge_outputs_kernel", [&] {
@@ -106,7 +106,7 @@ merge_outputs(
                     batch_data[j]);
         }
 
-        sampled_neighbors_per_node[j] = end_node - begin_node;
+        num_sampled_neighbors_per_node[j] = end_node - begin_node;
       }
     });
 
@@ -128,7 +128,7 @@ merge_outputs(
   });
 
   return std::make_tuple(out_node_id, out_edge_id, out_batch,
-                         sampled_neighbors_per_node);
+                         num_sampled_neighbors_per_node);
 }
 
 #define DISPATCH_MERGE_OUTPUTS(disjoint, ...) \

--- a/pyg_lib/csrc/sampler/dist_relabel.cpp
+++ b/pyg_lib/csrc/sampler/dist_relabel.cpp
@@ -11,7 +11,7 @@ namespace sampler {
 std::tuple<at::Tensor, at::Tensor> relabel_neighborhood(
     const at::Tensor& seed,
     const at::Tensor& sampled_nodes_with_duplicates,
-    const std::vector<int64_t>& sampled_neighbors_per_node,
+    const std::vector<int64_t>& num_sampled_neighbors_per_node,
     const int64_t num_nodes,
     const c10::optional<at::Tensor>& batch,
     bool csc,
@@ -28,7 +28,8 @@ std::tuple<at::Tensor, at::Tensor> relabel_neighborhood(
                        .findSchemaOrThrow("pyg::relabel_neighborhood", "")
                        .typed<decltype(relabel_neighborhood)>();
   return op.call(seed, sampled_nodes_with_duplicates,
-                 sampled_neighbors_per_node, num_nodes, batch, csc, disjoint);
+                 num_sampled_neighbors_per_node, num_nodes, batch, csc,
+                 disjoint);
 }
 
 std::tuple<c10::Dict<rel_type, at::Tensor>, c10::Dict<rel_type, at::Tensor>>
@@ -37,8 +38,8 @@ hetero_relabel_neighborhood(
     const std::vector<edge_type>& edge_types,
     const c10::Dict<node_type, at::Tensor>& seed_dict,
     const c10::Dict<node_type, at::Tensor>& sampled_nodes_with_duplicates_dict,
-    const c10::Dict<rel_type, std::vector<int64_t>>&
-        sampled_neighbors_per_node_dict,
+    const c10::Dict<rel_type, std::vector<std::vector<int64_t>>>&
+        num_sampled_neighbors_per_node_dict,
     const c10::Dict<node_type, int64_t>& num_nodes_dict,
     const c10::optional<c10::Dict<node_type, at::Tensor>>& batch_dict,
     bool csc,
@@ -62,21 +63,22 @@ hetero_relabel_neighborhood(
           .typed<decltype(hetero_relabel_neighborhood)>();
   return op.call(node_types, edge_types, seed_dict,
                  sampled_nodes_with_duplicates_dict,
-                 sampled_neighbors_per_node_dict, num_nodes_dict, batch_dict,
-                 csc, disjoint);
+                 num_sampled_neighbors_per_node_dict, num_nodes_dict,
+                 batch_dict, csc, disjoint);
 }
 
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::relabel_neighborhood(Tensor seed, Tensor "
-      "sampled_nodes_with_duplicates, int[] sampled_neighbors_per_node, int "
+      "sampled_nodes_with_duplicates, int[] num_sampled_neighbors_per_node, "
+      "int "
       "num_nodes, Tensor? batch = None, bool csc = False, bool disjoint = "
       "False) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::hetero_relabel_neighborhood(str[] node_types, (str, str, str)[] "
       "edge_types, Dict(str, Tensor) seed_dict, Dict(str, Tensor) "
-      "sampled_nodes_with_duplicates_dict, Dict(str, int[]) "
-      "sampled_neighbors_per_node_dict, Dict(str, int) num_nodes_dict, "
+      "sampled_nodes_with_duplicates_dict, Dict(str, int[][]) "
+      "num_sampled_neighbors_per_node_dict, Dict(str, int) num_nodes_dict, "
       "Dict(str, Tensor)? batch_dict = None, bool csc = False, bool disjoint = "
       "False) -> (Dict(str, Tensor), Dict(str, Tensor))"));
 }

--- a/pyg_lib/csrc/sampler/dist_relabel.h
+++ b/pyg_lib/csrc/sampler/dist_relabel.h
@@ -15,7 +15,7 @@ PYG_API
 std::tuple<at::Tensor, at::Tensor> relabel_neighborhood(
     const at::Tensor& seed,
     const at::Tensor& sampled_nodes_with_duplicates,
-    const std::vector<int64_t>& sampled_neighbors_per_node,
+    const std::vector<int64_t>& num_sampled_neighbors_per_node,
     const int64_t num_nodes,
     const c10::optional<at::Tensor>& batch = c10::nullopt,
     bool csc = false,
@@ -32,8 +32,8 @@ hetero_relabel_neighborhood(
     const std::vector<edge_type>& edge_types,
     const c10::Dict<node_type, at::Tensor>& seed_dict,
     const c10::Dict<node_type, at::Tensor>& sampled_nodes_with_duplicates_dict,
-    const c10::Dict<rel_type, std::vector<int64_t>>&
-        sampled_neighbors_per_node_dict,
+    const c10::Dict<rel_type, std::vector<std::vector<int64_t>>>&
+        num_sampled_neighbors_per_node_dict,
     const c10::Dict<node_type, int64_t>& num_nodes_dict,
     const c10::optional<c10::Dict<node_type, at::Tensor>>& batch_dict =
         c10::nullopt,

--- a/test/csrc/sampler/test_dist_merge_outputs.cpp
+++ b/test/csrc/sampler/test_dist_merge_outputs.cpp
@@ -41,8 +41,9 @@ TEST(DistMergeOutputsTest, BasicAssertions) {
   auto expected_edges = at::tensor({14, 15, 16, 17, 18, 19, 20}, options);
   EXPECT_TRUE(at::equal(std::get<1>(out), expected_edges));
 
-  const std::vector<int64_t> expected_sampled_neighbors_per_node = {2, 1, 2, 2};
-  EXPECT_EQ(std::get<3>(out), expected_sampled_neighbors_per_node);
+  const std::vector<int64_t> expected_num_sampled_neighbors_per_node = {2, 1, 2,
+                                                                        2};
+  EXPECT_EQ(std::get<3>(out), expected_num_sampled_neighbors_per_node);
 }
 
 TEST(DistMergeOutputsAllNeighborsTest, BasicAssertions) {
@@ -82,8 +83,9 @@ TEST(DistMergeOutputsAllNeighborsTest, BasicAssertions) {
   auto expected_edges = at::tensor({14, 15, 16, 17, 18, 19, 20, 21}, options);
   EXPECT_TRUE(at::equal(std::get<1>(out), expected_edges));
 
-  const std::vector<int64_t> expected_sampled_neighbors_per_node = {2, 1, 2, 3};
-  EXPECT_EQ(std::get<3>(out), expected_sampled_neighbors_per_node);
+  const std::vector<int64_t> expected_num_sampled_neighbors_per_node = {2, 1, 2,
+                                                                        3};
+  EXPECT_EQ(std::get<3>(out), expected_num_sampled_neighbors_per_node);
 }
 
 TEST(DistDisjointMergeOutputsTest, BasicAssertions) {
@@ -124,6 +126,7 @@ TEST(DistDisjointMergeOutputsTest, BasicAssertions) {
   auto expected_batch = at::tensor({0, 0, 1, 2, 2, 3, 3}, options);
   EXPECT_TRUE(at::equal(std::get<2>(out).value(), expected_batch));
 
-  const std::vector<int64_t> expected_sampled_neighbors_per_node = {2, 1, 2, 2};
-  EXPECT_EQ(std::get<3>(out), expected_sampled_neighbors_per_node);
+  const std::vector<int64_t> expected_num_sampled_neighbors_per_node = {2, 1, 2,
+                                                                        2};
+  EXPECT_EQ(std::get<3>(out), expected_num_sampled_neighbors_per_node);
 }

--- a/test/csrc/sampler/test_dist_relabel.cpp
+++ b/test/csrc/sampler/test_dist_relabel.cpp
@@ -11,12 +11,12 @@ TEST(DistRelabelNeighborhoodTest, BasicAssertions) {
 
   auto seed = at::arange(2, 4, options);
   auto sampled_nodes_with_duplicates = at::tensor({1, 3, 2, 4}, options);
-  std::vector<int64_t> sampled_neighbors_per_node = {2, 2};
+  std::vector<int64_t> num_sampled_neighbors_per_node = {2, 2};
 
   auto relabel_out = pyg::sampler::relabel_neighborhood(
       /*seed=*/seed,
       /*sampled_nodes_with_duplicates=*/sampled_nodes_with_duplicates,
-      /*sampled_neighbors_per_node=*/sampled_neighbors_per_node,
+      /*num_sampled_neighbors_per_node=*/num_sampled_neighbors_per_node,
       /*num_nodes=*/6);
 
   auto expected_row = at::tensor({0, 0, 1, 1}, options);
@@ -41,13 +41,13 @@ TEST(DistDisjointRelabelNeighborhoodTest, BasicAssertions) {
 
   auto seed = at::arange(2, 4, options);
   auto sampled_nodes_with_duplicates = at::tensor({1, 3, 2, 4}, options);
-  std::vector<int64_t> sampled_neighbors_per_node = {2, 2};
+  std::vector<int64_t> num_sampled_neighbors_per_node = {2, 2};
   auto batch = at::tensor({0, 0, 1, 1}, options);
 
   auto relabel_out = pyg::sampler::relabel_neighborhood(
       /*seed=*/seed,
       /*sampled_nodes_with_duplicates=*/sampled_nodes_with_duplicates,
-      /*sampled_neighbors_per_node=*/sampled_neighbors_per_node,
+      /*num_sampled_neighbors_per_node=*/num_sampled_neighbors_per_node,
       /*num_nodes=*/6,
       /*batch=*/batch,
       /*csc=*/false,
@@ -100,17 +100,21 @@ TEST(DistHeteroRelabelNeighborhoodTest, BasicAssertions) {
   num_nodes_dict.insert(node_key, 6);
 
   c10::Dict<node_type, at::Tensor> sampled_nodes_with_duplicates_dict;
-  c10::Dict<rel_type, std::vector<int64_t>> sampled_neighbors_per_node_dict;
+  c10::Dict<rel_type, std::vector<std::vector<int64_t>>>
+      num_sampled_neighbors_per_node_dict;
   sampled_nodes_with_duplicates_dict.insert(node_key,
                                             at::tensor({1, 3, 2, 4}, options));
-  sampled_neighbors_per_node_dict.insert(rel_key, std::vector<int64_t>(2, 2));
+  std::vector<std::vector<int64_t>> num_sampled_neighbors_per_node_vec(
+      2, std::vector<int64_t>(1, 2));
+  num_sampled_neighbors_per_node_dict.insert(
+      rel_key, num_sampled_neighbors_per_node_vec);
 
   auto relabel_out = pyg::sampler::hetero_relabel_neighborhood(
       /*node_types=*/node_types,
       /*edge_types=*/edge_types,
       /*seed_dict=*/seed_dict,
       /*sampled_nodes_with_duplicates_dict=*/sampled_nodes_with_duplicates_dict,
-      /*sampled_neighbors_per_node=*/sampled_neighbors_per_node_dict,
+      /*num_sampled_neighbors_per_node=*/num_sampled_neighbors_per_node_dict,
       /*num_nodes_dict=*/num_nodes_dict);
 
   auto expected_row = at::tensor({0, 0, 1, 1}, options);
@@ -155,17 +159,21 @@ TEST(DistHeteroRelabelNeighborhoodCscTest, BasicAssertions) {
   num_nodes_dict.insert(node_key, 6);
 
   c10::Dict<node_type, at::Tensor> sampled_nodes_with_duplicates_dict;
-  c10::Dict<rel_type, std::vector<int64_t>> sampled_neighbors_per_node_dict;
+  c10::Dict<rel_type, std::vector<std::vector<int64_t>>>
+      num_sampled_neighbors_per_node_dict;
   sampled_nodes_with_duplicates_dict.insert(node_key,
                                             at::tensor({1, 3, 2, 4}, options));
-  sampled_neighbors_per_node_dict.insert(rel_key, std::vector<int64_t>(2, 2));
+  std::vector<std::vector<int64_t>> num_sampled_neighbors_per_node_vec(
+      2, std::vector<int64_t>(1, 2));
+  num_sampled_neighbors_per_node_dict.insert(
+      rel_key, num_sampled_neighbors_per_node_vec);
 
   auto relabel_out = pyg::sampler::hetero_relabel_neighborhood(
       /*node_types=*/node_types,
       /*edge_types=*/edge_types,
       /*seed_dict=*/seed_dict,
       /*sampled_nodes_with_duplicates_dict=*/sampled_nodes_with_duplicates_dict,
-      /*sampled_neighbors_per_node=*/sampled_neighbors_per_node_dict,
+      /*num_sampled_neighbors_per_node=*/num_sampled_neighbors_per_node_dict,
       /*num_nodes_dict=*/num_nodes_dict,
       /*batch_dict=*/c10::nullopt,
       /*csc=*/true);
@@ -217,11 +225,15 @@ TEST(DistHeteroDisjointRelabelNeighborhoodTest, BasicAssertions) {
   num_nodes_dict.insert(node_key, 6);
 
   c10::Dict<node_type, at::Tensor> sampled_nodes_with_duplicates_dict;
-  c10::Dict<rel_type, std::vector<int64_t>> sampled_neighbors_per_node_dict;
+  c10::Dict<rel_type, std::vector<std::vector<int64_t>>>
+      num_sampled_neighbors_per_node_dict;
   c10::Dict<node_type, at::Tensor> batch_dict;
   sampled_nodes_with_duplicates_dict.insert(node_key,
                                             at::tensor({1, 3, 2, 4}, options));
-  sampled_neighbors_per_node_dict.insert(rel_key, std::vector<int64_t>(2, 2));
+  std::vector<std::vector<int64_t>> num_sampled_neighbors_per_node_vec(
+      2, std::vector<int64_t>(1, 2));
+  num_sampled_neighbors_per_node_dict.insert(
+      rel_key, num_sampled_neighbors_per_node_vec);
   batch_dict.insert(node_key, at::tensor({0, 0, 1, 1}, options));
 
   auto relabel_out = pyg::sampler::hetero_relabel_neighborhood(
@@ -229,7 +241,7 @@ TEST(DistHeteroDisjointRelabelNeighborhoodTest, BasicAssertions) {
       /*edge_types=*/edge_types,
       /*seed_dict=*/seed_dict,
       /*sampled_nodes_with_duplicates_dict=*/sampled_nodes_with_duplicates_dict,
-      /*sampled_neighbors_per_node=*/sampled_neighbors_per_node_dict,
+      /*num_sampled_neighbors_per_node=*/num_sampled_neighbors_per_node_dict,
       /*num_nodes_dict=*/num_nodes_dict,
       /*batch_dict=*/batch_dict,
       /*csc=*/false,


### PR DESCRIPTION
Due to the fact that the implementation of distributed training for hetero has changed, it is also necessary to change the dist hetero relabel neighborhood function.

Related pytorch_geometric PR: [#8503](https://github.com/pyg-team/pytorch_geometric/pull/8503)

Changes made:
    - `num_sampled_neighbors_per_node` dictionary currently store information about the number of sampled neighbors for each layer separately: 
    `const c10::Dict<rel_type, std::vector<int64_t>>&num_sampled_neighbors_per_node_dict` ->  `const c10::Dict<rel_type, std::vector<std::vector<int64_t>>>&num_sampled_neighbors_per_node_dict`
    - The method of mapping nodes has also been changed. This is now done layer by layer.
    - After each layer, the range of src nodes for each edge type for the next layer is calculated and the offsets for edge types having the same src node types must be the same.
    - The src node range for each edge type in a given layer is defined by a dictionary `srcs_slice_dict`. Local src nodes (`sampled_rows`) will be created on its basis and the starting value of the next layer will be the end value from the previous layer. 
