### PR TITLE
ci: Don't use unsupported `type: choice` in `workflow_call`

### DIFF
--- a/.github/workflows/_upload_index.yml
+++ b/.github/workflows/_upload_index.yml
@@ -9,14 +9,13 @@ on:  # yamllint disable-line rule:truthy
         options:
           - final
           - nightly
+        description: 'Either "final" or "nightly".'
   workflow_call:
     inputs:
       release-type:
         required: true
-        type: choice
-        options:
-          - final
-          - nightly
+        type: string
+        description: 'Either "final" or "nightly".'
 
 concurrency:
   group: upload-index-${{ inputs.release-type }}


### PR DESCRIPTION
Addresses:

```
Invalid workflow file: .github/workflows/_upload_index.yml#L1
(Line: 16, Col: 15): Unexpected value 'choice', (Line: 17, Col: 9): Unexpected value 'options', (Line: 32, Col: 14): Unexpected value ''
```