### PR TITLE
Remove usage of `torch::autograd::Variable`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/sampled_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/sampled_kernel.cpp
@@ -7,19 +7,18 @@ namespace ops {
 
 namespace {
 
-using torch::autograd::Variable;
 using torch::autograd::variable_list;
 
 class SampledOp : public torch::autograd::Function<SampledOp> {
  public:
   static variable_list forward(torch::autograd::AutogradContext* ctx,
-                               const Variable& left,
-                               const Variable& right,
+                               const at::Tensor& left,
+                               const at::Tensor& right,
                                const at::optional<at::Tensor> left_index,
                                const at::optional<at::Tensor> right_index,
                                const std::string fn) {
     at::AutoDispatchBelowADInplaceOrView g;
-    Variable out = sampled_op(left, right, left_index, right_index, fn);
+    at::Tensor out = sampled_op(left, right, left_index, right_index, fn);
     ctx->saved_data["has_left_index"] = left_index.has_value();
     ctx->saved_data["has_right_index"] = right_index.has_value();
     ctx->saved_data["fn"] = fn;
@@ -48,7 +47,7 @@ class SampledOp : public torch::autograd::Function<SampledOp> {
     }
     auto fn = ctx->saved_data["fn"].toStringRef();
 
-    auto grad_left = Variable();
+    auto grad_left = at::Tensor();
     if (torch::autograd::any_variable_requires_grad({left})) {
       grad_left = grad_out;
 
@@ -66,7 +65,7 @@ class SampledOp : public torch::autograd::Function<SampledOp> {
       }
     }
 
-    auto grad_right = Variable();
+    auto grad_right = at::Tensor();
     if (torch::autograd::any_variable_requires_grad({right})) {
       grad_right = grad_out;
 
@@ -91,7 +90,7 @@ class SampledOp : public torch::autograd::Function<SampledOp> {
       }
     }
 
-    return {grad_left, grad_right, Variable(), Variable(), Variable()};
+    return {grad_left, grad_right, at::Tensor(), at::Tensor(), at::Tensor()};
   }
 };
 

--- a/pyg_lib/csrc/ops/autograd/softmax_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/softmax_kernel.cpp
@@ -7,18 +7,17 @@ namespace ops {
 
 namespace {
 
-using torch::autograd::Variable;
 using torch::autograd::variable_list;
 
 class SoftmaxCSR : public torch::autograd::Function<SoftmaxCSR> {
  public:
   static variable_list forward(torch::autograd::AutogradContext* ctx,
-                               const Variable& src,
+                               const at::Tensor& src,
                                const at::Tensor& ptr,
                                const int64_t dim) {
     at::AutoDispatchBelowADInplaceOrView g;
 
-    Variable out = softmax_csr(src, ptr, dim);
+    at::Tensor out = softmax_csr(src, ptr, dim);
     ctx->saved_data["dim"] = dim;
     ctx->save_for_backward({src, out, ptr});
 
@@ -34,12 +33,12 @@ class SoftmaxCSR : public torch::autograd::Function<SoftmaxCSR> {
     const auto ptr = saved[2];
     const auto dim = ctx->saved_data["dim"].toInt();
 
-    auto src_grad = Variable();
+    auto src_grad = at::Tensor();
     if (torch::autograd::any_variable_requires_grad({src})) {
       src_grad = softmax_csr_backward(out, out_grad, ptr, dim);
     }
 
-    return {src_grad, Variable(), Variable()};
+    return {src_grad, at::Tensor(), at::Tensor()};
   }
 };
 


### PR DESCRIPTION
Replaces `Variable` with `Tensor` as per the docs:

> The only reason we are keeping the `Variable` class is backward compatibility with external user’s legacy C++ frontend code. Our intention is to eliminate the `Variable` class in the near future. 

https://pytorch.org/cppdocs/api/typedef_namespacetorch_1_1autograd_1aa5771cd953999c4b07b2a022f9d8f1d0.html