### PR TITLE
Add CXX11 ABI build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.5.0] - 2023-MM-DD
 ### Added
+- Added PyTorch 2.7 cuda >= 12.6 support ([#431]https://github.com/pyg-team/pyg-lib/pull/431)
 - Added PyTorch 2.5 support ([#360](https://github.com/pyg-team/pyg-lib/pull/338))
 - Added PyTorch 2.4 support ([#338](https://github.com/pyg-team/pyg-lib/pull/338))
 - Added PyTorch 2.3 support ([#322](https://github.com/pyg-team/pyg-lib/pull/322))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,25 @@ option(WITH_COV "Enable code coverage" OFF)
 option(USE_PYTHON "Link to Python when building" OFF)
 option(WITH_CUDA "Enable CUDA support" OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+if(NOT WIN32 AND NOT DEFINED USE_CXX11_ABI)
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  execute_process(
+      COMMAND ${Python3_EXECUTABLE} "-c"
+              "import torch; print(torch.compiled_with_cxx11_abi(),end='');"
+      RESULT_VARIABLE _PYTHON_SUCCESS
+      OUTPUT_VARIABLE USE_CXX11_ABI)
+  # Convert the bool variable to integer.
+  if(USE_CXX11_ABI)
+    set(USE_CXX11_ABI 1)
+  else()
+    set(USE_CXX11_ABI 0)
+  endif()
+  message(STATUS "Using USE_CXX11_ABI set by PyTorch to ${USE_CXX11_ABI}")
+else()
+  set(USE_CXX11_ABI 0)
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=${USE_CXX11_ABI}")
 
 set(WITH_MKL_BLAS 0)
 if(USE_MKL_BLAS AND DEFINED BLAS_INCLUDE_DIR)


### PR DESCRIPTION
Recent change in PyTorch dropped support to pre-cxx11abi:
https://github.com/pytorch/pytorch/pull/149888 

since `pytorch==2.7` + cuda >= 12.6 will ship w/ cxx11abi, pyg-lib needs to follow PyTorch's ABI 

thanks 🙏  @ptrblck for bringing this change to our attention

fix shamelessly taken from https://github.com/NVIDIA/TensorRT-LLM/blob/57cafe7f9bea5286ada3e08cb0d68c78adaf910d/cpp/CMakeLists.txt#L575