### PR TITLE
An error occurred while loading data using "torch geometry. datasets. Planetoid"

### DIFF
--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -326,7 +326,7 @@ def index_sort(
         A tuple containing sorted values and indices of the elements in the
         original :obj:`input` tensor.
     """
-    if not inputs.is_cpu:
+    if inputs.is_cpu:
         return torch.sort(inputs)
     return torch.ops.pyg.index_sort(inputs, max_value)
 


### PR DESCRIPTION
When using `torch_geometry.datasets.Planetoid` to load data on a Mac,  an error message `Could not run 'pyg::index_sort' with arguments from the 'CPU' backend.` The error message states that `pyg::index_sort 'is only available for these backups: [CUDA, MPS, Meta, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTens: Or, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, AutogradMPS, AutogradXPU, AutogradHPU, AutogradLazy, AutogradMeta, Tracer, AutocastCPU, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, Python TLSSnap, FuncTorchDynamicLayerFrontMode, PreDisp [attach, Python Dispatcher]`

After debugging the source code, I found that there was an issue with the if check in the function definition of `index_sort()`. This is because when loading the dataset, CPU mode is used by default, and the value of `is_cpu` should be true. In this case, `torch.sort()` should be used instead of `torch.ops.pyg.index_sort()`. This error will not appear on devices using CUDA, but will cause errors in dataset loading on devices using CPU by default.