### PR TITLE
CI: Upgrade CUTLASS from 3.7.0 to 3.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,18 @@ if (NOT MSVC)
 endif()
 
 find_package(Torch REQUIRED)
+if (MSVC)
+  # PyTorch's caffe2/public/cuda.cmake (gated on MSVC only) injects
+  # `--Werror cross-execution-space-call` into CMAKE_CUDA_FLAGS. CUTLASS 3.9
+  # has a longstanding pattern where CUTLASS_HOST_DEVICE templates call
+  # __host__-only virtuals — e.g. cutlass::CudaHostAdapter::memsetDevice in
+  # cuda_host_adapter.hpp:408 calls the pure-virtual __host__ memsetDeviceImpl.
+  # nvcc treats that as a warning by default, but with --Werror it becomes a
+  # hard error, breaking matmul_kernel.cu on Windows. Linux builds are unaffected
+  # because PyTorch only adds the flag on MSVC. Strip it so we keep nvcc's
+  # check as a warning instead of fatal.
+  string(REPLACE "--Werror cross-execution-space-call" "" CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+endif()
 message("-- TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TORCH_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,18 @@ if(WITH_CUDA)
   enable_language(CUDA)
   add_definitions(-DWITH_CUDA)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -allow-unsupported-compiler --compress-mode=size")
+  if (MSVC)
+    # Forward /Zc:__cplusplus to the host compiler (cl.exe) when nvcc compiles
+    # .cu files. Without this, MSVC reports __cplusplus=199711L regardless of
+    # /std:c++NN, which trips guards inside CUTLASS 3.9 headers (e.g.
+    # cutlass::platform::is_unsigned_v in platform.h is gated on raw __cplusplus)
+    # and skips the constexpr ctors of `dim3` in CUDA <13's vector_types.h
+    # (CUDA 13 added an `_MSC_VER` fallback; CUDA 12.6 still relies on
+    # __cplusplus alone). Both make CUTLASS 3.9 sm100 kernel headers fail to
+    # compile on Windows.
+    # https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/Zc:__cplusplus")
+  endif()
 
   if (NOT "$ENV{EXTERNAL_CUTLASS_INCLUDE_DIR}" STREQUAL "")
     include_directories($ENV{EXTERNAL_CUTLASS_INCLUDE_DIR})
@@ -83,8 +95,14 @@ else()
 endif()
 
 if (MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DIDXTYPEWIDTH=64 /DREALTYPEWIDTH=32")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DIDXTYPEWIDTH=64 /DREALTYPEWIDTH=32")
+  # /Zc:__cplusplus makes MSVC report the actual C++ standard via __cplusplus
+  # (it otherwise reports 199711L regardless of /std:c++NN). Required so that
+  # CUTLASS 3.9 headers gated on raw __cplusplus (e.g. is_unsigned_v in
+  # cutlass/platform/platform.h) and CUDA <13's `dim3` constexpr ctors are
+  # actually visible. Mirrors the -Xcompiler=/Zc:__cplusplus we add for nvcc.
+  # https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /DIDXTYPEWIDTH=64 /DREALTYPEWIDTH=32 /Zc:__cplusplus")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DIDXTYPEWIDTH=64 /DREALTYPEWIDTH=32 /Zc:__cplusplus")
 else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=32")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=32")


### PR DESCRIPTION
This PR tries to fix a Windows build error by upgrading CUTLASS:
```
[21/58] Building CUDA object CMakeFiles\pyg.dir\pyg_lib\csrc\ops\cuda\matmul_kernel.cu.obj
FAILED: [code=1] CMakeFiles/pyg.dir/pyg_lib/csrc/ops/cuda/matmul_kernel.cu.obj 
C:\PROGRA~1\NVIDIA~2\CUDA\v12.6\bin\nvcc.exe -forward-unknown-to-host-compiler -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DWITH_CUDA -Dpyg_EXPORTS -ID:\a\pyg-lib\pyg-lib\third_party\cutlass\include -ID:\a\pyg-lib\pyg-lib\third_party\cutlass\tools\util\include -ID:\a\pyg-lib\pyg-lib\third_party\cuCollections\include -ID:\a\pyg-lib\pyg-lib -ID:\a\pyg-lib\pyg-lib\third_party\parallel-hashmap -ID:\a\pyg-lib\pyg-lib\third_party\cccl\thrust -ID:\a\pyg-lib\pyg-lib\third_party\cccl\cub -ID:\a\pyg-lib\pyg-lib\third_party\cccl\libcudacxx\include -isystem D:\a\pyg-lib\pyg-lib\.venv\Lib\site-packages\torch\include -isystem D:\a\pyg-lib\pyg-lib\.venv\Lib\site-packages\torch\include\torch\csrc\api\include -isystem "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\include" -D_WINDOWS -Xcompiler=" /GR /EHsc" --expt-relaxed-constexpr -allow-unsupported-compiler --compress-mode=size -DONNX_NAMESPACE=onnx_c2 --use-local-env -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -Xcudafe --diag_suppress=cc_clobber_ignored,--diag_suppress=field_without_dll_interface,--diag_suppress=base_class_has_different_dll_interface,--diag_suppress=dll_interface_conflict_none_assumed,--diag_suppress=dll_interface_conflict_dllexport_assumed,--diag_suppress=bad_friend_decl --Werror cross-execution-space-call --no-host-device-move-forward --expt-relaxed-constexpr --expt-extended-lambda -Xcompiler="-O2 -Ob2" -DNDEBUG -Xcompiler /MD -std=c++20 -Xcompiler=-MD -MD -MT CMakeFiles\pyg.dir\pyg_lib\csrc\ops\cuda\matmul_kernel.cu.obj -MF CMakeFiles\pyg.dir\pyg_lib\csrc\ops\cuda\matmul_kernel.cu.obj.d -x cu -c D:\a\pyg-lib\pyg-lib\pyg_lib\csrc\ops\cuda\matmul_kernel.cu -o CMakeFiles\pyg.dir\pyg_lib\csrc\ops\cuda\matmul_kernel.cu.obj -Xcompiler=-FdCMakeFiles\pyg.dir\,-FS
D:/a/pyg-lib/pyg-lib/third_party/cutlass/include\cutlass/cuda_host_adapter.hpp(398): error: calling a __host__ function("memsetDeviceImpl") from a __host__ __device__ function("memsetDevice") is not allowed
      return this->memsetDeviceImpl(
                   ^

1 error detected in the compilation of "D:/a/pyg-lib/pyg-lib/pyg_lib/csrc/ops/cuda/matmul_kernel.cu".
matmul_kernel.cu
```

---

However, `pyg-lib` builds with nightly PyTorch release on Windows with CUDA support are still failing due to:

```
 + torch==2.13.0.dev20260425+cu130
...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import torch; print('PyTorch:', torch.__version__)
    ^^^^^^^^^^^^
  File "D:\a\pyg-lib\pyg-lib\.venv\Lib\site-packages\torch\__init__.py", line 287, in <module>
    _load_dll_libraries()
    ~~~~~~~~~~~~~~~~~~~^^
  File "D:\a\pyg-lib\pyg-lib\.venv\Lib\site-packages\torch\__init__.py", line 283, in _load_dll_libraries
    raise err
OSError: [WinError 126] The specified module could not be found. Error loading "D:\a\pyg-lib\pyg-lib\.venv\Lib\site-packages\torch\lib\shm.dll" or one of its dependencies.
```
https://github.com/pyg-team/pyg-lib/actions/runs/24950429195/job/73059451130?pr=640#step:3:338 which is likely related to https://github.com/pytorch/pytorch/issues/181375. Fixes/workarounds for this error is out of scope of this PR.