### PR TITLE
ci: Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    labels:
+      - "ci"
+      - "skip-changelog"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
We're using very old versions of GHA actions, e.g., stale bot. Updating them manually is not human work. This bot will make sure they're up to date.