### PR TITLE
CI: Build with PyTorch RC

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -40,12 +40,15 @@ runs:
 
     - name: Install PyTorch ${{ inputs.torch-version }}+${{ inputs.cuda-version }}
       run: |
-        if [ ${{ inputs.torch-version }} == '2.12.0' ]; then
+        if [ ${{ inputs.torch-version }} == '2.13.0' ]; then
           # packaging is required at torch import time (torch._native.cutedsl_utils)
           uv pip install packaging
           # Use --index-url instead of --torch-backend since uv may not yet
           # support the latest CUDA versions (e.g. cu132).
           uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${{ inputs.cuda-version }}
+        elif [ ${{ inputs.torch-version }} == '2.12.0' ]; then
+          # 2.12.0 is currently a release candidate; install from the test index.
+          uv pip install torch==${{ inputs.torch-version }} --index-url https://download.pytorch.org/whl/test/${{ inputs.cuda-version }}
         else
           uv pip install torch==${{ inputs.torch-version }} --torch-backend ${{ inputs.cuda-version }}
         fi

--- a/.github/workflows/utils/build_linux.sh
+++ b/.github/workflows/utils/build_linux.sh
@@ -14,9 +14,12 @@ echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}"
 
 export CIBW_BUILD="cp${PYTHON_VERSION//./}-manylinux_x86_64"
 # pyg-lib doesn't have torch as a dependency, so we need to explicitly install it when running tests.
-if [[ "${TORCH_VERSION}" == "2.12.0" ]]; then
+if [[ "${TORCH_VERSION}" == "2.13.0" ]]; then
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${CUDA_VERSION}"
   export CIBW_BEFORE_TEST="pip install pytest && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${CUDA_VERSION}"
+elif [[ "${TORCH_VERSION}" == "2.12.0" ]]; then
+  export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/test/${CUDA_VERSION}"
+  export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/test/${CUDA_VERSION}"
 else
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION}"
   export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION}"

--- a/.github/workflows/utils/build_macos.sh
+++ b/.github/workflows/utils/build_macos.sh
@@ -8,9 +8,12 @@ echo "TORCH_VERSION: ${TORCH_VERSION}"
 
 export CIBW_BUILD="cp${PYTHON_VERSION//./}-macosx_arm64"
 # pyg-lib doesn't have torch as a dependency, so we need to explicitly install it when running tests.
-if [[ "${TORCH_VERSION}" == "2.12.0" ]]; then
+if [[ "${TORCH_VERSION}" == "2.13.0" ]]; then
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu"
   export CIBW_BEFORE_TEST="pip install pytest && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu"
+elif [[ "${TORCH_VERSION}" == "2.12.0" ]]; then
+  export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/test/cpu"
+  export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/test/cpu"
 else
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/cpu"
   export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
### Before

```
  Looking in indexes: https://download.pytorch.org/whl/nightly/cu132
  Collecting torch
    Using cached https://download-r2.pytorch.org/whl/nightly/cu132/torch-2.13.0.dev20260426%2Bcu132-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (31 kB)
```

### After

```
  Looking in indexes: https://download.pytorch.org/whl/test/cu132
  Collecting torch==2.12.0
    Using cached https://download.pytorch.org/whl/test/cu132/torch-2.12.0%2Bcu132-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (31 kB)
```