### PR TITLE
Add `segment_min_coo`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -158,6 +158,111 @@ at::Tensor segment_mean_coo_autograd(
   return SegmentMeanCOO::apply(src, index, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::segment_min_coo`.
+//
+// COO ops fix the reduction axis at `dim = index.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `ScatterMin`).
+//
+// Backward formula (mirrors `ScatterMin` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket min and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+//
+// Adapted for COO: `dim = index.dim() - 1`. `arg_out` indexes positions
+// along that same `dim` (the reduction axis, which is the last axis of the
+// broadcast `index_b`). Because `arg_out` is shaped like `out` (which has
+// trailing K dims from `src` that `index_b` does not), we must broadcast
+// `arg_out` over the trailing K axes before the `scatter_` call so that
+// `grad_in.scatter_(dim, arg_out_b, grad_out)` lines up per (B, N, K).
+class SegmentMinCOO : public torch::autograd::Function<SegmentMinCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = index.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_min_coo: index must have at least 1 dimension");
+
+    // Mirror the kernel's broadcast+contiguous so backward sees an index of
+    // shape `src.shape[:index.dim()]`. We save `index_b` not because backward
+    // uses it directly (only `arg_out` and `src_shape` are needed), but for
+    // consistency with the rest of the family and to make any future
+    // backward refactor (e.g. via `gather_coo`) trivial.
+    auto sizes = index.sizes().vec();
+    for (int64_t i = 0; i < index.dim(); ++i)
+      sizes[i] = src.size(i);
+    auto index_b = index.expand(sizes).contiguous();
+
+    auto result = segment_min_coo(src, index, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({index_b, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `index_b`, kept for parity with other COO Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = SegmentMinCOO::apply(src, index, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
@@ -223,6 +328,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_sum_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
          TORCH_FN(gather_coo_autograd));
 }

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -330,6 +330,166 @@ at::Tensor segment_mean_coo_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_min_coo`.
+//
+// Same (B, E, K) layout as `segment_sum_coo_kernel` with `dim = index.dim() -
+// 1`. Sequential pass over the sorted-ascending `index`: maintain a running
+// minimum value and its first-match argindex per bucket run. Two output
+// tensors:
+//   * `out`: the per-bucket minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (matched against the sentinel in `arg_out`,
+//     mirrors `scatter_min_kernel`).
+//   * `arg_out`: the source position that produced each per-bucket min,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner E loop is sequential per `B` slice and uses
+// strict `<` on the comparison, so on ties the kernel preserves
+// *first-match* semantics. Parallelism is only over the leading `B` dim
+// where slices write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_min_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_min_coo: index must have at least 1 dimension");
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream
+  // `segment_coo_cpu.cpp:19-22`). Then force contiguous for the linear scan.
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_min_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_coo_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dim only. The inner E loop must
+        // remain sequential to preserve first-match argindex semantics on
+        // tied source values within a bucket run.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+
+                if (E == 0)
+                  continue;
+
+                // Sequential pass over the sorted-ascending `index` row.
+                // For each element, look up the current bucket's running
+                // min/argindex (already in `out`/`arg_out`) and update
+                // when the new value is strictly smaller (first-match).
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[idx_off + e];
+                  if (K == 1) {
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
@@ -432,6 +592,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_sum_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -535,6 +535,405 @@ at::Tensor segment_mean_coo_kernel(
   return out;
 }
 
+// Per-thread (register-level) `min` for the warp-tree and broadcast inner
+// loops. We do **not** use the built-in `<` operator on `at::Half` /
+// `at::BFloat16`: when `cuda_fp16.hpp` is included alongside `c10::Half`,
+// both an `operator<(__half, __half)` and the built-in `arithmetic <
+// arithmetic` participate in overload resolution and nvcc rejects the call as
+// ambiguous (same reason `atomicMinHalf` in `atomics.cuh` compares via
+// `static_cast<float>`). We dispatch on the dtype: half-precision goes through
+// `float`; everything else uses the natural operator.
+template <typename scalar_t>
+static inline __device__ scalar_t device_min(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) < static_cast<float>(b) ? a : b;
+  } else {
+    return a < b ? a : b;
+  }
+}
+
+// ============================================================================
+// `segment_min_coo` — Commit 8.
+//
+// Two CUDA kernels, launched on the same stream so completion ordering is
+// implicit:
+//
+//   1. Value pass — same structure as `segment_sum_coo`:
+//        * K==1: `segment_min_coo_cuda_kernel<scalar_t>` with `SHFL_UP_SYNC`
+//          warp-tree reduction over `val` only. The shuffle does **not**
+//          propagate `(value, idx)` pairs — argindex is assigned in a
+//          separate post-pass. At run boundaries the tail lane writes via
+//          `atomicMin(out_data + out_idx, val)` (CAS-loop helper from
+//          commit 4 in `atomics.cuh`).
+//        * K>1: `segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>` with
+//          the same `TB ∈ {4, 8, 16, 32}` ladder as `segment_sum_coo`.
+//
+//   2. Arg pass — `segment_min_coo_arg_cuda_kernel<scalar_t>` (and a
+//      broadcast variant for K>1) re-scans `src` and, where `src[i] ==
+//      out[bucket]`, performs `atomicMin(arg_out + bucket, i_within_dim)`
+//      over `int64_t`. Initialising `arg_out` to the sentinel
+//      `src.size(dim)` makes any valid contributor win the CAS and produces
+//      deterministic "first match" semantics (mirrors `scatter_min`'s
+//      arg pass).
+//
+// After both kernels: when we allocated `out` ourselves, we clear empty
+// buckets via `out.masked_fill_(arg_out == src.size(dim), 0)` so empty
+// buckets produce `0` instead of `numeric_limits::max()`.
+
+// Value-pass K==1 kernel. Mirrors `segment_sum_coo_cuda_kernel` but reduces
+// via `min` and writes via `atomicMin`. The shuffle propagates `val` only.
+template <typename scalar_t>
+__global__ void segment_min_coo_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int lane_idx = row_idx & (WARP_SIZE - 1);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int64_t next_idx;
+    int out_idx = (row_idx / D) * N + idx;
+
+    scalar_t val = src_data[row_idx];
+    scalar_t tmp;
+
+#pragma unroll
+    for (int i = 1; i < WARP_SIZE; i *= 2) {
+      // Warp-tree min reduction: same control flow as the sum kernel, but
+      // the per-pair update is `val = min(val, tmp)`. Argindex is NOT
+      // propagated through the shuffle — it is reconstructed in the arg
+      // pass by matching `src[i] == out[bucket]`.
+      tmp = SHFL_UP_SYNC(FULL_MASK, val, i);
+      next_idx = SHFL_UP_SYNC(FULL_MASK, idx, i);
+      if (lane_idx >= i && row_idx / D == (row_idx - i) / D) {
+        if (idx == next_idx) {
+          val = device_min(val, tmp);
+        }
+      }
+    }
+
+    // Tail-of-run lane writes via `atomicMin`. Conditions identical to the
+    // sum kernel: last lane in warp, outer-batch boundary, or next-row
+    // index differs.
+    next_idx = SHFL_DOWN_SYNC(FULL_MASK, idx, 1);
+    if (lane_idx == WARP_SIZE - 1 || row_idx / D != (row_idx + 1) / D ||
+        idx != next_idx) {
+      atomicMin(out_data + out_idx, val);
+    }
+  }
+}
+
+// Value-pass K>1 broadcast kernel. Mirrors
+// `segment_sum_coo_broadcast_cuda_kernel` but the per-thread accumulator is
+// `min` instead of `sum`, and the cross-thread atomic write is `atomicMin`.
+template <typename scalar_t, int TB>
+__global__ void segment_min_coo_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int D = index_info.sizes[index_info.dims - 1];
+  int E_1 = E / D;
+  int E_2 = (D - 1) + TB - ((D - 1) % TB);
+
+  int row_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  int col_idx = blockIdx.y * blockDim.x + threadIdx.x;
+
+  int dim_start = (row_idx * TB) / E_2;
+  int row_start = (row_idx * TB) % E_2;
+
+  if (dim_start < E_1 && col_idx < K) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        dim_start * D + row_start, index_info);
+    int64_t idx1 = index_info.data[offset];
+    int64_t idx2;
+
+    scalar_t val = src_data[K * (dim_start * D + row_start) + col_idx];
+
+#pragma unroll
+    for (int i = 1; i < TB; ++i) {
+      if (row_start + i >= D)
+        break;
+
+      idx2 =
+          index_info.data[offset + i * index_info.strides[index_info.dims - 1]];
+      if (idx1 == idx2) {
+        scalar_t cand = src_data[K * (dim_start * D + row_start + i) + col_idx];
+        val = device_min(val, cand);
+      } else {
+        atomicMin(out_data + (dim_start * N + idx1) * K + col_idx, val);
+        val = src_data[K * (dim_start * D + row_start + i) + col_idx];
+      }
+      idx1 = idx2;
+    }
+
+    atomicMin(out_data + (dim_start * N + idx1) * K + col_idx, val);
+  }
+}
+
+// Arg-pass K==1 kernel. Re-scans `src` and lowers `arg_out[bucket]` to
+// `row_idx % D` (position within the reduction axis) where `src[i] ==
+// out[bucket]`. Uses `atomicMin` so the *smallest* `e` wins on ties —
+// matches `scatter_min_arg_cuda_kernel`'s deterministic semantics.
+template <typename scalar_t>
+__global__ void segment_min_coo_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx = (row_idx / D) * static_cast<int>(N) + static_cast<int>(idx);
+
+    // Bit-exact equality. For `at::Half` / `at::BFloat16` we cast through
+    // `.x` for the same reason as `scatter_min_arg_cuda_kernel` (see the
+    // detailed comment there). The value pass wrote a specific bit pattern;
+    // we are checking for that exact pattern in `src`.
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[row_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[row_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+// Arg-pass K>1 broadcast kernel. One thread per `(row, col)` — re-reads
+// `out[bucket, col]` and lowers `arg_out[bucket, col]` to `row_idx % D` on
+// match.
+template <typename scalar_t>
+__global__ void segment_min_coo_arg_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < static_cast<int>(E) && col_idx < static_cast<int>(K)) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx =
+        ((row_idx / D) * static_cast<int>(N) + static_cast<int>(idx)) *
+            static_cast<int>(K) +
+        col_idx;
+
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[thread_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_min_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_min_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_min_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_min_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream convention;
+  // matches the sum/mean kernels above and `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  // `E_dim = src.size(dim)` is the sentinel value for `arg_out` (matches
+  // `scatter_min`'s sentinel). It is also the per-row D of `src` along the
+  // reduction axis.
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no init. The min semantics with `out=` thus
+    // combine the caller's initial value with the computed minima via
+    // `atomicMin` (matches upstream `segment_coo_cuda.cu:175-179`).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_min_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninit then fill with per-dtype `max()`. Same rationale as
+    // `scatter_min_kernel` (see `scatter_kernel.cu`): `at::full` with a
+    // single host `Scalar` can't represent each dtype's max correctly.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_min_coo_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E_dim = src.size(dim)`. Even when `out=` is supplied, `arg_out` is
+  // fresh (the schema returns it; the caller has no way to pre-allocate).
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          index_c.options().dtype(at::ScalarType::Long));
+
+  if (index_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors at all -> every bucket is empty; reset to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // -------- Value pass.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_min_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Same `TB` ladder as `segment_sum_coo`.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+
+        // -------- Arg pass. Same stream -> value-pass writes visible.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_min_coo_arg_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, index_info, out_data, arg_out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E * K + T - 1) / T));
+          segment_min_coo_arg_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data,
+                                    arg_out_data, E, K, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that bucket, so `out` still holds `numeric_limits::max()`. Reset to `0`
+  // to match the CPU kernel's contract. Skipped when `out=` is supplied —
+  // the caller's pre-existing values in empty buckets must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // ============================================================================
 // `gather_coo` — Commit 6.
 //
@@ -685,6 +1084,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_sum_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -62,6 +62,35 @@ PYG_API at::Tensor segment_mean_coo(const at::Tensor& src,
   return op.call(src, index, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_min_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_min_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_min_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_min_coo", "")
+                       .typed<decltype(segment_min_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
 PYG_API at::Tensor gather_coo(const at::Tensor& src,
                               const at::Tensor& index,
                               const std::optional<at::Tensor>& out) {
@@ -96,6 +125,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::segment_mean_coo(Tensor src, Tensor index, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_min_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));
 }

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -42,6 +43,37 @@ PYG_API at::Tensor segment_sum_coo(
 // by any `index` entry are left at their original value when `out=` is
 // supplied, or zero-initialized otherwise.
 PYG_API at::Tensor segment_mean_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+// Reduces all values from `src` into `out` at the segment positions specified
+// in `index` along the implicit axis `dim = index.dim() - 1` using a minimum
+// reduction, and returns both the per-bucket minimum value and the source
+// position that produced it (`arg_out`).
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `index.dim() - 1`. The `index` tensor must be
+// **sorted ascending** along that axis.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::max()` so that the running min is updated
+// on the first contributing element. Empty buckets (no contributing source
+// element) are reset to `0` after the reduction loop; the matching slot in
+// `arg_out` keeps the sentinel value `src.size(dim)` (one past the last
+// valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state (no max-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `<` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
     const at::Tensor& src,
     const at::Tensor& index,
     const std::optional<at::Tensor>& out = std::nullopt,

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -559,6 +559,32 @@ def segment_mean_coo(
     return torch.ops.pyg.segment_mean_coo(src, index, out, dim_size)
 
 
+def segment_min_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. The reduction axis is
+    ``index.dim() - 1``. Empty buckets yield value ``0`` and argindex
+    ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_min_coo(src, index, out, dim_size)
+
+
 def gather_coo(
     src: Tensor,
     index: Tensor,
@@ -826,6 +852,7 @@ __all__ = [
     'segment_sum_coo',
     'segment_add_coo',
     'segment_mean_coo',
+    'segment_min_coo',
     'gather_coo',
     'spline_basis',
     'spline_weighting',

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 # ---------------------------------------------------------------------------
 # Reference implementations
@@ -688,6 +688,389 @@ def test_segment_mean_coo_backward_empty_input(device):
     assert out.size() == (3, 4)
     # Sum to a scalar and backprop — exercises backward on an empty grad.
     out.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_min_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference for :func:`segment_min_coo`.
+
+    COO ops always reduce along ``dim = index.dim() - 1`` with a sorted
+    ``index``. Returns ``(value, argindex)``:
+      * ``value[..., j, ...]`` is the minimum of ``src`` entries whose
+        broadcast index equals ``j`` along ``dim``.
+      * ``argindex[..., j, ...]`` is the position along ``dim`` of the
+        *first-match* min entry (CPU upstream contract).
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (upstream sentinel).
+    """
+    dim = index.dim() - 1
+    bcast_index = _broadcast_index(index, src)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Per-element Python loop over src along the reduction dim, tracking
+    # running min + first-match argindex per output position.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v < cur):
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_min_coo_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    # Sorted ascending index — required by segment_*_coo.
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=6)
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _segment_min_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Trailing empty buckets at positions 4, 5 must have value 0 and
+    # argindex == sentinel.
+    for p in [4, 5]:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_segment_min_coo_empty_rows_in_middle(device):
+    """Empty rows fixture: row 1 has no entries -> value 0 + sentinel arg."""
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    # Row 1 entirely skipped.
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 has no contributors -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_segment_min_coo_empty_input(device):
+    """Empty source + empty index -> all-zero value, all-sentinel arg."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_min_coo_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Bucket 0: positions 0, 1, 2 all with value 1.0 (tied min).
+    # Bucket 1: positions 3, 4 with value 2.0 (tied min).
+    # Bucket 2: empty.
+    # Bucket 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 0, 0, 1, 1, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=4)
+    # Value must equal the true per-bucket min regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Bucket 0 arg must be in {0, 1, 2}; bucket 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Bucket 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must in fact attain the bucket's min value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'min is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_segment_min_coo_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` exercising empty
+    trailing rows. Their argindex points at the sentinel and the
+    ``+1``/``narrow`` backward pattern drops that slot — so the gradient
+    w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index, dim_size=6)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck (row 1 has no entries)."""
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_empty_input(device):
+    """Empty ``src`` and ``index`` — exercises the ``numel() > 0`` guard.
+    Backward must not crash on empty grad and must return a correctly-shaped
+    zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on empty grad.
+    value.sum().backward()
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))


### PR DESCRIPTION
Tuple-returning min reduction over a sorted COO index. CPU is
deterministic first-match via a sequential E-pass with strict `<`. CUDA
keeps the value pass identical in shape to `segment_sum_coo` (K==1 warp
`SHFL_UP_SYNC` + boundary `atomicMin`; K>1 broadcast template with
`TB ∈ {4, 8, 16, 32}`) but the shuffle propagates ONLY the value — the
argindex is set in a separate post-pass kernel that races to the smallest
matching `e` via `atomicMin` on `int64_t`. Empty buckets reset values
to 0 with the sentinel `arg = src.size(dim)`; backward uses the
`+1`/`narrow` pattern from `scatter_min`.
