### PR TITLE
Add `scatter_min`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -3,6 +3,8 @@
 
 #include <torch/autograd.h>
 
+#include <tuple>
+
 namespace pyg {
 namespace ops {
 
@@ -238,6 +240,99 @@ at::Tensor scatter_mean_autograd(const at::Tensor& src,
   return ScatterMean::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::scatter_min`.
+//
+// Forward returns `(out, arg_out)`. Only `out` is differentiable; `arg_out`
+// is marked non-differentiable via `ctx->mark_non_differentiable({arg_out})`
+// so PyTorch will not error when callers try to take gradients through it
+// and so gradcheck only probes the value output (convention 8).
+//
+// Backward formula (upstream `pytorch_scatter/csrc/scatter.cpp:184-196`):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket min and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+class ScatterMin : public torch::autograd::Function<ScatterMin> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` so the kernel can index per-K
+    // and so the saved `src_shape` aligns with the (per-position) backward
+    // scatter. Recording this on the autograd graph keeps the broadcast
+    // visible to any upstream graph rewriting, though `index` itself is
+    // non-differentiable.
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto result = scatter_min(src, index_b, dim_norm, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({arg_out});
+    ctx->saved_data["dim"] = dim_norm;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto arg_out = saved[0];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 5 input slots: (src, index, dim, out, dim_size). Only `src` is a
+    // real differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> scatter_min_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = ScatterMin::apply(src, index, dim, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
@@ -251,6 +346,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   // the not-implemented sentinel; the same wrapper handles both paths.
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mean"),
          TORCH_FN(scatter_mean_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_autograd));
 }
 
 // `scatter_mean` has no dedicated CPU/CUDA kernel; it is fully composed of

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -5,6 +5,9 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 
+#include <limits>
+#include <tuple>
+
 namespace pyg {
 namespace ops {
 
@@ -223,6 +226,148 @@ at::Tensor scatter_mul_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::scatter_min`.
+//
+// Same (B, E, K) layout as `scatter_sum_kernel`. Two output tensors:
+//   * `out`: the per-bucket minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (upstream convention).
+//   * `arg_out`: the source position that produced each per-bucket min,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner loop over `E` is sequential per `(B, K)`
+// slice and uses strict `<` on the comparison, so on ties the kernel
+// preserves *first-match* semantics. Parallelism is only over the
+// leading `B` dim, where slices write to disjoint sub-regions of
+// `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init). The caller is
+// responsible for any non-default starting state. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_min: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_min: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_min: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_c.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_min_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension only — the inner
+        // loop over E must remain sequential to preserve first-match
+        // argindex semantics on tied source values.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  if (K == 1) {
+                    const int64_t idx = index_data[src_off + e];
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t idx = index_data[j];
+                      const scalar_t v = src_data[j];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
@@ -230,6 +375,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(scatter_sum_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
          TORCH_FN(scatter_mul_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -324,3 +324,187 @@ static inline __device__ double atomicMul(double* address, double val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
+
+// -----------------------------------------------------------------------------
+// `atomicMin` — Commit 4 (`scatter_min`).
+//
+// CUDA provides a native `atomicMin` for `int`, `unsigned int`, `long long
+// int`, and `unsigned long long int` only — none of the narrow ints, neither
+// floating-point dtype, and not `at::Half` / `at::BFloat16`. For uniform
+// overload resolution at the kernel call site (where `scalar_t` ranges over
+// the `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set),
+// we provide CAS-loop overloads for every dtype below — even where a native
+// `atomicMin` exists — so that `atomicMin(out_data + j, src[i])` resolves
+// without an integer-promotion ambiguity inside the kernel.
+//
+// Storage strategy mirrors the `atomicMul` block above:
+//   * 1-byte ints (uint8_t / int8_t)            -> CAS on 32-bit word, byte
+//                                                  selector `(addr & 3) * 8`.
+//   * 2-byte ints + at::Half + at::BFloat16     -> CAS on 32-bit word,
+//                                                  halfword selector
+//                                                  `addr & 2`. Floating-point
+//                                                  half/bfloat16 use a
+//                                                  dedicated helper that
+//                                                  preserves the IEEE bit
+//                                                  pattern via `scalar_t::x`.
+//   * int32_t                                   -> forwards to CUDA's
+//                                                  native `atomicMin`.
+//   * float                                     -> CAS on 32-bit word via
+//                                                  `__float_as_int` /
+//                                                  `__int_as_float`.
+//   * int64_t                                   -> CAS on 64-bit word
+//                                                  (signed comparison done
+//                                                  on the reinterpreted
+//                                                  signed value).
+//   * double                                    -> CAS on 64-bit word via
+//                                                  `__double_as_longlong` /
+//                                                  `__longlong_as_double`.
+
+namespace pyg_atomics_detail {
+
+// 1-byte CAS-loop min (uint8_t / int8_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMin1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t result;
+
+  do {
+    assumed = old;
+    const scalar_t cur = (scalar_t)((old >> shift) & 0xff);
+    const scalar_t new_val = val < cur ? val : cur;
+    result = (assumed & ~(0x000000ff << shift)) |
+             (((uint32_t)new_val & 0xff) << shift);
+    old = atomicCAS(address_as_ui, assumed, result);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+// 2-byte CAS-loop min (int16_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMin2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    const scalar_t cur =
+        (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+    const scalar_t new_val = val < cur ? val : cur;
+    const uint32_t lo = (uint32_t)new_val & 0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (lo << 16)
+                                 : (old & 0xffff0000) | lo;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+// 2-byte CAS-loop min for `at::Half` / `at::BFloat16`. The integer-flavored
+// template above would clobber the IEEE 754 bit pattern because it casts the
+// half-word to/from `scalar_t` directly; here we stash the bits into
+// `scalar_t::x` (the underlying `unsigned short`), compare *as float*
+// (avoiding the `c10::Half`/`__half` operator overload ambiguity that
+// `cuda_fp16.hpp` introduces when both `__half::operator<` and the
+// built-in arithmetic `<` are visible), then write the chosen value's bit
+// pattern back.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMinHalf(scalar_t* address,
+                                                scalar_t val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+  const float val_f = static_cast<float>(val);
+
+  do {
+    assumed = old;
+    scalar_t cur;
+    cur.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    const scalar_t chosen = val_f < static_cast<float>(cur) ? val : cur;
+    old = (size_t)address & 2 ? (old & 0xffff) | ((unsigned int)chosen.x << 16)
+                              : (old & 0xffff0000) | (unsigned int)chosen.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  scalar_t ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+}  // namespace pyg_atomics_detail
+
+// Integer overloads.
+static inline __device__ uint8_t atomicMin(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicMin1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicMin(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicMin1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicMin(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicMin2B<int16_t>(address, val);
+}
+// `int32_t` (== `int` on every platform we target) — CUDA's native
+// `atomicMin(int*, int)` already participates in overload resolution, so we
+// do *not* define a wrapper here. (Doing so would collide on Linux x86_64
+// where `int32_t` is `int`.)
+//
+// `int64_t` is `long int` on Linux x86_64 (LP64); CUDA's native
+// `atomicMin(long long int*, long long int)` covers a *different* type, so
+// we provide our own CAS loop. The comparison is done in signed space on the
+// reinterpreted 64-bit word.
+static inline __device__ int64_t atomicMin(int64_t* address, int64_t val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const int64_t cur = (int64_t)assumed;
+    const int64_t new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, (unsigned long long int)new_val);
+  } while (assumed != old);
+  return (int64_t)old;
+}
+
+// Floating-point overloads.
+static inline __device__ at::Half atomicMin(at::Half* address, at::Half val) {
+  return pyg_atomics_detail::atomicMinHalf<at::Half>(address, val);
+}
+static inline __device__ at::BFloat16 atomicMin(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  return pyg_atomics_detail::atomicMinHalf<at::BFloat16>(address, val);
+}
+// float — CAS on the bit pattern. Safe for non-NaN inputs: IEEE 754 binary32
+// is monotone w.r.t. integer ordering for nonnegative values, but signed
+// comparison via `__int_as_float` then real `<` handles both signs correctly
+// (we compare floats, not the integer bit pattern).
+static inline __device__ float atomicMin(float* address, float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed;
+
+  do {
+    assumed = old;
+    const float cur = __int_as_float(assumed);
+    const float new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_i, assumed, __float_as_int(new_val));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+static inline __device__ double atomicMin(double* address, double val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const double cur = __longlong_as_double(assumed);
+    const double new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, __double_as_longlong(new_val));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -5,6 +5,10 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
 
+#include <limits>
+#include <tuple>
+#include <type_traits>
+
 #include "atomics.cuh"
 
 namespace pyg {
@@ -263,6 +267,211 @@ at::Tensor scatter_mul_kernel(const at::Tensor& src,
   return out;
 }
 
+// ============================================================================
+// `scatter_min` — Commit 4.
+//
+// Two CUDA kernels, launched on the same stream so completion ordering is
+// implicit:
+//
+//   1. `scatter_min_value_cuda_kernel`. 1 thread per `src` element; performs
+//      `atomicMin(out + linear_offset, src[i])`. `out` is pre-initialized on
+//      the host to `numeric_limits<scalar_t>::max()` (when `out=None`); the
+//      caller is responsible for any non-default starting state when `out=`
+//      is supplied (mirrors the upstream `out.fill_(Reducer::init())` skip).
+//
+//   2. `scatter_arg_cuda_kernel`. 1 thread per `src` element; re-scans `src`
+//      and where `src[i] == out[linear_offset]`, performs
+//      `atomicMin(arg_out + linear_offset, i)` over `int64_t`. Initialising
+//      `arg_out` to the sentinel `src.size(dim)` makes any valid contributor
+//      `i < src.size(dim)` win the CAS; subsequent ties pick the *smallest*
+//      `i` (the "first match" argindex convention shared with the CPU
+//      kernel — note upstream's CUDA kernel races and returns *some* arg
+//      index, but mirroring CPU semantics on the GPU is the conservative
+//      port choice and costs only the int64_t atomic).
+//
+// After both kernels complete, the host clears the sentinel buckets via
+// `out.masked_fill_(arg_out == src.size(dim), 0)` so that empty buckets
+// produce `0` instead of `numeric_limits::max()`. This is skipped when
+// `out=` is supplied — the caller owns the buffer.
+
+// Value-pass kernel.
+template <typename scalar_t>
+__global__ void scatter_min_value_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    scalar_t* __restrict__ out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicMin(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// Arg-pass kernel. Reads `out_data` (now holding the per-bucket minima from
+// the value pass) and atomically lowers `arg_out_data[linear_offset]` to `e`
+// (the position within the reduction axis) whenever `src[i] == out[j]`.
+template <typename scalar_t>
+__global__ void scatter_min_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t e = (thread_idx / K) % E;
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    const int64_t j = b * N * K + idx * K + k;
+    // Equality compared bit-exactly. For `at::Half` / `at::BFloat16`, the
+    // `__half`/`__nv_bfloat16` operator overloads from `cuda_fp16.hpp` /
+    // `cuda_bf16.hpp` conflict with the built-in `arithmetic ==` once
+    // `c10::Half` is convertible to both — so we cast through the underlying
+    // bit pattern (`.x`) for half-precision types and use the natural
+    // operator for all other dtypes. Bit-exact equality is what we want
+    // here: the value pass wrote a specific bit pattern, and we are
+    // checking whether `src[i]` has that same bit pattern.
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[j].x;
+    } else {
+      match = src_data[thread_idx] == out_data[j];
+    }
+    if (match) {
+      atomicMin(arg_out_data + j, e);
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_min (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_min (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_min (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_min (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_min (CUDA): dim out of range");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  const int64_t E = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_min (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninitialized, then fill per-dtype with
+    // `std::numeric_limits<scalar_t>::max()`. We can't use `at::full` with
+    // a single host `Scalar` because the conversion of `f64 max` to e.g.
+    // int8_t would saturate/overflow; the per-dtype dispatch picks the
+    // correct `max()` for each scalar. (`std::numeric_limits` has
+    // specializations for `at::Half` and `at::BFloat16` provided by
+    // PyTorch via `<c10/util/Half.h>` / `<c10/util/BFloat16.h>`.)
+    out = at::empty(sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "scatter_min_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E = src.size(dim)`. Even when `out=` is supplied, `arg_out` is fresh
+  // (the schema returns it; the caller has no way to pre-allocate it).
+  auto arg_out =
+      at::full(out.sizes(), E, index_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors at all: every bucket is "empty" -> sentinel-mask to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_min_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // Value pass.
+        scatter_min_value_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        // Arg pass. Same stream -> the value-pass writes are visible.
+        scatter_min_arg_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, arg_out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E`, no contributor wrote to that
+  // bucket, so `out` still holds `numeric_limits::max()`. Reset to `0` to
+  // match the CPU kernel's contract. Only do this when we allocated `out`
+  // ourselves — if `out=` was provided, the caller's pre-existing values in
+  // empty buckets must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -270,6 +479,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(scatter_sum_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
          TORCH_FN(scatter_mul_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -93,6 +93,36 @@ PYG_API at::Tensor scatter_mean(const at::Tensor& src,
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_min"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_min: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_min: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_min", "")
+                       .typed<decltype(scatter_min)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
@@ -103,6 +133,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_mean(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_min(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -49,6 +50,34 @@ PYG_API at::Tensor scatter_mul(
 // When `out` is provided, the accumulation happens in the caller's buffer
 // (no zero-init), matching the upstream `scatter_sum` contract.
 PYG_API at::Tensor scatter_mean(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+// Reduces all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim` using a minimum reduction, and returns
+// both the per-bucket minimum value and the source position that produced
+// it (`arg_out`).
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::max()` so that the running min is updated
+// on the first contributing element. Empty buckets (no contributing source
+// element) are reset to `0` after the reduction loop; the matching slot in
+// `arg_out` keeps the sentinel value `src.size(dim)` (one past the last
+// valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state and the caller is responsible for any non-default starting value.
+// This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties. The CUDA kernel is not guaranteed to match on ties (any valid
+// argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
     const at::Tensor& src,
     const at::Tensor& index,
     int64_t dim = -1,

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -439,6 +439,36 @@ def scatter_mean(
     return torch.ops.pyg.scatter_mean(src, index, dim, out, dim_size)
 
 
+def scatter_min(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)`` where ``argindex[i]`` is the index
+    along ``dim`` of the source element that contributed to ``values[i]``.
+    Empty buckets yield value ``0`` and argindex ``src.size(dim)`` (sentinel).
+    Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.scatter_min(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -681,6 +711,7 @@ __all__ = [
     'scatter_add',
     'scatter_mul',
     'scatter_mean',
+    'scatter_min',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import os.path as osp
 from importlib.util import find_spec
@@ -12,6 +13,7 @@ from pyg_lib import get_home_dir
 
 
 def withSeed(func: Callable) -> Callable:
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         torch.manual_seed(12345)
         func(*args, **kwargs)

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 
 def _broadcast_index(
@@ -835,5 +835,445 @@ def test_scatter_mean_backward_gradcheck_with_dim_size(device):
 
     def fn(s):
         return pyg_lib.ops.scatter_mean(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter_min
+# ---------------------------------------------------------------------------
+
+
+def _scatter_min_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference implementation of :func:`scatter_min`.
+
+    Returns a tuple ``(value, argindex)``:
+      * ``value[j]`` is the minimum of ``src`` entries whose broadcast index
+        equals ``j`` along ``dim``.
+      * ``argindex[j]`` is the position along ``dim`` of *any* entry that
+        attains that minimum. On CPU the upstream contract is first-match;
+        we match that here.
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (the upstream sentinel).
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Walk over ``src`` along ``dim`` and, for each output position, track the
+    # running min and the position of its first-match.
+    # We implement this with a per-element Python loop for clarity.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            # Recover the multi-index for the "other" dims.
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                # First contribution into this bucket; always take it.
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v < cur):  # strict less: first-match tie-break
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    # Empty buckets: value == 0 (already initialized), argindex stays at
+    # sentinel == src.size(dim).
+    return value, argindex
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_min_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        # A unique-value integer fixture covering the chosen buckets.
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        # Build a unique-valued float tensor via a randperm permutation.
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(value, ref_value, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_neg1(device):
+    # Unique values along dim=-1 ensure deterministic argindex.
+    torch.manual_seed(0)
+    src = (torch.randperm(3 * 8, device=device).to(torch.float32) - 12).view(
+        3,
+        8,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_nonneg(device):
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(3 * 6 * 5, device=device).to(torch.float32) - 40
+    ).view(3, 6, 5)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=1)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=1)
+    assert value.size() == (3, 3, 5)
+    assert arg.size() == (3, 3, 5)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.scatter_min(
+        src,
+        index,
+        dim=-1,
+        dim_size=6,
+    )
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Empty trailing buckets at positions 2, 4, 5 must have value 0 and
+    # argindex == sentinel.
+    empty_positions = [2, 4, 5]
+    for p in empty_positions:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_scatter_min_empty_bucket_in_middle(device):
+    """Empty buckets anywhere (not just trailing) yield value 0 + sentinel
+    argindex.
+    """
+    # index skips bucket 2 entirely.
+    src = torch.tensor(
+        [[1.0, 2.0, 3.0],
+         [-1.0, 4.0, 5.0],
+         [6.0, -3.0, 7.0],
+         [8.0, 9.0, -10.0],
+         [11.0, 12.0, 13.0],
+         [14.0, 15.0, 16.0]],
+        device=device,
+    )  # yapf: disable
+    index = torch.tensor([0, 1, 0, 1, 3, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=4)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0, dim_size=4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 2 has no contributors -> zero row + sentinel arg row.
+    torch.testing.assert_close(
+        value[2],
+        torch.zeros(3, device=device),
+    )
+    torch.testing.assert_close(
+        arg[2],
+        torch.full((3,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_scatter_min_out_overrides_init_buffer(device):
+    """When ``out`` is provided, the op writes the per-bucket min into it
+    (per the contract: out is initialized to numeric_limits::max() internally,
+    callers supplying ``out`` are responsible for any non-default initial
+    state).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    # Pre-fill out with something that should NOT contaminate the min — the
+    # per-bucket min of src is strictly less than these values for every
+    # non-empty bucket.
+    out = torch.full((4,), 100.0, device=device)
+    result_value, result_arg = pyg_lib.ops.scatter_min(
+        src,
+        index,
+        dim=0,
+        out=out,
+    )
+
+    # The non-empty buckets should match the reference exactly.
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0, dim_size=4)
+    # Non-empty buckets: 0 (idx 0,2), 1 (idx 1,3,4), 3 (idx 5).
+    # Bucket 2 is empty; with out=, the upstream contract leaves the caller's
+    # value in place when nothing is written. We only assert the non-empty
+    # buckets match the reference.
+    non_empty = [0, 1, 3]
+    for p in non_empty:
+        torch.testing.assert_close(result_value[p], ref_value[p])
+        torch.testing.assert_close(result_arg[p], ref_arg[p])
+
+
+@withCUDA
+def test_scatter_min_empty_input(device):
+    """An empty source with an empty index yields an all-zero value tensor
+    and an all-sentinel argindex tensor.
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_scatter_min_argindex_ties_returns_valid(device):
+    """Tied values: only assert the returned argindex is *a valid* argmin,
+    not a specific tie-breaker. CUDA atomic ordering is non-deterministic.
+    """
+    # Construct a deliberate tie: indices 0 and 2 both map to bucket 0 with
+    # value 1.0; indices 1 and 4 both map to bucket 1 with value 2.0.
+    src = torch.tensor(
+        [1.0, 2.0, 1.0, 5.0, 2.0, 7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Value tensor must equal the true per-bucket min regardless of tie-break.
+    expected_value = torch.tensor(
+        [1.0, 2.0, 0.0, 7.0],
+        device=device,
+    )
+    torch.testing.assert_close(value, expected_value)
+    # Argindex on bucket 0 must be 0 or 2 (both have value 1.0).
+    assert int(arg[0].item()) in (0, 2)
+    # Argindex on bucket 1 must be one of the value-2.0 positions: 1 or 4.
+    assert int(arg[1].item()) in (1, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == src.size(0)
+    # Bucket 3 has a unique value at position 5.
+    assert int(arg[3].item()) == 5
+    # All non-sentinel argindexes must in fact attain the bucket's min value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == src.size(0):
+            continue  # empty bucket
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'min is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_scatter_min_arg_non_differentiable(device):
+    """The argindex output must have ``requires_grad=False`` even when the
+    value output participates in autograd.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Value tensor must require grad (forwarded from src).
+    assert value.requires_grad
+    # Argindex must NOT require grad — it's non-differentiable.
+    assert not arg.requires_grad
+    # And it must be an integer tensor.
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is non-differentiable and
+    excluded by extracting ``[0]`` from the tuple.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    # Unique-valued src via randperm avoids ties (which would break gradcheck).
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=0)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(2 * 6 * 3, device=device).to(torch.double) - 18)
+        .view(2, 6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=1)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets. Their argindex points at the sentinel (== src.size(dim)) and
+    the ``+1``/``narrow`` backward pattern in the implementation drops that
+    slot — so the gradient w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=-1, dim_size=6)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))


### PR DESCRIPTION
Tuple-returning reduction `(values, argindex)`. CPU is deterministic
first-match via a sequential inner loop with strict `<` comparison. CUDA
runs a two-pass kernel: value pass with `atomicMin` (CAS-loop for
Half/BFloat16/narrow-int/double), then an argindex pass that races to the
smallest valid `e` via `atomicMin` on `int64_t`. Empty buckets reset
values to 0 with the sentinel `arg = src.size(dim)`, which the backward
exploits via the `+1`/`narrow` pattern (gradients to sentinel-tagged
slots land in a synthesized extra slot and are dropped). `argindex` is
marked non-differentiable.

Also: `withSeed` in `pyg_lib.testing` now uses `functools.wraps` so
stacking `@withCUDA` over it preserves the `device` parameter (first
user of the decorator combo).
