### PR TITLE
Add `segment_mean_coo`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -65,6 +65,99 @@ at::Tensor segment_sum_coo_autograd(
   return SegmentSumCOO::apply(src, index, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::segment_mean_coo`.
+//
+// Forward computes the per-bucket mean of `src` at the segment positions
+// in `index`. Backward routes each `grad_out[bucket]` back to every source
+// entry that landed in that bucket, scaled by `1 / count[bucket]`. We do
+// this with the symmetric `gather_coo` (which lifts a per-bucket value to
+// per-entry positions) of `(grad_out / count)`.
+//
+// Storage: we save `index_b` (the post-expand index, contiguous) and a
+// freshly recomputed flat `count` of shape `index_b.sizes()` with the last
+// dim replaced by `N`. Recomputing count at backward time would require
+// re-running the sequential pass; saving it keeps backward O(E + N) instead
+// of O(2E + N). The count is stored flat (no trailing K dims); backward
+// `gather_coo`s it to per-entry positions and unsqueezes for the K dims.
+class SegmentMeanCOO : public torch::autograd::Function<SegmentMeanCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    // Mirror the kernel's broadcast+contiguous so backward sees an index of
+    // shape `src.shape[:index.dim()]`. Also compute the count tensor here
+    // for backward; we run the (cheap) sum-coo-style accumulate-and-count
+    // pass via existing primitives: build a per-entry "ones" tensor along
+    // the dim axis and segment_sum it. That keeps the kernel itself focused
+    // on the mean compute path.
+    const int64_t dim = index.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_mean_coo: index must have at least 1 dimension");
+
+    auto sizes = index.sizes().vec();
+    for (int64_t i = 0; i < index.dim(); ++i)
+      sizes[i] = src.size(i);
+    auto index_b = index.expand(sizes).contiguous();
+
+    auto out = segment_mean_coo(src, index, optional_out, dim_size);
+
+    // Build the flat count tensor with shape `index_b.shape` but last dim
+    // replaced by `out.size(dim)`. We compute it by segment-summing a
+    // `ones`-tensor shaped like `index_b` along the dim axis.
+    auto ones = at::ones(index_b.sizes(), out.options());
+    auto count = segment_sum_coo(ones, index_b, std::nullopt, out.size(dim));
+
+    ctx->save_for_backward({index_b, count});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index_b = saved[0];
+    auto count = saved[1];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    auto grad_in = at::empty(src_shape, grad_out.options());
+
+    // Match upstream `segment_csr.cpp:100-109`: skip the gather/divide when
+    // `grad_in` is empty (e.g. empty `src`); the empty tensor itself is the
+    // correct gradient.
+    if (grad_in.numel() > 0) {
+      gather_coo(grad_out, index_b, grad_in);
+
+      // Lift the per-bucket count to per-entry positions along `dim`, then
+      // broadcast over the trailing K dims by unsqueezing.
+      count = gather_coo(count, index_b, std::nullopt);
+      for (int64_t i = 0; i < grad_out.dim() - index_b.dim(); ++i)
+        count = count.unsqueeze(-1);
+      grad_in.true_divide_(count);
+    }
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is real.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_mean_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  return SegmentMeanCOO::apply(src, index, optional_out, dim_size)[0];
+}
+
 // Autograd Function for `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
@@ -128,6 +221,8 @@ at::Tensor gather_coo_autograd(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
          TORCH_FN(gather_coo_autograd));
 }

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -169,6 +169,167 @@ at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::segment_mean_coo`.
+//
+// Same layout/shape as `segment_sum_coo_kernel`: sequential pass over the
+// sorted-ascending `index`, accumulate runs of equal indices, but ALSO track
+// the per-bucket count and divide at the end. The count tensor is allocated
+// with shape `index.sizes()` with the last dim replaced by `N` (i.e. without
+// the trailing K dims) — this is a flat `B*N` count, matching upstream
+// `segment_coo_cpu.cpp:54-56`. Backward gathers this 1-D-per-row count and
+// `unsqueeze`s along K, so we keep the storage minimal here.
+//
+// `out=` contract: upstream MEAN does **not** honor an accumulate contract
+// (it overwrites buckets touched by `index`). We match that. Buckets not
+// touched by `index` are left at zero (fresh `out`) or untouched (supplied
+// `out`). This means the `out=` form of `segment_mean_coo` is rarely useful
+// directly, but the kernel still accepts it for API symmetry with sum.
+at::Tensor segment_mean_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_mean_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_mean_coo: index must have at least 1 dimension");
+
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_mean_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  // Count storage: shape `index_b.shape` with last dim replaced by `N`. This
+  // is `B*N` flat per the `dim` axis — no trailing K. Allocate as float to
+  // match `out`'s scalar type at division time, but use the same dtype as
+  // `out` so we can re-use the dispatcher branch.
+  auto count_sizes = index_b.sizes().vec();
+  count_sizes[dim] = N;
+  auto count = at::zeros(count_sizes, src_c.options());
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_coo_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* count_data = count.data_ptr<scalar_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+                const int64_t cnt_off = b * N;
+
+                if (E == 0)
+                  continue;
+
+                int64_t cur_idx = index_data[idx_off];
+                int64_t run_start = 0;
+
+                if (K == 1) {
+                  opmath_t acc = static_cast<opmath_t>(0);
+                  for (int64_t e = 0; e < E; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      out_data[out_off + cur_idx] = static_cast<scalar_t>(acc);
+                      count_data[cnt_off + cur_idx] =
+                          static_cast<scalar_t>(e + 1 - run_start);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        acc = static_cast<opmath_t>(0);
+                        run_start = e + 1;
+                      }
+                    }
+                  }
+                } else {
+                  std::vector<opmath_t> acc(K, static_cast<opmath_t>(0));
+                  for (int64_t e = 0; e < E; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      for (int64_t k = 0; k < K; ++k)
+                        out_data[out_off + cur_idx * K + k] =
+                            static_cast<scalar_t>(acc[k]);
+                      count_data[cnt_off + cur_idx] =
+                          static_cast<scalar_t>(e + 1 - run_start);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        for (int64_t k = 0; k < K; ++k)
+                          acc[k] = static_cast<opmath_t>(0);
+                        run_start = e + 1;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Buckets that received no entries have count == 0; clamp to 1 to avoid
+  // division by zero (the corresponding `out` slot is already 0 or
+  // user-supplied and untouched).
+  count.masked_fill_(count < static_cast<int64_t>(1), 1);
+
+  // Broadcast count along trailing K dims by unsqueezing once per trailing
+  // dim of `src` past `index.dim()`.
+  auto count_b = count;
+  for (int64_t i = 0; i < src_c.dim() - index_b.dim(); ++i)
+    count_b = count_b.unsqueeze(-1);
+  out.div_(count_b);
+
+  return out;
+}
+
 // CPU implementation of `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
@@ -269,6 +430,8 @@ at::Tensor gather_coo_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -326,6 +326,216 @@ at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
 }
 
 // ============================================================================
+// `segment_mean_coo` — Commit 7.
+//
+// Strategy: reuse the `segment_sum_coo_*` kernels to compute the per-bucket
+// sum into `out`, then run a tiny counting kernel that atomically increments
+// a per-bucket `int64_t` count buffer, then divide `out` by `count` (clamped
+// at 1 to avoid div-by-zero for empty buckets).
+//
+// Count storage choice: a **separate `int64_t` buffer** of shape
+// `[..., out.size(dim)]` (leading dims match `index`, the reduction axis is
+// `N = out.size(dim)`). Upstream `pytorch_scatter` (`segment_coo_cuda.cu:
+// 199-203, 264-278`) instead reuses the `arg_out` slot typed as the input's
+// `scalar_t` and runs the sum kernel with a `nullptr` src to get count-of-1
+// behavior. We deviate for two reasons:
+//
+//   1. Precision: counting in `Half`/`BFloat16` saturates at the dtype's
+//      max representable integer (2048 / 256 for `Half`/`BFloat16`).
+//   2. Simplicity: a dedicated 1-thread-per-`src`-row counting kernel is
+//      trivial and avoids the `HAS_VAL=false` plumbing.
+//
+// Count tensor is `int64_t`; `atomicAdd(int64_t*, int64_t)` is provided in
+// `atomics.cuh`.
+
+// Counting kernel — one thread per `index` entry, atomically increments
+// `count[batch_offset + idx]`. `count` has shape `[B, N]` (leading dims of
+// `index` with the reduction axis replaced by `N = out.size(dim)`).
+__global__ void segment_mean_coo_count_cuda_kernel(
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    int64_t* __restrict__ count_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    // `(row_idx / D) * N + idx` picks the count slot inside the per-batch
+    // count row, matching the `out_idx` arithmetic in `segment_sum_coo`.
+    int count_idx = (row_idx / D) * static_cast<int>(N) + static_cast<int>(idx);
+    atomicAdd(count_data + count_idx, static_cast<int64_t>(1));
+  }
+}
+
+at::Tensor segment_mean_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_mean_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_mean_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_mean_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_mean_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (same rule as the sum
+  // kernel; matches upstream `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Match `segment_sum_coo`'s `out=` handling: caller owns the buffer, no
+    // zero-init. The mean semantics with `out=` thus combine the caller's
+    // initial value with the new sum before division (mirrors upstream
+    // `segment_coo_cuda.cu:175-179, 264-278`).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_mean_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      // Auto-infer from the last (sorted-ascending) index along `dim`.
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Zero-init so the `atomicAdd` sum pass starts from a clean slate.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (index_c.numel() == 0) {
+    return out;
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  // Count buffer: shape `[..., N]` (leading dims of `index`, reduction axis
+  // replaced by `N`). Same shape rule upstream uses for the MEAN-reuse
+  // `arg_out` (`segment_coo_cuda.cu:200-203`).
+  auto count_sizes = index_c.sizes().vec();
+  count_sizes[dim] = N;
+  auto count = at::zeros(count_sizes, index_c.options());  // `int64_t`
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // -------- Pass 1: sum into `out`. Reuses the `segment_sum_coo_*` kernels.
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_sum_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Same `TB` ladder as `segment_sum_coo` — picks the best
+          // per-thread inner-loop length for the average run.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+      });
+
+  // -------- Pass 2: count into `count`. One thread per `index` entry.
+  {
+    const int T = threads();
+    const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+    segment_mean_coo_count_cuda_kernel<<<B, T, 0, stream>>>(
+        index_info, count.data_ptr<int64_t>(), E, N);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  // -------- Pass 3: divide. Clamp count to >=1 to keep zero-count buckets
+  // unchanged (mirrors upstream `arg_out.masked_fill_(arg_out < 1, 1)` at
+  // `segment_coo_cuda.cu:269-270`). Then unsqueeze trailing K dims and
+  // broadcast-divide.
+  count.clamp_min_(1);
+  auto count_b = count;
+  for (int64_t i = dim + 1; i < out.dim(); ++i) {
+    count_b = count_b.unsqueeze(-1);
+  }
+  if (out.is_floating_point()) {
+    out.true_divide_(count_b);
+  } else {
+    out.div_(count_b, "floor");
+  }
+
+  return out;
+}
+
+// ============================================================================
 // `gather_coo` — Commit 6.
 //
 // Trivial gather: `out[i] = src[index[i]]` along `dim = index.dim() - 1`,
@@ -473,6 +683,8 @@ at::Tensor gather_coo_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -34,6 +34,34 @@ PYG_API at::Tensor segment_sum_coo(const at::Tensor& src,
   return op.call(src, index, out, dim_size);
 }
 
+PYG_API at::Tensor segment_mean_coo(const at::Tensor& src,
+                                    const at::Tensor& index,
+                                    const std::optional<at::Tensor>& out,
+                                    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_mean_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_mean_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_mean_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_mean_coo", "")
+                       .typed<decltype(segment_mean_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
 PYG_API at::Tensor gather_coo(const at::Tensor& src,
                               const at::Tensor& index,
                               const std::optional<at::Tensor>& out) {
@@ -64,6 +92,9 @@ PYG_API at::Tensor gather_coo(const at::Tensor& src,
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::segment_sum_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_mean_coo(Tensor src, Tensor index, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -27,6 +27,26 @@ PYG_API at::Tensor segment_sum_coo(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Computes the mean of all values from `src` at the segment positions
+// specified in `index` along the implicit axis `dim = index.dim() - 1`. The
+// per-bucket count is computed internally during the sequential pass and
+// applied as a final division.
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `index.dim() - 1`. The `index` tensor must be
+// **sorted ascending** along that axis.
+//
+// `out=` contract: unlike `segment_sum_coo` (which accumulates), the mean
+// kernel **overwrites** `out` at every bucket touched by `index` (matches
+// upstream `segment_coo_cpu.cpp` for the MEAN reducer). Buckets not visited
+// by any `index` entry are left at their original value when `out=` is
+// supplied, or zero-initialized otherwise.
+PYG_API at::Tensor segment_mean_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 // Gathers values from `src` at positions specified in `index`, along the
 // implicit axis `dim = index.dim() - 1`. Concretely:
 //

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -532,6 +532,33 @@ def segment_sum_coo(
 segment_add_coo = segment_sum_coo
 
 
+def segment_mean_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``mean`` as the reduction. Empty
+    buckets yield zero.
+
+    The reduction axis is ``index.dim() - 1``. For integer dtypes,
+    floor-division is used.
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis. Auto-inferred from :obj:`index.max() + 1` if
+            :obj:`None`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_mean_coo(src, index, out, dim_size)
+
+
 def gather_coo(
     src: Tensor,
     index: Tensor,
@@ -798,6 +825,7 @@ __all__ = [
     'scatter_max',
     'segment_sum_coo',
     'segment_add_coo',
+    'segment_mean_coo',
     'gather_coo',
     'spline_basis',
     'spline_weighting',

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -52,6 +52,37 @@ def _segment_sum_coo_ref(
     return out
 
 
+def _segment_mean_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_mean_coo`.
+
+    Computes per-bucket sums via :func:`_segment_sum_coo_ref`, then divides by
+    per-bucket counts. Counts for empty buckets are masked to 1 so empty
+    buckets yield exactly 0 (matching upstream semantics).
+    """
+    dim = index.dim() - 1
+    summed = _segment_sum_coo_ref(src, index, dim_size=dim_size)
+    if dim_size is None:
+        dim_size = summed.size(dim)
+    # Count per bucket: scatter-add of ones along the COO dim.
+    counts = torch.zeros(dim_size, dtype=src.dtype, device=src.device)
+    if index.numel() > 0:
+        counts.scatter_add_(
+            0,
+            index.reshape(-1),
+            torch.ones(index.numel(), dtype=src.dtype, device=src.device),
+        )
+    # Shape counts for broadcasting along ``dim``.
+    shape = [1] * summed.dim()
+    shape[dim] = dim_size
+    counts = counts.view(shape)
+    safe_counts = counts.masked_fill(counts == 0, 1)
+    return summed / safe_counts
+
+
 def _gather_coo_ref(
     src: torch.Tensor,
     index: torch.Tensor,
@@ -464,3 +495,199 @@ def test_gather_coo_gradgradcheck(device):
         return pyg_lib.ops.gather_coo(s, index)
 
     assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_mean_coo_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_1d(device):
+    src = torch.randn(8, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_k1_small_trailing(device):
+    """K==1 path: no trailing feature dims (purely 1-D)."""
+    src = torch.randn(10, device=device)
+    index = torch.tensor([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert out.size(-1) == 4
+    expected = _segment_mean_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_dim_size_explicit(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _segment_mean_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Trailing empty buckets should be exactly zero (count masked to 1).
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+
+
+@withCUDA
+def test_segment_mean_coo_empty_rows_in_middle(device):
+    """Row 1 has no entries — its output must be zero (count = 0 -> 0/1)."""
+    src = torch.randn(5, 4, device=device)
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_mean_coo_empty_input(device):
+    """Empty source and index — output is all-zero of the requested shape."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` -> empty trailing rows."""
+    src = torch.randn(
+        5,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index, dim_size=5)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_empty_input(device):
+    """Empty ``src`` and ``index`` — exercises the ``numel() > 0`` guard in
+    backward. The forward is well-defined (all-zero output); the backward
+    must not crash on the empty grad and should return a correctly-shaped
+    zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=3)
+    assert out.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on an empty grad.
+    out.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))


### PR DESCRIPTION
Like `segment_sum_coo`, plus division by per-bucket counts. CPU stores
the count as a 1-D tensor sized to `out.size(dim)`, masked-fills the zero
positions to 1 (so empty buckets yield 0 rather than NaN), and broadcasts
along trailing K dims. CUDA keeps the count in a dedicated `int64_t`
buffer (rather than upstream's trick of reusing `arg_out` storage typed
as `scalar_t`) to avoid precision saturation on Half/BFloat16.

`SegmentMeanCOO::backward` wraps the whole body in `if (grad_in.numel()
> 0)` — mirrors the upstream `segment_csr.cpp:100-109` guard and avoids
crashes when the input is empty.
