### PR TITLE
Add `scatter_sum` (with `scatter_add` alias)

### DIFF
--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -1,0 +1,81 @@
+#include "../scatter.h"
+#include "../utils.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::scatter_sum`.
+//
+// The C++ dispatcher returns a fresh tensor (when `out=None`) or the caller's
+// buffer mutated in place (when `out=` is supplied). The `mark_dirty` call in
+// the latter case lets gradcheck pick up the in-place mutation; the actual
+// backward gradient is computed the same way regardless.
+class ScatterSum : public torch::autograd::Function<ScatterSum> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    // Normalize `dim` once so saved metadata is consistent with what backward
+    // sees from `torch.gather`.
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` (records unsqueeze/expand on the
+    // autograd graph so backward can call `.gather` directly).
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto out = scatter_sum(src, index_b, dim_norm, optional_out, dim_size);
+
+    ctx->save_for_backward({index_b});
+    ctx->saved_data["dim"] = dim_norm;
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index_b = saved[0];
+    const auto dim = ctx->saved_data["dim"].toInt();
+
+    // `grad_src[i] = grad_out[index[i]]` — exactly `gather` along `dim`.
+    auto grad_src = grad_out.gather(dim, index_b);
+
+    // 5 input slots: (src, index, dim, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor scatter_sum_autograd(const at::Tensor& src,
+                                const at::Tensor& index,
+                                int64_t dim,
+                                const std::optional<at::Tensor>& optional_out,
+                                std::optional<int64_t> dim_size) {
+  return ScatterSum::apply(src, index, dim, optional_out, dim_size)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -1,0 +1,134 @@
+#include "../scatter.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::scatter_sum`.
+//
+// Layout: `src` is viewed as (B, E, K) where
+//   * B = product of dim sizes before `dim`,
+//   * E = src.size(dim),
+//   * K = product of dim sizes after `dim`.
+// `out` has the same layout with N replacing E (N = out.size(dim)). `index`
+// must already be broadcast to `src.shape` (the dispatcher / autograd front
+// guarantees this) and is forced contiguous here before the kernel scan.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). This matches upstream pytorch_scatter and is what
+// makes `gather_coo` / `gather_csr` backward efficient.
+at::Tensor scatter_sum_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_sum: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_sum: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_sum: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Zero-init the freshly allocated buffer so that the accumulate loop
+    // below produces the correct result.
+    out = at::zeros(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_sum_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension. Each `b` slice writes
+        // to a disjoint sub-region of `out`, so no atomics are needed.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[src_off + e * K];
+                  // Note: when `index` is broadcast from a 1-D shape (i.e.
+                  // shape
+                  // `(E,)` expanded along K), the K positions in row `e` all
+                  // hold the same index, so reading `index_data[src_off + e * K
+                  // + 0]` is sufficient. The expand contract guarantees this;
+                  // the upstream kernel matches.
+                  //
+                  // For the general case (index already had a K dimension
+                  // before broadcast), each (e, k) pair may legitimately have a
+                  // distinct index, so we still index per-k below.
+                  if (K == 1) {
+                    const opmath_t v =
+                        static_cast<opmath_t>(src_data[src_off + e]);
+                    out_data[out_off + idx] = static_cast<scalar_t>(
+                        static_cast<opmath_t>(out_data[out_off + idx]) + v);
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t i = index_data[j];
+                      const opmath_t v = static_cast<opmath_t>(src_data[j]);
+                      out_data[out_off + i * K + k] = static_cast<scalar_t>(
+                          static_cast<opmath_t>(out_data[out_off + i * K + k]) +
+                          v);
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -1,0 +1,148 @@
+#pragma once
+
+// Atomic helpers for `pyg::scatter_*` and `pyg::segment_*` CUDA kernels.
+//
+// This file is grown commit-by-commit as the migration of pytorch_scatter
+// kernels lands. Commit 1 (`scatter_sum`) introduces:
+//
+//   * 16-bit CAS-loop `atomicAdd` for `at::Half` and `at::BFloat16` (the
+//     primary helpers — CUDA's native `__half`/`__nv_bfloat16` `atomicAdd`
+//     intrinsics are gated on sm_70+/sm_80+ respectively, while the CAS-loop
+//     works on every architecture pyg-lib targets).
+//   * Narrow-int CAS-loop `atomicAdd` for `uint8_t`, `int8_t`, `int16_t`,
+//     plus a `int64_t` wrapper that forwards to CUDA's `unsigned long long`
+//     intrinsic. These are mandatory for the
+//     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set —
+//     without them the kernel fails to link for narrow integer dtypes.
+//
+// Pattern mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`: rewind the address
+// to the nearest 32-bit-aligned word, then CAS the full word while updating
+// only the bytes/halfword we care about. Selector `(size_t)address & 2` picks
+// high (offset 2) vs. low (offset 0) halfword; `(size_t)address & 3` picks
+// the byte position.
+//
+// The overloads are defined in the global namespace so they participate in
+// overload resolution alongside the built-in CUDA `atomicAdd(int*, int)`,
+// `atomicAdd(float*, float)`, etc. Defining them inside `pyg::ops` would
+// shadow the built-ins for any unqualified call site inside that namespace.
+
+#include <ATen/ATen.h>
+#include <cuda_runtime.h>
+
+// `atomicAdd(at::Half*, at::Half)` — CAS-loop on the enclosing 32-bit word.
+//
+// Notes:
+//   * `address - ((size_t)address & 2)` rewinds to the 4-byte-aligned word.
+//   * `at::Half::x` is `unsigned short` (the IEEE 754 binary16 bit pattern).
+//   * `hsum = old_half + val` uses `at::Half`'s `operator+`, which itself
+//     promotes to `float` for the actual addition — this matches the upstream
+//     pytorch_scatter behavior and keeps precision sane for accumulation.
+//   * Returns the previous value at `address`, mirroring CUDA's built-in
+//     `atomicAdd` return convention.
+static inline __device__ at::Half atomicAdd(at::Half* address, at::Half val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    at::Half hsum;
+    hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hsum = hsum + val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16)
+                              : (old & 0xffff0000) | hsum.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  at::Half ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+// `atomicAdd(at::BFloat16*, at::BFloat16)` — same CAS-loop pattern.
+static inline __device__ at::BFloat16 atomicAdd(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    at::BFloat16 hsum;
+    hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hsum = hsum + val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16)
+                              : (old & 0xffff0000) | hsum.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  at::BFloat16 ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+// Narrow-integer CAS-loop helpers (1-byte and 2-byte). Mirrors the
+// 1/2-byte specializations of `AtomicAddIntegerImpl` in
+// `pytorch_scatter/csrc/cuda/atomics.cuh:6-41`.
+
+namespace pyg_atomics_detail {
+
+template <typename scalar_t>
+static inline __device__ scalar_t atomicAdd1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t sum;
+
+  do {
+    assumed = old;
+    sum = (uint32_t)((scalar_t)((old >> shift) & 0xff) + val) & 0xff;
+    old = (assumed & ~(0x000000ff << shift)) | (sum << shift);
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+template <typename scalar_t>
+static inline __device__ scalar_t atomicAdd2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t sum;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    sum = (uint32_t)((size_t)address & 2 ? (scalar_t)(old >> 16) + val
+                                         : (scalar_t)(old & 0xffff) + val) &
+          0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (sum << 16)
+                                 : (old & 0xffff0000) | sum;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+}  // namespace pyg_atomics_detail
+
+static inline __device__ uint8_t atomicAdd(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicAdd1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicAdd(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicAdd1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicAdd(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicAdd2B<int16_t>(address, val);
+}
+
+// `atomicAdd(int64_t*, int64_t)` — CUDA's native `atomicAdd` is defined for
+// `unsigned long long int`, so we reinterpret the address. Signed overflow
+// wraps around on 2's-complement, which is what we want for sum accumulation
+// (and matches CPU behavior for the same dtype).
+static inline __device__ int64_t atomicAdd(int64_t* address, int64_t val) {
+  return (int64_t)atomicAdd((unsigned long long int*)address,
+                            (unsigned long long int)val);
+}

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -1,0 +1,168 @@
+#include "../scatter.h"
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+
+#include "atomics.cuh"
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). ROCm warp=64 is not a target. Not used by this commit;
+// included here so subsequent commits in this family can rely on the same
+// constant without redefining it.
+#define WARP_SIZE 32
+
+// Convention 12: dynamic block sizing. Replicates the inline `threads()` /
+// `blocks()` pattern from
+// `pyg_lib/csrc/sampler/cuda/random_walk_kernel.cu:10-21` — there is no shared
+// helper in `pyg_lib/csrc/ops/cuda/` yet, so each new kernel file carries its
+// own copy. `maxThreadsPerBlock` is capped at 1024 because launching with more
+// threads than `maxThreadsPerBlock` would fail at runtime, and 1024 is the
+// upper bound on every supported arch.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  // `std::max(1, ...)` guards against pathological cases where the
+  // `cudaDeviceProp` struct is degenerate (e.g. local nvcc/runtime version
+  // mismatches that leave `multiProcessorCount` reading as 0/1 due to layout
+  // skew). Launching with `<<<0, ...>>>` is a `cudaErrorInvalidValue`; a
+  // single block is always a safe fallback for the work we have to do.
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// 1 thread per `src` element. Atomically accumulates into
+// `out[b * N * K + idx * K + k]` where `idx = index_data[thread_idx]`. The
+// index tensor must already be broadcast to `src.shape` and `.contiguous()`
+// (the dispatcher enforces both). Grid is a strided 1-D loop so we cover
+// `numel` correctly even when `numel > gridDim.x * blockDim.x`.
+template <typename scalar_t>
+__global__ void scatter_sum_cuda_kernel(const scalar_t* __restrict__ src_data,
+                                        const int64_t* __restrict__ index_data,
+                                        scalar_t* __restrict__ out_data,
+                                        int64_t E,
+                                        int64_t K,
+                                        int64_t N,
+                                        int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicAdd(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// CUDA implementation of `pyg::scatter_sum`. Mirrors the CPU kernel layout
+// (B, E, K) and the `out=` contract:
+//   * `optional_out` provided -> accumulate into the caller's buffer (no zero
+//     init). The buffer is `.contiguous()`-ified at the kernel boundary.
+//   * `optional_out` absent -> allocate `at::zeros(...)` so that
+//     `atomicAdd`-based accumulation starts from a clean slate.
+at::Tensor scatter_sum_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_sum (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_sum (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_sum (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_sum (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_sum (CUDA): dim out of range");
+
+  // Pin the current CUDA device to the input's device so subsequent
+  // `at::cuda::getCurrentDeviceProperties()` / `getCurrentCUDAStream()` calls
+  // resolve to the right device (matches upstream pytorch_scatter's
+  // `c10::cuda::MaybeSetDevice(src.get_device())`).
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary. The autograd
+  // wrapper calls `broadcast(index, src, dim)` (which produces an expanded,
+  // non-contiguous view); we materialize it here so the kernel can index by a
+  // single linear offset.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_sum (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Zero-init so the atomicAdd accumulation starts from a clean slate.
+    out = at::zeros(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_sum_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        scatter_sum_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -1,0 +1,45 @@
+#include "scatter.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor scatter_sum(const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& out,
+                               std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_sum"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_sum: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_sum: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_sum", "")
+                       .typed<decltype(scatter_sum)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the indices specified in `index`
+// along a given axis `dim`.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// the symmetric-pair backwards (`gather_coo` / `gather_csr`) efficient.
+PYG_API at::Tensor scatter_sum(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/utils.h
+++ b/pyg_lib/csrc/ops/utils.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace pyg {
+namespace ops {
+
+// Broadcasts `src` so that its shape matches `other`. Mirrors the helper at
+// `pytorch_scatter/csrc/scatter.cpp:25-33`. The result records `unsqueeze` /
+// `expand` operations on the autograd graph and is used inside autograd
+// `forward` methods before kernel dispatch so that the broadcast index keeps
+// gradient connectivity (where applicable) and so that downstream kernels can
+// assume an index tensor whose shape matches `other`.
+//
+// Algorithm:
+//   * If `src` is 1-D, prepend `dim` singleton dims (`src.unsqueeze(0)` x dim).
+//   * Append singleton dims until `src.dim() == other.dim()`.
+//   * `src.expand(other.sizes())`.
+//
+// The returned tensor is *not* contiguous; the caller is responsible for
+// `.contiguous()` if the kernel requires it.
+inline at::Tensor broadcast(const at::Tensor& src,
+                            const at::Tensor& other,
+                            int64_t dim) {
+  auto out = src;
+  if (out.dim() == 1) {
+    for (int64_t i = 0; i < dim; ++i)
+      out = out.unsqueeze(0);
+  }
+  for (int64_t i = out.dim(); i < other.dim(); ++i)
+    out = out.unsqueeze(-1);
+  out = out.expand(other.sizes());
+  return out;
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -350,6 +350,38 @@ def softmax_csr(
     return torch.ops.pyg.softmax_csr(src, ptr, dim)
 
 
+def scatter_sum(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``sum`` as the reduction.
+
+    If :obj:`out` is not given, a new tensor is allocated and zero-initialized.
+    If :obj:`out` is given, values are **accumulated** into it (no zero-init).
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`. If :obj:`dim_size` is
+            also :obj:`None`, a minimal sized output is returned.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.scatter_sum(src, index, dim, out, dim_size)
+
+
+scatter_add = scatter_sum
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -588,6 +620,8 @@ __all__ = [
     'sampled_div',
     'index_sort',
     'softmax_csr',
+    'scatter_sum',
+    'scatter_add',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -1,0 +1,233 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+
+def _broadcast_index(
+    index: torch.Tensor,
+    src: torch.Tensor,
+    dim: int,
+) -> torch.Tensor:
+    """Broadcasts a 1-D :obj:`index` to the shape of :obj:`src` along
+    :obj:`dim`. Mirrors the helper used by upstream pytorch_scatter and the
+    C++ ``broadcast`` util in ``pyg_lib/csrc/ops/utils.h``.
+    """
+    if index.dim() == src.dim():
+        return index
+    if dim < 0:
+        dim = dim + src.dim()
+    size = [1] * src.dim()
+    size[dim] = -1
+    return index.view(size).expand_as(src)
+
+
+def _scatter_sum_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference implementation of :func:`scatter_sum`.
+
+    Mirrors the contract of ``pyg_lib.ops.scatter_sum``:
+      * Index is broadcast to ``src`` along ``dim``.
+      * If ``out`` is :obj:`None`, an output of the appropriate shape is
+        zero-initialized.
+      * If ``out`` is provided, the op accumulates into it (no zeroing).
+      * If ``dim_size`` is :obj:`None`, infer from ``index.max() + 1``.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if out is None:
+        if dim_size is None:
+            dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+        size = list(src.size())
+        size[dim] = dim_size
+        out = torch.zeros(size, dtype=src.dtype, device=src.device)
+    out.scatter_add_(dim, bcast_index, src)
+    return out
+
+
+def test_scatter_add_is_scatter_sum_alias():
+    assert pyg_lib.ops.scatter_add is pyg_lib.ops.scatter_sum
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_sum_forward_dtypes(dtype, device):
+    if device.type == 'cpu' and dtype == torch.float16:
+        # CPU half-precision arithmetic is supported but tolerances are loose;
+        # we still run it to check parity.
+        pass
+    if dtype in (torch.int32, torch.int64):
+        src = torch.randint(-10, 10, (8, 4), dtype=dtype, device=device)
+    else:
+        src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_neg1(device):
+    src = torch.randn(3, 8, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1)
+    expected = _scatter_sum_ref(src, index, dim=-1)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_nonneg(device):
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_middle(device):
+    src = torch.randn(3, 6, 5, device=device)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=1)
+    expected = _scatter_sum_ref(src, index, dim=1)
+    assert out.size() == (3, 3, 5)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4
+    assert out.size(-1) == 4
+    expected = _scatter_sum_ref(src, index, dim=-1)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_dim_size_explicit(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    # Larger than implicit dim_size — trailing buckets are empty (zeros).
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _scatter_sum_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Empty buckets should be exactly zero.
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+
+
+@withCUDA
+def test_scatter_sum_out_accumulates(device):
+    """When ``out`` is provided, the op accumulates into it without zeroing."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out_init = torch.randn(4, 4, device=device)
+    out = out_init.clone()
+    result = pyg_lib.ops.scatter_sum(src, index, dim=0, out=out)
+
+    # Accumulate semantics: result == out_init + scatter_sum into zeros.
+    delta = _scatter_sum_ref(src, index, dim=0, dim_size=4)  # zero-initialized
+    expected = out_init + delta
+    torch.testing.assert_close(result, expected)
+    # The op should also have updated ``out`` in-place.
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_empty_input(device):
+    """An empty source with an empty index should yield an empty output."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck_dim_middle(device):
+    src = torch.randn(
+        2,
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=1)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets in the output.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))


### PR DESCRIPTION
First commit of the pytorch_scatter port. Introduces all scatter-family
scaffolding plus `cuda/atomics.cuh` with `atomicAdd<Half/BFloat16>` (and
narrow-int CAS-loop overloads needed to satisfy `AT_DISPATCH_ALL_TYPES_AND2`
linking). CPU kernel uses `at::opmath_type` accumulator; CUDA kernel uses
1-thread-per-src-element `atomicAdd` with dynamic block sizing and
`.contiguous()` on broadcast index. Autograd `ScatterSum::backward` is
`grad_out.gather(dim, broadcast_index)`. `out=` follows the accumulate
contract (no zero-init).
