### PR TITLE
Fix incorrect reduction condition in fused_scatter_reduce Triton kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for CUDA architectures below `sm_60` (required by cuCollections)
 
 ### Fixed
+
 - Fixed incorrect reduction condition in `fused_scatter_reduce` Triton kernel
 
-### Security 
+### Security
 
 ## [0.6.0] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for CUDA architectures below `sm_60` (required by cuCollections)
 
 ### Fixed
+- Fixed incorrect reduction condition in `fused_scatter_reduce` Triton kernel
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed incorrect reduction condition in `fused_scatter_reduce` Triton kernel
 
-### Security
+### Security 
 
 ## [0.6.0] - 2026-03-24
 

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -19,7 +19,7 @@ def _fused_scatter_reduce_forward_kernel(
     out_ptr,
     num_feats,
     num_reductions,
-    numel,
+    numel, 
     REDUCE0,
     REDUCE1,
     REDUCE2,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -19,7 +19,7 @@ def _fused_scatter_reduce_forward_kernel(
     out_ptr,
     num_feats,
     num_reductions,
-    numel, 
+    numel,
     REDUCE0,
     REDUCE1,
     REDUCE2,

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -60,9 +60,9 @@ def _fused_scatter_reduce_forward_kernel(
             tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
         elif REDUCE1 == 2:  # mean
             tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE2 == 3:  # min
+        elif REDUCE1 == 3:  # min
             tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE3 == 4:  # max
+        elif REDUCE1 == 4:  # max
             tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
     if REDUCE2 > 0:


### PR DESCRIPTION
### Description
While reviewing the Triton implementations for `fused_scatter_reduce`, I noticed a copy-paste error in the `REDUCE1` block of `_fused_scatter_reduce_forward_kernel`. 

Specifically, when `REDUCE1` is evaluated for `min` or `max`, the kernel incorrectly checks `REDUCE2 == 3` and `REDUCE3 == 4` instead of `REDUCE1`. This causes silent mathematical errors and failing reductions when multiple reduction types (including min/max) are passed in specific orders.

### Changes Made:
- Fixed the condition inside `if REDUCE1 > 0:` to correctly check `REDUCE1 == 3` (min) and `REDUCE1 == 4` (max).

*Note: I also noticed the TODOs regarding double computation of `sum/mean`, unrolling the loops (since `tl.static_unroll` is now available), and adding backward passes. I plan to address those optimizations in follow-up PRs once this critical fix is merged.*