### PR TITLE
Avoid deprecated format in `project.license` field in `pyproject.toml`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -34,31 +34,3 @@ runs:
       run: |
         bash ./.github/workflows/cuda/${{ runner.os }}.sh ${{ inputs.cuda-version }}
       shell: bash
-
-    - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}
-      run: |
-        pip install torch==${{ inputs.torch-version }} --extra-index-url https://download.pytorch.org/whl/${{ inputs.cuda-version }}
-        python -c "import torch; print('PyTorch:', torch.__version__)"
-        python -c "import torch; print('CUDA:', torch.version.cuda)"
-        python -c "import torch; print('CXX11 ABI:', torch.compiled_with_cxx11_abi())"
-      shell: bash
-
-    - name: Disable CUDNN
-      if: ${{ (inputs.cuda-version != 'cpu') && ((inputs.torch-version == '1.12.0') || (inputs.torch-version == '1.13.0')) }}
-      run: |
-        Torch_DIR=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
-        sed -i '95,100d' ${Torch_DIR}/Caffe2/Caffe2Config.cmake
-        sed -i 's/;caffe2::cudnn-public//g' ${Torch_DIR}/Caffe2/Caffe2Targets.cmake
-      shell: bash
-
-    - name: Downgrade GLIBC
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        sed -i '1s/^/#if defined(__linux__) \&\& defined(__x86_64__)\n__asm__(".symver log,log@GLIBC_2.2.5");\n#endif\n/' third_party/METIS/GKlib/gk_proto.h
-        sed -i '1s/^/#if defined(__linux__) \&\& defined(__x86_64__)\n__asm__(".symver pow,pow@GLIBC_2.2.5");\n#endif\n/' third_party/METIS/libmetis/metislib.h
-      shell: bash
-
-    - name: Install additional dependencies
-      run: |
-        pip install setuptools ninja wheel
-      shell: bash

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -66,9 +66,8 @@ jobs:
         env:
           CIBW_BUILD: cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_BUILD: bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }}
           # Install system library
-          CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)
+          CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true) && (bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }})
           # CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy"
           # CIBW_SKIP: "*musllinux*"
 

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BEFORE_BUILD: bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }}
           # Install system library
-          # CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)
+          CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)
           # CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy"
           # CIBW_SKIP: "*musllinux*"
 

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -10,89 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        # torch-version: [1.13.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0]
-        torch-version: [2.6.0]
-        cuda-version: ['cpu', 'cu117', 'cu118', 'cu121', 'cu124', 'cu126']
-        exclude:
-          - torch-version: 1.13.0
-            python-version: '3.13'
-          - torch-version: 2.0.0
-            python-version: '3.13'
-          - torch-version: 2.1.0
-            python-version: '3.13'
-          - torch-version: 2.2.0
-            python-version: '3.13'
-          - torch-version: 2.3.0
-            python-version: '3.13'
-          - torch-version: 2.4.0
-            python-version: '3.13'
-          - torch-version: 2.5.0
-            python-version: '3.13'
-          - torch-version: 1.13.0
-            python-version: '3.12'
-          - torch-version: 2.0.0
-            python-version: '3.12'
-          - torch-version: 2.1.0
-            python-version: '3.12'
-          - torch-version: 1.13.0
-            python-version: '3.11'
-          - torch-version: 1.13.0
-            cuda-version: 'cu118'
-          - torch-version: 1.13.0
-            cuda-version: 'cu121'
-          - torch-version: 1.13.0
-            cuda-version: 'cu124'
-          - torch-version: 1.13.0
-            cuda-version: 'cu126'
-          - torch-version: 2.0.0
-            cuda-version: 'cu124'
-          - torch-version: 2.0.0
-            cuda-version: 'cu126'
-          - torch-version: 2.1.0
-            cuda-version: 'cu117'
-          - torch-version: 2.1.0
-            cuda-version: 'cu124'
-          - torch-version: 2.1.0
-            cuda-version: 'cu126'
-          - torch-version: 2.2.0
-            cuda-version: 'cu117'
-          - torch-version: 2.2.0
-            cuda-version: 'cu124'
-          - torch-version: 2.2.0
-            cuda-version: 'cu126'
-          - torch-version: 2.3.0
-            cuda-version: 'cu117'
-          - torch-version: 2.3.0
-            cuda-version: 'cu124'
-          - torch-version: 2.3.0
-            cuda-version: 'cu126'
-          - torch-version: 2.4.0
-            cuda-version: 'cu117'
-          - torch-version: 2.4.0
-            cuda-version: 'cu126'
-          - torch-version: 2.5.0
-            cuda-version: 'cu117'
-          - torch-version: 2.5.0
-            cuda-version: 'cu126'
-          - torch-version: 2.6.0
-            cuda-version: 'cu117'
-          - torch-version: 2.6.0
-            cuda-version: 'cu121'
-          - os: macos-14
-            cuda-version: 'cu117'
-          - os: macos-14
-            cuda-version: 'cu118'
-          - os: macos-14
-            cuda-version: 'cu121'
-          - os: macos-14
-            cuda-version: 'cu124'
-          - os: macos-14
-            cuda-version: 'cu126'
-          - os: windows-2019
-            torch-version: 2.0.0
-            cuda-version: 'cu121'
+        include:
+          - {os: ubuntu-22.04, torch-version: '2.7.0', python-version: '3.10', cuda-version: 'cpu'}
 
     steps:
       - name: Checkout repository
@@ -145,13 +64,13 @@ jobs:
           cd ..
         shell: bash
 
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+      # - name: Configure AWS
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: us-west-1
 
-      - name: Upload wheel
-        run: |
-          aws s3 sync dist s3://data.pyg.org/whl/torch-${{ matrix.torch-version }}+${{ matrix.cuda-version }} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      # - name: Upload wheel
+      #   run: |
+      #     aws s3 sync dist s3://data.pyg.org/whl/torch-${{ matrix.torch-version }}+${{ matrix.cuda-version }} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -15,6 +15,8 @@ jobs:
 
   wheel:
     runs-on: ${{ matrix.os }}
+    container:
+      image: quay.io/pypa/manylinux2014_x86_64
 
     strategy:
       fail-fast: false

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -64,13 +64,15 @@ jobs:
         shell: bash
 
       - name: Test wheel
+        working-directory: dist
         run: |
-          cd dist
           ls -lah
+          pip install auditwheel
+          auditwheel repair *.whl
+
           pip install *.whl
           python -c "import pyg_lib; print('pyg-lib:', pyg_lib.__version__)"
           python -c "import pyg_lib; print('CUDA:', pyg_lib.cuda_version())"
-          cd ..
         shell: bash
 
       # - name: Configure AWS

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         env:
           CIBW_BUILD: cp310-manylinux_x86_64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BEFORE_BUILD: bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }}
           # Install system library
           # CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -35,9 +35,6 @@ jobs:
           torch-version: ${{ matrix.torch-version }}
           cuda-version: ${{ matrix.cuda-version }}
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.23.3
-
       - name: Set version on non-macOS
         if: ${{ runner.os != 'macOS' }}
         run: |
@@ -62,12 +59,12 @@ jobs:
       - name: Build wheel
         run: |
           source ./.github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
-          pip install build
+          pip install build cibuildwheel==2.23.3
           python -m cibuildwheel --output-dir dist
           # python -m build --wheel --no-isolation --outdir dist
         shell: bash
         env:
-          CIBW_BUILD: "p310-manylinux_x86_64"
+          CIBW_BUILD: "cp310-manylinux_x86_64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_BUILD: git submodule update --init --recursive && pip install .
           # Install system library

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -35,6 +35,9 @@ jobs:
           torch-version: ${{ matrix.torch-version }}
           cuda-version: ${{ matrix.cuda-version }}
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.23.3
+
       - name: Set version on non-macOS
         if: ${{ runner.os != 'macOS' }}
         run: |
@@ -60,7 +63,8 @@ jobs:
         run: |
           source ./.github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
           pip install build
-          python -m build --wheel --no-isolation --outdir dist
+          python -m cibuildwheel --output-dir dist
+          # python -m build --wheel --no-isolation --outdir dist
         shell: bash
 
       - name: Test wheel

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -64,9 +64,9 @@ jobs:
           # python -m build --wheel --no-isolation --outdir dist
         shell: bash
         env:
-          CIBW_BUILD: "cp310-manylinux_x86_64"
+          CIBW_BUILD: cp310-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: git submodule update --init --recursive && pip install .
+          CIBW_BEFORE_BUILD: bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }}
           # Install system library
           # CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)
           # CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy"

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -15,8 +15,6 @@ jobs:
 
   wheel:
     runs-on: ${{ matrix.os }}
-    container:
-      image: quay.io/pypa/manylinux2014_x86_64
 
     strategy:
       fail-fast: false

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -1,6 +1,15 @@
 name: Building Wheels
 
-on: [workflow_dispatch]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    branches:
+      - aki/manylinux
+
+
+concurrency:
+  group: aki_hobby
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -66,6 +66,14 @@ jobs:
           python -m cibuildwheel --output-dir dist
           # python -m build --wheel --no-isolation --outdir dist
         shell: bash
+        env:
+          CIBW_BUILD: "p310-manylinux_x86_64"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_BUILD: git submodule update --init --recursive && pip install .
+          # Install system library
+          # CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true)
+          # CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy"
+          # CIBW_SKIP: "*musllinux*"
 
       - name: Test wheel
         working-directory: dist

--- a/.github/workflows/building_aki.yml
+++ b/.github/workflows/building_aki.yml
@@ -1,18 +1,15 @@
 name: Building Wheels
 
 on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
-#   push:
-#     branches:
-#       - aki/manylinux
+  push:
+    branches:
+      - aki/manylinux
 
-
-# concurrency:
-#   group: aki_hobby
-#   cancel-in-progress: true
+concurrency:
+  group: aki_hobby
+  cancel-in-progress: true
 
 jobs:
-
   wheel:
     runs-on: ${{ matrix.os }}
 
@@ -20,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-22.04, torch-version: '2.7.0', python-version: '3.10', cuda-version: 'cpu'}
+          - {os: ubuntu-22.04, torch-version: '2.6.0', python-version: '3.11', cuda-version: 'cpu'}
 
     steps:
       - name: Checkout repository
@@ -28,15 +25,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies
-        uses: ./.github/actions/setup
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          torch-version: ${{ matrix.torch-version }}
-          cuda-version: ${{ matrix.cuda-version }}
+          python-version: '3.11'  # Always use 3.11+ as recommended by cibuildwheel
 
-      - name: Set version on non-macOS
-        if: ${{ runner.os != 'macOS' }}
+      - name: Prepare for building
         run: |
           VERSION=`sed -n "s/^__version__ = '\(.*\)'/\1/p" pyg_lib/__init__.py`
           TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/..$//" | sed "s/\.//g"`
@@ -46,25 +40,15 @@ jobs:
           sed -i "s/$VERSION/$VERSION+$TORCH_VERSION$CUDA_VERSION/" pyg_lib/__init__.py
         shell: bash
 
-      - name: Set version on macOS
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          VERSION=`sed -n "s/^__version__ = '\(.*\)'/\1/p" pyg_lib/__init__.py`
-          TORCH_VERSION=`echo "pt${{ matrix.torch-version }}" | sed "s/..$//" | sed "s/\.//g"`
-          echo "New version name: $VERSION+$TORCH_VERSION"
-          sed -i "" "s/$VERSION/$VERSION+$TORCH_VERSION/" setup.py
-          sed -i "" "s/$VERSION/$VERSION+$TORCH_VERSION/" pyg_lib/__init__.py
-        shell: bash
-
       - name: Build wheel
         run: |
           source ./.github/workflows/cuda/${{ runner.os }}-env.sh ${{ matrix.cuda-version }}
-          pip install build cibuildwheel==2.23.3
+          pip install build cibuildwheel -U
           python -m cibuildwheel --output-dir dist
           # python -m build --wheel --no-isolation --outdir dist
         shell: bash
         env:
-          CIBW_BUILD: cp310-manylinux_x86_64
+          CIBW_BUILD: cp311-manylinux_x86_64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           # Install system library
           CIBW_BEFORE_BUILD_LINUX: (yum install -y libffi-devel || apt-get install -y libffi-devel || apk add --update --no-cache libffi-devel || true) && (yum install -y libc6 || apt-get install -y libc6 || apk add --update --no-cache libc6 || true) && (bash ./tools/prepare_for_build.sh ${{ matrix.torch-version }} ${{ matrix.cuda-version }})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ repository="https://github.com/pyg-team/pyg-lib.git"
 changelog="https://github.com/pyg-team/pyg-lib/blob/master/CHANGELOG.md"
 
 [tool.cibuildwheel]
-build-frontend = {name="build", args=["--wheel", "--no-isolation"]}
+build-frontend = {name="build", args=["--no-isolation"]}
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ documentation="https://pyg-lib.readthedocs.io"
 repository="https://github.com/pyg-team/pyg-lib.git"
 changelog="https://github.com/pyg-team/pyg-lib/blob/master/CHANGELOG.md"
 
+[tool.cibuildwheel]
+build-frontend = {name=" build", args=["--wheel", "--no-isolation"]}
+
+
 [tool.pytest.ini_options]
 addopts=[
     "--capture=no",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ repository="https://github.com/pyg-team/pyg-lib.git"
 changelog="https://github.com/pyg-team/pyg-lib/blob/master/CHANGELOG.md"
 
 [tool.cibuildwheel]
-build-frontend = {name=" build", args=["--wheel", "--no-isolation"]}
+build-frontend = {name="build", args=["--wheel", "--no-isolation"]}
 
 
 [tool.pytest.ini_options]

--- a/tools/prepare_for_build.sh
+++ b/tools/prepare_for_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Usage:
+# ./prepare_for_build.sh <torch_version> <cuda_version> [torch_dir]
+set -e
+
+TORCH_VERSION="${1:?Specify torch version, e.g. 2.1.0}"
+CUDA_VERSION="${2:?Specify cuda version, e.g. cu121}"
+
+pip install torch=="${TORCH_VERSION}" --extra-index-url "https://download.pytorch.org/whl/${CUDA_VERSION}"
+python -c "import torch; print('PyTorch:', torch.__version__)"
+python -c "import torch; print('CUDA:', torch.version.cuda)"
+python -c "import torch; print('CXX11 ABI:', torch.compiled_with_cxx11_abi())"
+
+sed -i '1s/^/#if defined(__linux__) \&\& defined(__x86_64__)\n__asm__(".symver log,log@GLIBC_2.2.5");\n#endif\n/' third_party/METIS/GKlib/gk_proto.h
+sed -i '1s/^/#if defined(__linux__) \&\& defined(__x86_64__)\n__asm__(".symver pow,pow@GLIBC_2.2.5");\n#endif\n/' third_party/METIS/libmetis/metislib.h
+
+pip install setuptools ninja wheel


### PR DESCRIPTION
To supress ~an annoyingly loud warning~ a warning in CI:

```
* Building wheel...
  /opt/python/cp311-cp311/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
  !!
```