### PR TITLE
Start pushing manylinux wheels built with CUDA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           # Set Linux matrix
           filename=".github/workflows/utils/full_matrix_linux.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] } | select(."cuda-version" | IN("cpu", "cu118", "cu124", "cu126", "cu128", "cu129"))]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
           echo "linux-matrix=$matrix" >> $GITHUB_OUTPUT
           echo "linux-matrix=$matrix"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,7 @@ jobs:
         run: |
           # Set Linux matrix
           filename=".github/workflows/utils/full_matrix_linux.json"
-          # TODO: Build for CUDA versions.
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": "cpu" }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] } | select(."cuda-version" | IN("cpu", "cu118", "cu124", "cu126", "cu128", "cu129"))]' $filename)
           echo "linux-matrix=$matrix" >> $GITHUB_OUTPUT
           echo "linux-matrix=$matrix"
 

--- a/.github/workflows/nightly_legacy.yml
+++ b/.github/workflows/nightly_legacy.yml
@@ -14,7 +14,8 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2022]
+        # NOTE: ubuntu-22.04 is disabled in favor of nightly.yml.
+        os: [macos-14, windows-2022]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # TODO: Uncomment this once we split the workflow to avoid GitHub Actions' 256 matrix configuration limit.
         # torch-version: [1.13.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.7.0]
@@ -122,9 +123,6 @@ jobs:
           - os: windows-2022
             torch-version: 2.0.0
             cuda-version: 'cu121'
-          # Disabled in favor of nightly.yml.
-          - os: ubuntu-22.04
-            cuda-version: 'cpu'
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.5.0] - 2023-MM-DD
 ### Added
-- Added `manylinux_2_28` wheel support in nightly releases ([#480](https://github.com/pyg-team/pyg-lib/pull/480))
+- Added support for `manylinux_2_28` wheels built with CUDA in nightly releases ([#496](https://github.com/pyg-team/pyg-lib/pull/496))
+- Added support for `manylinux_2_28` wheels in nightly releases ([#480](https://github.com/pyg-team/pyg-lib/pull/480))
 - Added CUDA 12.9 support ([#494](https://github.com/pyg-team/pyg-lib/pull/494))
 - Added PyTorch 2.8 support ([#494](https://github.com/pyg-team/pyg-lib/pull/494))
 - Added PyTorch 2.7 support ([#442](https://github.com/pyg-team/pyg-lib/pull/442))


### PR DESCRIPTION
Part of #457, https://github.com/pyg-team/pytorch_geometric/issues/10398.

* Triggered at https://github.com/pyg-team/pyg-lib/actions?query=branch%3Aaki%2Fcuda-nightly+event%3Aworkflow_dispatch.
* Built wheels are pushed to https://data.pyg.org/whl/nightly/:
[torch-2.8.0+cpu](https://data.pyg.org/whl/nightly/torch-2.8.0%2Bcpu.html)
[torch-2.8.0+cu126](https://data.pyg.org/whl/nightly/torch-2.8.0%2Bcu126.html)
[torch-2.8.0+cu128](https://data.pyg.org/whl/nightly/torch-2.8.0%2Bcu128.html)
[torch-2.8.0+cu129](https://data.pyg.org/whl/nightly/torch-2.8.0%2Bcu129.html)