### PR TITLE
Add `scatter_mul`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -70,11 +70,82 @@ at::Tensor scatter_sum_autograd(const at::Tensor& src,
   return ScatterSum::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::scatter_mul`.
+//
+// Backward formula (upstream pytorch_scatter `scatter.cpp:101-112`):
+//
+//   grad_src = (grad_out * out).gather(dim, index_b) / src
+//
+// where `out` is the forward result. At positions where `src == 0`, this
+// expression is ill-defined (0/0 NaN); upstream produces a NaN and then
+// masks it with `masked_fill_(isnan, 0)`. We use `torch::where(src != 0,
+// ..., zeros)` to produce zeros directly without going through NaN.
+class ScatterMul : public torch::autograd::Function<ScatterMul> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` so that backward's `gather` can
+    // use it directly. Recording the broadcast on the autograd graph keeps
+    // gradient connectivity (though `index` itself is non-differentiable).
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto out = scatter_mul(src, index_b, dim_norm, optional_out, dim_size);
+
+    // Backward needs `src` (denominator), `index_b` (gather axis), and `out`
+    // (so that `grad_out * out` can be gathered at the contributing indices).
+    ctx->save_for_backward({src, index_b, out});
+    ctx->saved_data["dim"] = dim_norm;
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto src = saved[0];
+    const auto index_b = saved[1];
+    const auto out = saved[2];
+    const auto dim = ctx->saved_data["dim"].toInt();
+
+    // Note: `(grad_out * out)` is the gradient that arrives at the bucket;
+    // gathering it back to the source positions multiplies by the product
+    // of all *other* contributors, which is `out / src`. Hence the divide.
+    auto gathered = (grad_out * out).gather(dim, index_b);
+    auto grad_src = at::where(src != 0, gathered / src, at::zeros_like(src));
+
+    // 5 input slots: (src, index, dim, out, dim_size).
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor scatter_mul_autograd(const at::Tensor& src,
+                                const at::Tensor& index,
+                                int64_t dim,
+                                const std::optional<at::Tensor>& optional_out,
+                                std::optional<int64_t> dim_size) {
+  return ScatterMul::apply(src, index, dim, optional_out, dim_size)[0];
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_autograd));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -123,11 +123,113 @@ at::Tensor scatter_sum_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::scatter_mul`.
+//
+// Same (B, E, K) layout as `scatter_sum_kernel`. The only differences:
+//   * The reduction is multiplicative.
+//   * When `out=None`, the freshly allocated buffer is initialized with
+//     **ones** (the multiplicative identity), not zeros.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **multiply
+// into** it (no ones-init). The caller is responsible for any non-default
+// starting state. This matches upstream pytorch_scatter.
+at::Tensor scatter_mul_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_mul: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_mul: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_mul: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Ones-init the freshly allocated buffer so that the multiplicative
+    // reduction starts from the multiplicative identity.
+    out = at::ones(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_mul_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension. Each `b` slice writes
+        // to a disjoint sub-region of `out`, so no atomics are needed.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  if (K == 1) {
+                    const int64_t idx = index_data[src_off + e];
+                    const opmath_t v =
+                        static_cast<opmath_t>(src_data[src_off + e]);
+                    out_data[out_off + idx] = static_cast<scalar_t>(
+                        static_cast<opmath_t>(out_data[out_off + idx]) * v);
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t i = index_data[j];
+                      const opmath_t v = static_cast<opmath_t>(src_data[j]);
+                      out_data[out_off + i * K + k] = static_cast<scalar_t>(
+                          static_cast<opmath_t>(out_data[out_off + i * K + k]) *
+                          v);
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -15,6 +15,14 @@
 //     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set —
 //     without them the kernel fails to link for narrow integer dtypes.
 //
+// Commit 2 (`scatter_mul`) adds:
+//
+//   * CAS-loop `atomicMul` for every dtype in
+//     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)`. CUDA does not provide
+//     a native `atomicMul` for any dtype, so all overloads CAS on the
+//     enclosing 32-bit or 64-bit storage word. See the comment block above
+//     the overloads for the per-dtype storage strategy.
+//
 // Pattern mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`: rewind the address
 // to the nearest 32-bit-aligned word, then CAS the full word while updating
 // only the bytes/halfword we care about. Selector `(size_t)address & 2` picks
@@ -145,4 +153,174 @@ static inline __device__ int16_t atomicAdd(int16_t* address, int16_t val) {
 static inline __device__ int64_t atomicAdd(int64_t* address, int64_t val) {
   return (int64_t)atomicAdd((unsigned long long int*)address,
                             (unsigned long long int)val);
+}
+
+// -----------------------------------------------------------------------------
+// `atomicMul` — Commit 2 (`scatter_mul`).
+//
+// CUDA does not natively provide `atomicMul` for any dtype, so every overload
+// below is a CAS-loop on the enclosing 32-bit or 64-bit storage word.
+//
+// Storage strategy per dtype (mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`'s
+// `AtomicMulIntegerImpl<scalar, size>` / `AtomicMulDecimalImpl<scalar, size>`
+// specializations):
+//   * 1-byte ints (uint8_t / int8_t)            -> CAS on 32-bit word, byte
+//                                                  selector `(addr & 3) * 8`.
+//   * 2-byte ints + at::Half + at::BFloat16     -> CAS on 32-bit word,
+//                                                  halfword selector `addr &
+//                                                  2`.
+//   * int32_t                                   -> CAS on 32-bit word.
+//   * float                                     -> CAS on 32-bit word via
+//                                                  `__float_as_int` /
+//                                                  `__int_as_float`.
+//   * int64_t                                   -> CAS on 64-bit word
+//                                                  (`unsigned long long`).
+//   * double                                    -> CAS on 64-bit word via
+//                                                  `__double_as_longlong` /
+//                                                  `__longlong_as_double`.
+//
+// As with the `atomicAdd` overloads above, these live in the global namespace
+// so they participate in overload resolution alongside the CUDA built-ins.
+
+namespace pyg_atomics_detail {
+
+// 1-byte CAS-loop multiply (uint8_t / int8_t). Selector chooses which byte of
+// the 32-bit word we're updating; the other three bytes are preserved.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMul1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t prod;
+
+  do {
+    assumed = old;
+    prod = (uint32_t)((scalar_t)((old >> shift) & 0xff) * val) & 0xff;
+    old = (assumed & ~(0x000000ff << shift)) | (prod << shift);
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+// 2-byte CAS-loop multiply (int16_t / at::Half / at::BFloat16).
+// `at::Half` / `at::BFloat16` use this template via `scalar_t::operator*`,
+// which (like `operator+` in the `atomicAdd` overloads) promotes to `float`
+// for the actual multiply — matches upstream pytorch_scatter precision.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMul2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t prod;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    prod = (uint32_t)((size_t)address & 2 ? (scalar_t)(old >> 16) * val
+                                          : (scalar_t)(old & 0xffff) * val) &
+           0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (prod << 16)
+                                 : (old & 0xffff0000) | prod;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+// 2-byte CAS-loop multiply for `at::Half` / `at::BFloat16`. The
+// integer-flavoured template above would clobber the IEEE 754 bit pattern
+// because it casts the half-word to/from `scalar_t` directly. Instead, we
+// stash the bits into `scalar_t::x` (the underlying `unsigned short`),
+// multiply via the operator overload (which promotes to float), then write
+// the result's bit pattern back.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMulHalf(scalar_t* address,
+                                                scalar_t val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    scalar_t hprod;
+    hprod.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hprod = hprod * val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hprod.x << 16)
+                              : (old & 0xffff0000) | hprod.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  scalar_t ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+}  // namespace pyg_atomics_detail
+
+// Integer overloads.
+static inline __device__ uint8_t atomicMul(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicMul1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicMul(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicMul1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicMul(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicMul2B<int16_t>(address, val);
+}
+static inline __device__ int32_t atomicMul(int32_t* address, int32_t val) {
+  uint32_t* address_as_ui = (uint32_t*)address;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ui, assumed, (uint32_t)((int32_t)assumed * val));
+  } while (assumed != old);
+  return (int32_t)old;
+}
+static inline __device__ int64_t atomicMul(int64_t* address, int64_t val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    (unsigned long long int)((int64_t)assumed * val));
+  } while (assumed != old);
+  return (int64_t)old;
+}
+
+// Floating-point overloads.
+static inline __device__ at::Half atomicMul(at::Half* address, at::Half val) {
+  return pyg_atomics_detail::atomicMulHalf<at::Half>(address, val);
+}
+static inline __device__ at::BFloat16 atomicMul(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  return pyg_atomics_detail::atomicMulHalf<at::BFloat16>(address, val);
+}
+static inline __device__ float atomicMul(float* address, float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_i, assumed,
+                    __float_as_int(val * __int_as_float(assumed)));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+static inline __device__ double atomicMul(double* address, double val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val * __longlong_as_double(assumed)));
+  } while (assumed != old);
+  return __longlong_as_double(old);
 }

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -157,11 +157,119 @@ at::Tensor scatter_sum_kernel(const at::Tensor& src,
   return out;
 }
 
+// 1 thread per `src` element. Atomically multiplies into
+// `out[b * N * K + idx * K + k]` where `idx = index_data[thread_idx]`. Same
+// addressing scheme as `scatter_sum_cuda_kernel` — only the atomic differs.
+template <typename scalar_t>
+__global__ void scatter_mul_cuda_kernel(const scalar_t* __restrict__ src_data,
+                                        const int64_t* __restrict__ index_data,
+                                        scalar_t* __restrict__ out_data,
+                                        int64_t E,
+                                        int64_t K,
+                                        int64_t N,
+                                        int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicMul(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// CUDA implementation of `pyg::scatter_mul`. Mirrors `scatter_sum_kernel` with
+// two differences:
+//   * Uses `atomicMul` (CAS-loop from `atomics.cuh`) for accumulation.
+//   * When `optional_out` is absent, the fresh buffer is filled with **ones**,
+//     not zeros — multiplicative identity. Mirrors upstream pytorch_scatter's
+//     `out.fill_(Reducer<scalar_t, REDUCE>::init())` for `REDUCE = MUL`.
+at::Tensor scatter_mul_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_mul (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_mul (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_mul (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_mul (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_mul (CUDA): dim out of range");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary. The autograd
+  // wrapper passes a `broadcast(index, src, dim)`-expanded (non-contiguous)
+  // view; materialize it so the kernel can index by a single linear offset.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_mul (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Multiplicative identity (1) so `atomicMul` accumulation starts cleanly.
+    out = at::ones(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_mul_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        scatter_mul_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  return out;
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -35,9 +35,41 @@ PYG_API at::Tensor scatter_sum(const at::Tensor& src,
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API at::Tensor scatter_mul(const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& out,
+                               std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_mul"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_mul: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_mul: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_mul", "")
+                       .typed<decltype(scatter_mul)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_mul(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
 }
 

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -21,5 +21,20 @@ PYG_API at::Tensor scatter_sum(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Multiplies all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim`.
+//
+// When `out` is not provided, a fresh ones-initialized buffer is allocated
+// (so that the multiplicative reduction starts from the multiplicative
+// identity). When `out` *is* provided, the operation multiplies into the
+// caller's buffer (no ones-init); the caller is responsible for any non-
+// default starting state. This matches the upstream contract.
+PYG_API at::Tensor scatter_mul(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 }  // namespace ops
 }  // namespace pyg

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -382,6 +382,35 @@ def scatter_sum(
 scatter_add = scatter_sum
 
 
+def scatter_mul(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``mul`` as the reduction.
+
+    If :obj:`out` is not given, a new tensor is allocated and initialized to
+    ones (the multiplicative identity). If :obj:`out` is given, values are
+    **multiplied** into it (no ones-init).
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.scatter_mul(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -622,6 +651,7 @@ __all__ = [
     'softmax_csr',
     'scatter_sum',
     'scatter_add',
+    'scatter_mul',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -231,3 +231,340 @@ def test_scatter_sum_backward_gradcheck_with_dim_size(device):
         return pyg_lib.ops.scatter_sum(s, index, dim=-1, dim_size=6)
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter_mul
+# ---------------------------------------------------------------------------
+
+
+def _scatter_mul_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference implementation of :func:`scatter_mul`.
+
+    Mirrors the contract of ``pyg_lib.ops.scatter_mul``:
+      * Index is broadcast to ``src`` along ``dim``.
+      * If ``out`` is :obj:`None`, an output of the appropriate shape is
+        initialized to **ones** (not zeros).
+      * If ``out`` is provided, the op multiplies into it (no ones-init).
+      * If ``dim_size`` is :obj:`None`, infer from ``index.max() + 1``.
+
+    Implemented via an explicit per-element scalar walk along ``dim`` so we
+    avoid relying on ``Tensor.scatter_reduce_(reduce="prod")`` whose
+    initialization semantics differ from upstream's ones-init.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if out is None:
+        if dim_size is None:
+            dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+        size = list(src.size())
+        size[dim] = dim_size
+        out = torch.ones(size, dtype=src.dtype, device=src.device)
+    else:
+        out = out.clone()  # don't mutate caller's tensor in the reference
+
+    # Walk over ``src`` along ``dim`` and multiply each slice into ``out``.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            # Recover the multi-index for the "other" dims.
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out[tuple(out_idx)] = out[tuple(out_idx)] * flat_src[k]
+    return out
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_mul_forward_dtypes(dtype, device):
+    if dtype in (torch.int32, torch.int64):
+        # Keep values small so the product doesn't blow up integer ranges.
+        src = torch.randint(-3, 4, (8, 4), dtype=dtype, device=device)
+    else:
+        # Keep values O(1) so fp16/bf16 products stay well within range.
+        src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    # Looser tolerances for low-precision floats; chained multiplies amplify
+    # rounding error relative to a single scatter_add pass.
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_neg1(device):
+    src = torch.randn(3, 8, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1)
+    expected = _scatter_mul_ref(src, index, dim=-1)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_nonneg(device):
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_middle(device):
+    src = torch.randn(3, 6, 5, device=device)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=1)
+    expected = _scatter_mul_ref(src, index, dim=1)
+    assert out.size() == (3, 3, 5)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4
+    assert out.size(-1) == 4
+    expected = _scatter_mul_ref(src, index, dim=-1)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_dim_size_explicit(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets remain at
+    the ones-init (no src elements multiply into them).
+    """
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _scatter_mul_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Empty buckets keep the ones-init (NOT zero, unlike scatter_sum).
+    torch.testing.assert_close(out[4:], torch.ones(2, device=device))
+
+
+@withCUDA
+def test_scatter_mul_out_multiplies_into_buffer(device):
+    """When ``out`` is provided, mul into it without ones-init."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out_init = torch.randn(4, 4, device=device)
+    out = out_init.clone()
+    result = pyg_lib.ops.scatter_mul(src, index, dim=0, out=out)
+
+    # Multiply-into semantics: result == out_init * scatter_mul into ones.
+    factor = _scatter_mul_ref(
+        src,
+        index,
+        dim=0,
+        dim_size=4,
+    )  # ones-initialized
+    expected = out_init * factor
+    torch.testing.assert_close(result, expected)
+    # The op should also have updated ``out`` in-place.
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_empty_input(device):
+    """An empty source with an empty index should yield ones-initialised
+    output (no multiplies happened).
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.ones(3, 4, device=device))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck(device):
+    # Avoid src == 0 in this base gradcheck — the upstream-matched
+    # ``where(src != 0, ..., 0)`` rule deliberately deviates from the true
+    # mathematical gradient at zeros, which would otherwise trip finite-diff.
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    # Push values away from zero so the analytical == numerical comparison
+    # uses the smooth branch of the autograd rule everywhere.
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck_dim_middle(device):
+    src = torch.randn(
+        2,
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=1)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets in the output. Empty buckets stay at the ones-init; their
+    gradient w.r.t. ``src`` is zero because no ``src`` element flows into them.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_gradient_at_src_zero(device):
+    """The mathematical gradient of a product is unstable at zero entries;
+    upstream returns zero (we replicate via ``torch.where(src != 0, ...)``).
+
+    Verify that the returned gradient at positions where ``src == 0`` is
+    finite (zero), not NaN/inf, and that the gradient at non-zero positions
+    is unaffected.
+    """
+    # Mix zeros into the source.
+    src = torch.tensor(
+        [2.0, 0.0, 3.0, 0.0, 5.0, 0.0],
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 2, 2], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    # Sum so we have a scalar loss; ``grad_out`` is all-ones.
+    out.sum().backward()
+
+    grad = src.grad
+    assert grad is not None
+    # No NaNs and no infinities anywhere.
+    assert torch.isfinite(grad).all(), (
+        f'grad contains non-finite values: {grad}'
+    )
+    # Positions where src == 0 must have grad == 0 (the upstream convention).
+    zero_mask = src.detach() == 0
+    torch.testing.assert_close(
+        grad[zero_mask],
+        torch.zeros_like(grad[zero_mask]),
+    )
+    # Sanity-check non-zero positions: for bucket {2, 0} with grad_out=1,
+    # grad_src for src==2 = (grad_out * out_bucket) / src_at_2 where
+    # out_bucket = 2 * 0 = 0, so grad = 0. Same for all buckets containing
+    # a zero entry. So actually all grads should be zero here.
+    # Construct a different fixture where the non-zero grad path matters:
+    src2 = torch.tensor(
+        [2.0, 0.0, 3.0, 4.0, 5.0, 6.0],
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index2 = torch.tensor([0, 0, 1, 1, 2, 2], device=device)
+    out2 = pyg_lib.ops.scatter_mul(src2, index2, dim=0)
+    out2.sum().backward()
+    grad2 = src2.grad
+    assert grad2 is not None
+    assert torch.isfinite(grad2).all()
+    # src2[1] == 0 -> grad2[1] must be 0 by the upstream rule.
+    torch.testing.assert_close(
+        grad2[1],
+        torch.zeros((), dtype=torch.double, device=device),
+    )
+    # Bucket {3, 4}: product 12; grad[2] = 12/3 = 4, grad[3] = 12/4 = 3.
+    torch.testing.assert_close(
+        grad2[2],
+        torch.tensor(4.0, dtype=torch.double, device=device),
+    )
+    torch.testing.assert_close(
+        grad2[3],
+        torch.tensor(3.0, dtype=torch.double, device=device),
+    )
+    # Bucket {5, 6}: product 30; grad[4] = 30/5 = 6, grad[5] = 30/6 = 5.
+    torch.testing.assert_close(
+        grad2[4],
+        torch.tensor(6.0, dtype=torch.double, device=device),
+    )
+    torch.testing.assert_close(
+        grad2[5],
+        torch.tensor(5.0, dtype=torch.double, device=device),
+    )


### PR DESCRIPTION
Mul reduction. `out=None` initializes to ones (multiplicative identity);
`out=` multiplies into the caller's buffer. CUDA `atomicMul` lands as a
CAS-loop family in `atomics.cuh` covering all `AT_DISPATCH_ALL_TYPES_AND2`
dtypes (int8/16/32/64, Half, BFloat16, float, double). Backward is
`(grad_out * out).gather(dim, index) / src`, masked with `where(src != 0)`
to keep gradients zero where `src == 0` (mirrors upstream: when one bucket
contributor is 0, the bucket product is 0 so every contributor's gradient
is 0).
