### PR TITLE
Only trigger automerge workflow on opening a PR

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: Auto-merge Bot PRs
 
 on:  # yamllint disable-line rule:truthy
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened]
 
 permissions:
   contents: write


### PR DESCRIPTION
To avoid something like #433:

<img width="686" alt="image" src="https://github.com/user-attachments/assets/acf70530-c856-4556-8dcb-6b52128b8922" />
