### PR TITLE
Avoid deprecated format in `project.license` field in `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         # TODO: Set min to 10 when pyroma adds support for PEP 639
         # https://github.com/regebro/pyroma/issues/93
         # https://peps.python.org/pep-0639/
-        args: [--min=10, .]
+        args: [--min=9, .]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         # TODO: Set min to 10 when pyroma adds support for PEP 639
         # https://github.com/regebro/pyroma/issues/93
         # https://peps.python.org/pep-0639/
-        args: [--min=9, .]
+        args: [--min=10, .]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,10 @@ repos:
     hooks:
       - id: pyroma
         name: Check packaging
-        args: [--min=10, .]
+        # TODO: Set min to 10 when pyroma adds support for PEP 639
+        # https://github.com/regebro/pyroma/issues/93
+        # https://peps.python.org/pep-0639/
+        args: [--min=9, .]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords=[
     "graph-neural-networks",
     "graph-convolutional-networks",
 ]
-license-files=["LICENSE"]
+license-files=["LICENSE", "LICENSE_radix_sort"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords=[
     "graph-neural-networks",
     "graph-convolutional-networks",
 ]
-license={file="LICENSE"}
+license-files=["LICENSE"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords=[
     "graph-neural-networks",
     "graph-convolutional-networks",
 ]
-license-files=["LICENSE", "LICENSE_radix_sort"]
+license-files=["LICENSE*"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",


### PR DESCRIPTION
To supress ~an annoyingly loud warning~ a warning in CI:

```
* Building wheel...
  /opt/python/cp311-cp311/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
  !!
```