### PR TITLE
Revert "Avoid deprecated format in `project.license` field in `pyproject.toml` (#446)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,7 @@ repos:
     hooks:
       - id: pyroma
         name: Check packaging
-        # TODO: Set min to 10 when pyroma adds support for PEP 639
-        # https://github.com/regebro/pyroma/issues/93
-        # https://peps.python.org/pep-0639/
-        args: [--min=9, .]
+        args: [--min=10, .]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords=[
     "graph-neural-networks",
     "graph-convolutional-networks",
 ]
-license-files=["LICENSE*"]
+license={file="LICENSE"}
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",


### PR DESCRIPTION
Due to some build issue in certain versions, this reverts commit 10b2fe1192b16dc73ef557ce518a8560d4dcb722.