### PR TITLE
Limit concurrency for nightly jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,8 +10,8 @@ jobs:
   wheel:
     if: github.repository == 'pyg-team/pyg-lib'
     runs-on: ${{ matrix.os }}
-
     strategy:
+      max-parallel: 10
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2019]


### PR DESCRIPTION
This PR limits the number of concurrent nightly jobs to let other repos to use the resource of GitHub-hosted runners. Currently, we have 200 scheduled nightly jobs, and each takes from 3.5 min to 15 min, occupying the max number of concurrent jobs (i.e., 20) across all repos `pyg-team` org:

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/372c4255-2941-46df-ab83-c1ad308466ad" />


This should be ok because nightly builds don't need to be avaialble ASAP.