### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   wheel:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # torch-version: [1.13.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.7.0]
         torch-version: [2.7.0]
@@ -114,7 +114,7 @@ jobs:
             cuda-version: 'cu126'
           - os: macos-14
             cuda-version: 'cu128'
-          - os: windows-2019
+          - os: windows-2022
             torch-version: 2.0.0
             cuda-version: 'cu121'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # TODO: Uncomment this once we split the workflow to avoid GitHub Actions' 256 matrix configuration limit.
         # torch-version: [1.13.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.7.0]
@@ -119,7 +119,7 @@ jobs:
             cuda-version: 'cu126'
           - os: macos-14
             cuda-version: 'cu128'
-          - os: windows-2019
+          - os: windows-2022
             torch-version: 2.0.0
             cuda-version: 'cu121'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,11 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyg_lib/csrc/config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/pyg_lib/csrc/config.h")
 
 if(WITH_CUDA)
+  # Set CUDA flags BEFORE enabling CUDA language for compiler detection
+  set(CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr -allow-unsupported-compiler" CACHE STRING "CUDA compiler flags" FORCE)
+
   enable_language(CUDA)
   add_definitions(-DWITH_CUDA)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -allow-unsupported-compiler")
 
   if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
     set(CMAKE_CUDA_ARCHITECTURES "75;80;86;90;100;120")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,15 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyg_lib/csrc/config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/pyg_lib/csrc/config.h")
 
 if(WITH_CUDA)
-  # Set CUDA flags BEFORE enabling CUDA language for compiler detection
-  set(CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr -allow-unsupported-compiler" CACHE STRING "CUDA compiler flags" FORCE)
+  # Set CUDA flags for compiler detection phase - this is crucial for Windows Visual Studio compatibility
+  if(NOT DEFINED CMAKE_CUDA_FLAGS_INIT)
+    set(CMAKE_CUDA_FLAGS_INIT "--expt-relaxed-constexpr -allow-unsupported-compiler" CACHE STRING "Initial CUDA compiler flags")
+  endif()
+
+  # Also set as environment variable as backup for older CMake versions
+  if(WIN32 AND NOT DEFINED ENV{CUDAFLAGS})
+    set(ENV{CUDAFLAGS} "-allow-unsupported-compiler")
+  endif()
 
   enable_language(CUDA)
   add_definitions(-DWITH_CUDA)


### PR DESCRIPTION
The windows-2019 runner was removed as per https://github.com/actions/runner-images/issues/12045.

Fixes:

```
   C:\Program Files\NVIDIA GPU Computing
  Toolkit\CUDA\v11.8\include\crt/host_config.h(153): fatal error C1189:
  #error: -- unsupported Microsoft Visual Studio version! Only the versions
  between 2017 and 2022 (inclusive) are supported! The nvcc flag
  '-allow-unsupported-compiler' can be used to override this version check;
  however, using an unsupported host compiler may cause compilation failure
  or incorrect run time execution.  Use at your own risk.

  # --error 0x2 --





Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerId.cmake:8 (CMAKE_DETERMINE_COMPILER_ID_BUILD)
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerId.cmake:53 (__determine_compiler_id_test)
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCUDACompiler.cmake:131 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:50 (enable_language)
```
https://github.com/pyg-team/pyg-lib/actions/runs/16552639182/job/46809699717?pr=489