### PR TITLE
[Bug] Fixing bug in `fused_scatter_reduce` function.

### DIFF
--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -120,7 +120,7 @@ def fused_scatter_reduce(
     out = inputs.new(dim_size, len(reduce_list) * num_feats)
 
     # Pre-processing: Take care of correct initialization for each reduction:
-    for reduce in enumerate(reduce_list):
+    for reduce in reduce_list:
         assert reduce in REDUCTIONS
         if reduce == 'min':
             fill_value = float('inf')


### PR DESCRIPTION
Fixing a bug introduced in [MR#370](https://github.com/pyg-team/pyg-lib/pull/370/files).
After removing `i` but still using `enumerate`, the `reduce` variable is incorrectly set to (0, **value**) instead of the expected **value**.