### PR TITLE
Add `segment_max_coo`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -3,6 +3,8 @@
 
 #include <torch/autograd.h>
 
+#include <tuple>
+
 namespace pyg {
 namespace ops {
 
@@ -238,6 +240,99 @@ at::Tensor scatter_mean_autograd(const at::Tensor& src,
   return ScatterMean::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::scatter_min`.
+//
+// Forward returns `(out, arg_out)`. Only `out` is differentiable; `arg_out`
+// is marked non-differentiable via `ctx->mark_non_differentiable({arg_out})`
+// so PyTorch will not error when callers try to take gradients through it
+// and so gradcheck only probes the value output (convention 8).
+//
+// Backward formula (upstream `pytorch_scatter/csrc/scatter.cpp:184-196`):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket min and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+class ScatterMin : public torch::autograd::Function<ScatterMin> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` so the kernel can index per-K
+    // and so the saved `src_shape` aligns with the (per-position) backward
+    // scatter. Recording this on the autograd graph keeps the broadcast
+    // visible to any upstream graph rewriting, though `index` itself is
+    // non-differentiable.
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto result = scatter_min(src, index_b, dim_norm, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({arg_out});
+    ctx->saved_data["dim"] = dim_norm;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto arg_out = saved[0];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 5 input slots: (src, index, dim, out, dim_size). Only `src` is a
+    // real differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> scatter_min_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = ScatterMin::apply(src, index, dim, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
@@ -251,6 +346,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   // the not-implemented sentinel; the same wrapper handles both paths.
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mean"),
          TORCH_FN(scatter_mean_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_autograd));
 }
 
 // `scatter_mean` has no dedicated CPU/CUDA kernel; it is fully composed of

--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -333,6 +333,100 @@ std::tuple<at::Tensor, at::Tensor> scatter_min_autograd(
   return std::make_tuple(result[0], result[1]);
 }
 
+// Autograd Function for `pyg::scatter_max`.
+//
+// Forward returns `(out, arg_out)`. Only `out` is differentiable; `arg_out`
+// is marked non-differentiable via `ctx->mark_non_differentiable({arg_out})`
+// so PyTorch will not error when callers try to take gradients through it
+// and so gradcheck only probes the value output (convention 8).
+//
+// Backward formula (identical to `scatter_min`; upstream
+// `pytorch_scatter/csrc/scatter.cpp:184-196` is symmetric for max):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket max and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+class ScatterMax : public torch::autograd::Function<ScatterMax> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` so the kernel can index per-K
+    // and so the saved `src_shape` aligns with the (per-position) backward
+    // scatter. Recording this on the autograd graph keeps the broadcast
+    // visible to any upstream graph rewriting, though `index` itself is
+    // non-differentiable.
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto result = scatter_max(src, index_b, dim_norm, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({arg_out});
+    ctx->saved_data["dim"] = dim_norm;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto arg_out = saved[0];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 5 input slots: (src, index, dim, out, dim_size). Only `src` is a
+    // real differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> scatter_max_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = ScatterMax::apply(src, index, dim, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
@@ -348,6 +442,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(scatter_mean_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
          TORCH_FN(scatter_min_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_max"),
+         TORCH_FN(scatter_max_autograd));
 }
 
 // `scatter_mean` has no dedicated CPU/CUDA kernel; it is fully composed of

--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -139,6 +139,105 @@ at::Tensor scatter_mul_autograd(const at::Tensor& src,
   return ScatterMul::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::scatter_mean`.
+//
+// Composite op: forward dispatches to `scatter_sum` twice (numerator over
+// `src` and denominator over a `ones`-tensor sized like `index`) and then
+// divides. Because there is no dedicated CPU/CUDA kernel, the wrapper is
+// registered to `CompositeExplicitAutograd` rather than `Autograd`: that
+// key routes the call here for *all* backends and regardless of whether
+// any input requires grad. `Function::apply` itself decides whether to
+// record on the autograd tape based on input grad state, so this single
+// registration handles both `requires_grad=True` and `requires_grad=False`
+// callers correctly.
+//
+// Backward formula (upstream pytorch_scatter `scatter.cpp:149-160`):
+//
+//   grad_src = (grad_out.gather(dim, index_b)) / count.gather(dim, index_b)
+//
+// where `count` is the broadcast per-bucket count tensor saved from forward.
+class ScatterMean : public torch::autograd::Function<ScatterMean> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` for the sum dispatch and so
+    // backward's `gather` can use it directly.
+    auto index_b = broadcast(index, src, dim_norm);
+
+    // Numerator: per-bucket sum of `src` values.
+    auto out_tensor =
+        scatter_sum(src, index_b, dim_norm, optional_out, dim_size);
+
+    // Denominator: per-bucket count. Use the *original* (non-broadcast)
+    // `index` against a 1-D `ones` of length `index.size(...)`. Upstream
+    // mirrors the same trick to avoid double-counting when `index` is
+    // broadcast across multiple non-`dim` axes. The reduction `dim` for
+    // this auxiliary call is the last axis of `index` if `index` has
+    // fewer dims than `dim_norm` (i.e. `index` is 1-D and the broadcast
+    // adds leading singletons), else `dim_norm`.
+    const int64_t count_dim =
+        index.dim() <= dim_norm ? index.dim() - 1 : dim_norm;
+    auto ones = at::ones(index.sizes(), src.options());
+    auto count = scatter_sum(ones, index, count_dim, std::nullopt,
+                             out_tensor.size(dim_norm));
+    count.masked_fill_(count < 1, 1);
+
+    // Broadcast `count` (1-D along `dim_norm`) up to `out_tensor.shape`
+    // so it aligns for in-place division along the reduction axis.
+    auto count_b = broadcast(count, out_tensor, dim_norm);
+
+    if (out_tensor.is_floating_point()) {
+      out_tensor.true_divide_(count_b);
+    } else {
+      out_tensor.div_(count_b, "floor");
+    }
+
+    // Save the *broadcast* count: backward's `gather(count_b, dim, index_b)`
+    // expects `count` to be shaped like `out_tensor` so gather aligns.
+    ctx->save_for_backward({index_b, count_b});
+    ctx->saved_data["dim"] = dim_norm;
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out_tensor};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index_b = saved[0];
+    const auto count_b = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+
+    // `grad_src[i] = grad_out[index[i]] / count[index[i]]`. Gather both
+    // along `dim` using the broadcast index so per-position counts line up.
+    auto count_gathered = count_b.gather(dim, index_b);
+    auto grad_src = grad_out.gather(dim, index_b).true_divide_(count_gathered);
+
+    // 5 input slots: (src, index, dim, out, dim_size).
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor scatter_mean_autograd(const at::Tensor& src,
+                                 const at::Tensor& index,
+                                 int64_t dim,
+                                 const std::optional<at::Tensor>& optional_out,
+                                 std::optional<int64_t> dim_size) {
+  return ScatterMean::apply(src, index, dim, optional_out, dim_size)[0];
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
@@ -146,6 +245,22 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(scatter_sum_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
          TORCH_FN(scatter_mul_autograd));
+  // `scatter_mean` is also registered to `Autograd` (in addition to
+  // `CompositeExplicitAutograd` below) to silence the runtime warning
+  // emitted when PyTorch finds no Autograd-key kernel and falls back to
+  // the not-implemented sentinel; the same wrapper handles both paths.
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mean"),
+         TORCH_FN(scatter_mean_autograd));
+}
+
+// `scatter_mean` has no dedicated CPU/CUDA kernel; it is fully composed of
+// other dispatcher calls. Registering to `CompositeExplicitAutograd` makes
+// the dispatcher route the call to our wrapper for *every* backend (and
+// regardless of `requires_grad`), so non-grad callers do not fall through
+// to an empty backend kernel slot.
+TORCH_LIBRARY_IMPL(pyg, CompositeExplicitAutograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mean"),
+         TORCH_FN(scatter_mean_autograd));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -1,0 +1,81 @@
+#include "../scatter.h"
+#include "../utils.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::scatter_sum`.
+//
+// The C++ dispatcher returns a fresh tensor (when `out=None`) or the caller's
+// buffer mutated in place (when `out=` is supplied). The `mark_dirty` call in
+// the latter case lets gradcheck pick up the in-place mutation; the actual
+// backward gradient is computed the same way regardless.
+class ScatterSum : public torch::autograd::Function<ScatterSum> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    // Normalize `dim` once so saved metadata is consistent with what backward
+    // sees from `torch.gather`.
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` (records unsqueeze/expand on the
+    // autograd graph so backward can call `.gather` directly).
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto out = scatter_sum(src, index_b, dim_norm, optional_out, dim_size);
+
+    ctx->save_for_backward({index_b});
+    ctx->saved_data["dim"] = dim_norm;
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index_b = saved[0];
+    const auto dim = ctx->saved_data["dim"].toInt();
+
+    // `grad_src[i] = grad_out[index[i]]` — exactly `gather` along `dim`.
+    auto grad_src = grad_out.gather(dim, index_b);
+
+    // 5 input slots: (src, index, dim, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor scatter_sum_autograd(const at::Tensor& src,
+                                const at::Tensor& index,
+                                int64_t dim,
+                                const std::optional<at::Tensor>& optional_out,
+                                std::optional<int64_t> dim_size) {
+  return ScatterSum::apply(src, index, dim, optional_out, dim_size)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/scatter_kernel.cpp
@@ -70,11 +70,82 @@ at::Tensor scatter_sum_autograd(const at::Tensor& src,
   return ScatterSum::apply(src, index, dim, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::scatter_mul`.
+//
+// Backward formula (upstream pytorch_scatter `scatter.cpp:101-112`):
+//
+//   grad_src = (grad_out * out).gather(dim, index_b) / src
+//
+// where `out` is the forward result. At positions where `src == 0`, this
+// expression is ill-defined (0/0 NaN); upstream produces a NaN and then
+// masks it with `masked_fill_(isnan, 0)`. We use `torch::where(src != 0,
+// ..., zeros)` to produce zeros directly without going through NaN.
+class ScatterMul : public torch::autograd::Function<ScatterMul> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim_norm = dim < 0 ? src.dim() + dim : dim;
+
+    // Broadcast `index` up to `src.shape` so that backward's `gather` can
+    // use it directly. Recording the broadcast on the autograd graph keeps
+    // gradient connectivity (though `index` itself is non-differentiable).
+    auto index_b = broadcast(index, src, dim_norm);
+
+    auto out = scatter_mul(src, index_b, dim_norm, optional_out, dim_size);
+
+    // Backward needs `src` (denominator), `index_b` (gather axis), and `out`
+    // (so that `grad_out * out` can be gathered at the contributing indices).
+    ctx->save_for_backward({src, index_b, out});
+    ctx->saved_data["dim"] = dim_norm;
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto src = saved[0];
+    const auto index_b = saved[1];
+    const auto out = saved[2];
+    const auto dim = ctx->saved_data["dim"].toInt();
+
+    // Note: `(grad_out * out)` is the gradient that arrives at the bucket;
+    // gathering it back to the source positions multiplies by the product
+    // of all *other* contributors, which is `out / src`. Hence the divide.
+    auto gathered = (grad_out * out).gather(dim, index_b);
+    auto grad_src = at::where(src != 0, gathered / src, at::zeros_like(src));
+
+    // 5 input slots: (src, index, dim, out, dim_size).
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor scatter_mul_autograd(const at::Tensor& src,
+                                const at::Tensor& index,
+                                int64_t dim,
+                                const std::optional<at::Tensor>& optional_out,
+                                std::optional<int64_t> dim_size) {
+  return ScatterMul::apply(src, index, dim, optional_out, dim_size)[0];
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_autograd));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -65,6 +65,99 @@ at::Tensor segment_sum_coo_autograd(
   return SegmentSumCOO::apply(src, index, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::segment_mean_coo`.
+//
+// Forward computes the per-bucket mean of `src` at the segment positions
+// in `index`. Backward routes each `grad_out[bucket]` back to every source
+// entry that landed in that bucket, scaled by `1 / count[bucket]`. We do
+// this with the symmetric `gather_coo` (which lifts a per-bucket value to
+// per-entry positions) of `(grad_out / count)`.
+//
+// Storage: we save `index_b` (the post-expand index, contiguous) and a
+// freshly recomputed flat `count` of shape `index_b.sizes()` with the last
+// dim replaced by `N`. Recomputing count at backward time would require
+// re-running the sequential pass; saving it keeps backward O(E + N) instead
+// of O(2E + N). The count is stored flat (no trailing K dims); backward
+// `gather_coo`s it to per-entry positions and unsqueezes for the K dims.
+class SegmentMeanCOO : public torch::autograd::Function<SegmentMeanCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    // Mirror the kernel's broadcast+contiguous so backward sees an index of
+    // shape `src.shape[:index.dim()]`. Also compute the count tensor here
+    // for backward; we run the (cheap) sum-coo-style accumulate-and-count
+    // pass via existing primitives: build a per-entry "ones" tensor along
+    // the dim axis and segment_sum it. That keeps the kernel itself focused
+    // on the mean compute path.
+    const int64_t dim = index.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_mean_coo: index must have at least 1 dimension");
+
+    auto sizes = index.sizes().vec();
+    for (int64_t i = 0; i < index.dim(); ++i)
+      sizes[i] = src.size(i);
+    auto index_b = index.expand(sizes).contiguous();
+
+    auto out = segment_mean_coo(src, index, optional_out, dim_size);
+
+    // Build the flat count tensor with shape `index_b.shape` but last dim
+    // replaced by `out.size(dim)`. We compute it by segment-summing a
+    // `ones`-tensor shaped like `index_b` along the dim axis.
+    auto ones = at::ones(index_b.sizes(), out.options());
+    auto count = segment_sum_coo(ones, index_b, std::nullopt, out.size(dim));
+
+    ctx->save_for_backward({index_b, count});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index_b = saved[0];
+    auto count = saved[1];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    auto grad_in = at::empty(src_shape, grad_out.options());
+
+    // Match upstream `segment_csr.cpp:100-109`: skip the gather/divide when
+    // `grad_in` is empty (e.g. empty `src`); the empty tensor itself is the
+    // correct gradient.
+    if (grad_in.numel() > 0) {
+      gather_coo(grad_out, index_b, grad_in);
+
+      // Lift the per-bucket count to per-entry positions along `dim`, then
+      // broadcast over the trailing K dims by unsqueezing.
+      count = gather_coo(count, index_b, std::nullopt);
+      for (int64_t i = 0; i < grad_out.dim() - index_b.dim(); ++i)
+        count = count.unsqueeze(-1);
+      grad_in.true_divide_(count);
+    }
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is real.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_mean_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  return SegmentMeanCOO::apply(src, index, optional_out, dim_size)[0];
+}
+
 // Autograd Function for `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
@@ -128,6 +221,8 @@ at::Tensor gather_coo_autograd(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
          TORCH_FN(gather_coo_autograd));
 }

--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -263,6 +263,111 @@ std::tuple<at::Tensor, at::Tensor> segment_min_coo_autograd(
   return std::make_tuple(result[0], result[1]);
 }
 
+// Autograd Function for `pyg::segment_max_coo`.
+//
+// COO ops fix the reduction axis at `dim = index.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `ScatterMax`).
+//
+// Backward formula (mirrors `ScatterMax` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket max and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+//
+// Adapted for COO: `dim = index.dim() - 1`. `arg_out` indexes positions
+// along that same `dim` (the reduction axis, which is the last axis of the
+// broadcast `index_b`). Because `arg_out` is shaped like `out` (which has
+// trailing K dims from `src` that `index_b` does not), we must broadcast
+// `arg_out` over the trailing K axes before the `scatter_` call so that
+// `grad_in.scatter_(dim, arg_out_b, grad_out)` lines up per (B, N, K).
+class SegmentMaxCOO : public torch::autograd::Function<SegmentMaxCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = index.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_max_coo: index must have at least 1 dimension");
+
+    // Mirror the kernel's broadcast+contiguous so backward sees an index of
+    // shape `src.shape[:index.dim()]`. We save `index_b` not because backward
+    // uses it directly (only `arg_out` and `src_shape` are needed), but for
+    // consistency with the rest of the family and to make any future
+    // backward refactor (e.g. via `gather_coo`) trivial.
+    auto sizes = index.sizes().vec();
+    for (int64_t i = 0; i < index.dim(); ++i)
+      sizes[i] = src.size(i);
+    auto index_b = index.expand(sizes).contiguous();
+
+    auto result = segment_max_coo(src, index, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({index_b, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `index_b`, kept for parity with other COO Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_max_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = SegmentMaxCOO::apply(src, index, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
@@ -330,6 +435,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_mean_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
          TORCH_FN(segment_min_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_coo"),
+         TORCH_FN(segment_max_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
          TORCH_FN(gather_coo_autograd));
 }

--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -158,6 +158,111 @@ at::Tensor segment_mean_coo_autograd(
   return SegmentMeanCOO::apply(src, index, optional_out, dim_size)[0];
 }
 
+// Autograd Function for `pyg::segment_min_coo`.
+//
+// COO ops fix the reduction axis at `dim = index.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `ScatterMin`).
+//
+// Backward formula (mirrors `ScatterMin` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions
+// that produced the per-bucket min and silently drops any contribution
+// from buckets whose `arg_out` is still at the sentinel (empty buckets).
+//
+// Adapted for COO: `dim = index.dim() - 1`. `arg_out` indexes positions
+// along that same `dim` (the reduction axis, which is the last axis of the
+// broadcast `index_b`). Because `arg_out` is shaped like `out` (which has
+// trailing K dims from `src` that `index_b` does not), we must broadcast
+// `arg_out` over the trailing K axes before the `scatter_` call so that
+// `grad_in.scatter_(dim, arg_out_b, grad_out)` lines up per (B, N, K).
+class SegmentMinCOO : public torch::autograd::Function<SegmentMinCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = index.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_min_coo: index must have at least 1 dimension");
+
+    // Mirror the kernel's broadcast+contiguous so backward sees an index of
+    // shape `src.shape[:index.dim()]`. We save `index_b` not because backward
+    // uses it directly (only `arg_out` and `src_shape` are needed), but for
+    // consistency with the rest of the family and to make any future
+    // backward refactor (e.g. via `gather_coo`) trivial.
+    auto sizes = index.sizes().vec();
+    for (int64_t i = 0; i < index.dim(); ++i)
+      sizes[i] = src.size(i);
+    auto index_b = index.expand(sizes).contiguous();
+
+    auto result = segment_min_coo(src, index, optional_out, dim_size);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // normalized `dim`, and the original `src.sizes()` (so the +1/narrow
+    // trick reconstructs the right shape).
+    ctx->save_for_backward({index_b, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `index_b`, kept for parity with other COO Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are
+    // dropped by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  auto result = SegmentMinCOO::apply(src, index, optional_out, dim_size);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
@@ -223,6 +328,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_sum_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
          TORCH_FN(gather_coo_autograd));
 }

--- a/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_coo_kernel.cpp
@@ -1,0 +1,136 @@
+#include "../segment_coo.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::segment_sum_coo`.
+//
+// COO ops fix the reduction axis at `dim = index.dim() - 1`. Forward saves
+// `index` (the kernel handles its own `expand`); backward is exactly
+// `gather_coo(grad_out, index)` — the symmetric-pair inverse of forward.
+//
+// `out=` contract: the C++ dispatcher accumulates into the caller's buffer
+// when `out=` is supplied. `mark_dirty` lets gradcheck pick up the in-place
+// mutation; the backward gradient itself is computed the same way regardless.
+class SegmentSumCOO : public torch::autograd::Function<SegmentSumCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out,
+                               std::optional<int64_t> dim_size) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = segment_sum_coo(src, index, optional_out, dim_size);
+
+    // Save `index` for backward's `gather_coo` call. The gather kernel
+    // applies the same `expand` convention, so we save the *original*
+    // (possibly pre-broadcast) `index`.
+    ctx->save_for_backward({index});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index = saved[0];
+
+    // `grad_src[..., e, ...] = grad_out[..., index[..., e], ...]` — exactly
+    // what `gather_coo` computes along `dim = index.dim() - 1`.
+    auto grad_src = gather_coo(grad_out, index, std::nullopt);
+
+    // 4 input slots: (src, index, out, dim_size). Only `src` is a real
+    // differentiable tensor; the rest get undefined-Tensor grads.
+    return {grad_src, at::Tensor(), at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_sum_coo_autograd(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  return SegmentSumCOO::apply(src, index, optional_out, dim_size)[0];
+}
+
+// Autograd Function for `pyg::gather_coo`.
+//
+// COO ops fix the gather axis at `dim = index.dim() - 1`. Forward saves
+// `index` and `src.size(dim)`; backward is exactly `segment_sum_coo` with
+// the saved `dim_size`, deposited into a freshly allocated `zeros(src_shape)`
+// buffer via the `out=` accumulate contract.
+class GatherCOO : public torch::autograd::Function<GatherCOO> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = gather_coo(src, index, optional_out);
+
+    // Backward needs `index` (where each output position pulled from), the
+    // original `src.sizes()` (to allocate the right-shaped `grad_in`), and
+    // `src.size(dim)` (passed as `dim_size` to `segment_sum_coo`).
+    const int64_t dim = index.dim() - 1;
+    ctx->save_for_backward({index});
+    ctx->saved_data["src_shape"] = src.sizes();
+    ctx->saved_data["src_size_dim"] = src.size(dim);
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto index = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+    const int64_t src_size_dim = ctx->saved_data["src_size_dim"].toInt();
+
+    // Allocate the gradient buffer at `src.shape` and use the `out=`
+    // accumulate contract of `segment_sum_coo` to deposit each `grad_out`
+    // entry at its source position. This is the inverse of forward.
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    segment_sum_coo(grad_out, index, /*out=*/grad_in,
+                    /*dim_size=*/src_size_dim);
+
+    // 3 input slots: (src, index, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor gather_coo_autograd(const at::Tensor& src,
+                               const at::Tensor& index,
+                               const std::optional<at::Tensor>& optional_out) {
+  return GatherCOO::apply(src, index, optional_out)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
+         TORCH_FN(segment_sum_coo_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"),
+         TORCH_FN(gather_coo_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -1,0 +1,143 @@
+#include "../segment_csr.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr`; backward is exactly `gather_csr(grad_out, indptr)` — the
+// symmetric-pair inverse of forward (each `grad_out[r]` is broadcast back to
+// every source position `i ∈ [indptr[r], indptr[r+1])`).
+//
+// `out=` contract: the C++ dispatcher accumulates into the caller's buffer
+// when `out=` is supplied. `mark_dirty` lets gradcheck pick up the in-place
+// mutation; the backward gradient itself is computed the same way regardless.
+class SegmentSumCSR : public torch::autograd::Function<SegmentSumCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = segment_sum_csr(src, indptr, optional_out);
+
+    // Save `indptr` for backward's `gather_csr` call. The gather kernel
+    // applies the same broadcast convention, so we save the *original*
+    // (possibly pre-broadcast) `indptr`.
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `grad_src[..., i, ...] = grad_out[..., r, ...]` where `r` is the row
+    // such that `i ∈ [indptr[r], indptr[r+1])` — exactly `gather_csr`.
+    // We allocate a `grad_in` buffer the size of `src` and let `gather_csr`
+    // fill it via the `out=` overwrite contract. Positions in `grad_in` that
+    // are not covered by any `[indptr[r], indptr[r+1])` range (e.g. when
+    // `src` has trailing entries past `indptr[-1]`) remain uninitialized;
+    // upstream `segment_csr.cpp:75-76` uses `torch::empty` here for the same
+    // reason — those positions never received any contribution in forward,
+    // so their gradient is undefined.
+    auto grad_in = at::empty(src_shape, grad_out.options());
+    gather_csr(grad_out, indptr, grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_sum_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  return SegmentSumCSR::apply(src, indptr, optional_out)[0];
+}
+
+// Autograd Function for `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr` and `src.sizes()`; backward allocates `at::zeros(src_shape)` and
+// calls `segment_sum_csr(grad_out, indptr, /*out=*/grad_in)`, which
+// accumulates each `grad_out` entry into its source position via the `out=`
+// accumulate contract. This is the inverse of forward.
+class GatherCSR : public torch::autograd::Function<GatherCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = gather_csr(src, indptr, optional_out);
+
+    // Backward needs `indptr` (to know which `grad_out` entries map to which
+    // source row) and `src.sizes()` (to allocate the right-shaped `grad_in`).
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // Allocate the gradient buffer at `src.shape` and use the `out=`
+    // accumulate contract of `segment_sum_csr` to deposit each `grad_out`
+    // entry at its source row. This is the inverse of forward: each
+    // `grad_in[r]` accumulates `grad_out[i]` for all `i ∈ [indptr[r],
+    // indptr[r+1])`.
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    segment_sum_csr(grad_out, indptr, /*out=*/grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor gather_csr_autograd(const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+  return GatherCSR::apply(src, indptr, optional_out)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
+         TORCH_FN(gather_csr_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -368,6 +368,148 @@ std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
   return std::make_tuple(out, arg_out);
 }
 
+// CPU implementation of `pyg::scatter_max`.
+//
+// Same (B, E, K) layout as `scatter_sum_kernel`. Two output tensors:
+//   * `out`: the per-bucket maximum value, init to `numeric_limits::lowest()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (upstream convention).
+//   * `arg_out`: the source position that produced each per-bucket max,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner loop over `E` is sequential per `(B, K)`
+// slice and uses strict `>` on the comparison, so on ties the kernel
+// preserves *first-match* semantics. Parallelism is only over the
+// leading `B` dim, where slices write to disjoint sub-regions of
+// `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no lowest-init). The caller is
+// responsible for any non-default starting state. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> scatter_max_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_max: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_max: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_max: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::lowest()` before the reduction loop.
+    out = at::empty(sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_c.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_max_cpu", [&] {
+        // Init `out` to `numeric_limits::lowest()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::lowest());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension only — the inner
+        // loop over E must remain sequential to preserve first-match
+        // argindex semantics on tied source values.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  if (K == 1) {
+                    const int64_t idx = index_data[src_off + e];
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v > *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t idx = index_data[j];
+                      const scalar_t v = src_data[j];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v > *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::lowest()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
@@ -377,6 +519,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(scatter_mul_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
          TORCH_FN(scatter_min_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_max"),
+         TORCH_FN(scatter_max_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -1,0 +1,134 @@
+#include "../scatter.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::scatter_sum`.
+//
+// Layout: `src` is viewed as (B, E, K) where
+//   * B = product of dim sizes before `dim`,
+//   * E = src.size(dim),
+//   * K = product of dim sizes after `dim`.
+// `out` has the same layout with N replacing E (N = out.size(dim)). `index`
+// must already be broadcast to `src.shape` (the dispatcher / autograd front
+// guarantees this) and is forced contiguous here before the kernel scan.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). This matches upstream pytorch_scatter and is what
+// makes `gather_coo` / `gather_csr` backward efficient.
+at::Tensor scatter_sum_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_sum: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_sum: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_sum: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Zero-init the freshly allocated buffer so that the accumulate loop
+    // below produces the correct result.
+    out = at::zeros(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_sum_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension. Each `b` slice writes
+        // to a disjoint sub-region of `out`, so no atomics are needed.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[src_off + e * K];
+                  // Note: when `index` is broadcast from a 1-D shape (i.e.
+                  // shape
+                  // `(E,)` expanded along K), the K positions in row `e` all
+                  // hold the same index, so reading `index_data[src_off + e * K
+                  // + 0]` is sufficient. The expand contract guarantees this;
+                  // the upstream kernel matches.
+                  //
+                  // For the general case (index already had a K dimension
+                  // before broadcast), each (e, k) pair may legitimately have a
+                  // distinct index, so we still index per-k below.
+                  if (K == 1) {
+                    const opmath_t v =
+                        static_cast<opmath_t>(src_data[src_off + e]);
+                    out_data[out_off + idx] = static_cast<scalar_t>(
+                        static_cast<opmath_t>(out_data[out_off + idx]) + v);
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t i = index_data[j];
+                      const opmath_t v = static_cast<opmath_t>(src_data[j]);
+                      out_data[out_off + i * K + k] = static_cast<scalar_t>(
+                          static_cast<opmath_t>(out_data[out_off + i * K + k]) +
+                          v);
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -123,11 +123,113 @@ at::Tensor scatter_sum_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::scatter_mul`.
+//
+// Same (B, E, K) layout as `scatter_sum_kernel`. The only differences:
+//   * The reduction is multiplicative.
+//   * When `out=None`, the freshly allocated buffer is initialized with
+//     **ones** (the multiplicative identity), not zeros.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **multiply
+// into** it (no ones-init). The caller is responsible for any non-default
+// starting state. This matches upstream pytorch_scatter.
+at::Tensor scatter_mul_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_mul: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_mul: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_mul: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Ones-init the freshly allocated buffer so that the multiplicative
+    // reduction starts from the multiplicative identity.
+    out = at::ones(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_mul_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension. Each `b` slice writes
+        // to a disjoint sub-region of `out`, so no atomics are needed.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  if (K == 1) {
+                    const int64_t idx = index_data[src_off + e];
+                    const opmath_t v =
+                        static_cast<opmath_t>(src_data[src_off + e]);
+                    out_data[out_off + idx] = static_cast<scalar_t>(
+                        static_cast<opmath_t>(out_data[out_off + idx]) * v);
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t i = index_data[j];
+                      const opmath_t v = static_cast<opmath_t>(src_data[j]);
+                      out_data[out_off + i * K + k] = static_cast<scalar_t>(
+                          static_cast<opmath_t>(out_data[out_off + i * K + k]) *
+                          v);
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/scatter_kernel.cpp
@@ -5,6 +5,9 @@
 #include <ATen/Parallel.h>
 #include <torch/library.h>
 
+#include <limits>
+#include <tuple>
+
 namespace pyg {
 namespace ops {
 
@@ -223,6 +226,148 @@ at::Tensor scatter_mul_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::scatter_min`.
+//
+// Same (B, E, K) layout as `scatter_sum_kernel`. Two output tensors:
+//   * `out`: the per-bucket minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (upstream convention).
+//   * `arg_out`: the source position that produced each per-bucket min,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner loop over `E` is sequential per `(B, K)`
+// slice and uses strict `<` on the comparison, so on ties the kernel
+// preserves *first-match* semantics. Parallelism is only over the
+// leading `B` dim, where slices write to disjoint sub-regions of
+// `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init). The caller is
+// responsible for any non-default starting state. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_min: src.dim() must equal index.dim() "
+              "after broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // Normalize `dim` to a non-negative value relative to `src.dim()`.
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(), "scatter_min: dim out of range");
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "scatter_min: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + *index_c.max().data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_c.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_min_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dimension only — the inner
+        // loop over E must remain sequential to preserve first-match
+        // argindex semantics on tied source values.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                for (int64_t e = 0; e < E; ++e) {
+                  if (K == 1) {
+                    const int64_t idx = index_data[src_off + e];
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const int64_t j = src_off + e * K + k;
+                      const int64_t idx = index_data[j];
+                      const scalar_t v = src_data[j];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
@@ -230,6 +375,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(scatter_sum_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
          TORCH_FN(scatter_mul_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -490,6 +490,166 @@ std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
   return std::make_tuple(out, arg_out);
 }
 
+// CPU implementation of `pyg::segment_max_coo`.
+//
+// Same (B, E, K) layout as `segment_sum_coo_kernel` with `dim = index.dim() -
+// 1`. Sequential pass over the sorted-ascending `index`: maintain a running
+// maximum value and its first-match argindex per bucket run. Two output
+// tensors:
+//   * `out`: the per-bucket maximum value, init to `numeric_limits::lowest()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (matched against the sentinel in `arg_out`,
+//     mirrors `scatter_max_kernel`).
+//   * `arg_out`: the source position that produced each per-bucket max,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner E loop is sequential per `B` slice and uses
+// strict `>` on the comparison, so on ties the kernel preserves
+// *first-match* semantics. Parallelism is only over the leading `B` dim
+// where slices write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no lowest-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_max_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_max_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_max_coo: index must have at least 1 dimension");
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream
+  // `segment_coo_cpu.cpp:19-22`). Then force contiguous for the linear scan.
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_max_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::lowest()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_max_coo_cpu", [&] {
+        // Init `out` to `numeric_limits::lowest()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::lowest());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dim only. The inner E loop must
+        // remain sequential to preserve first-match argindex semantics on
+        // tied source values within a bucket run.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+
+                if (E == 0)
+                  continue;
+
+                // Sequential pass over the sorted-ascending `index` row.
+                // For each element, look up the current bucket's running
+                // max/argindex (already in `out`/`arg_out`) and update
+                // when the new value is strictly greater (first-match).
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[idx_off + e];
+                  if (K == 1) {
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v > *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v > *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::lowest()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
@@ -594,6 +754,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
          TORCH_FN(segment_min_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_coo"),
+         TORCH_FN(segment_max_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -1,0 +1,276 @@
+#include "../segment_coo.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::segment_sum_coo`.
+//
+// COO ops fix the reduction axis at `dim = index.dim() - 1` (upstream
+// `segment_coo_cpu.cpp:24`). The `index` tensor is sorted-ascending along
+// that axis; equal-index runs collapse into a single output bucket.
+//
+// Layout: `index` is expanded to `src.shape[:index.dim()]` (each leading
+// dim of `index` matches `src`). With `dim = index.dim() - 1`:
+//   * B = product of leading dims before `dim` (= index.numel() /
+//   src.size(dim)),
+//   * E = src.size(dim) = index.size(dim),
+//   * K = product of trailing dims of `src` past `index.dim()`
+//         (= src.numel() / index.numel()),
+//   * N = out.size(dim).
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). Matches upstream and is what makes
+// `GatherCOO::backward` efficient.
+at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
+                                  const at::Tensor& index,
+                                  const std::optional<at::Tensor>& optional_out,
+                                  std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_sum_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  // COO ops fix the reduction axis at the last index dim.
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_sum_coo: index must have at least 1 dimension");
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream
+  // `segment_coo_cpu.cpp:19-22`). Then force contiguous for the linear scan.
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_sum_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      // Last index in the (sorted-ascending) last row gives `dim_size - 1`.
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    // Zero-init the freshly allocated buffer so the accumulate loop below
+    // produces the correct result.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  // `B` is the product of leading dims of `index` before `dim`. We compute
+  // it from `index_b` (post-expand) so it stays well-defined even when the
+  // original `index` is 1-D.
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  // `K` is the product of trailing dims of `src` past `index.dim()`.
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_coo_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dim only. Each `b` slice writes
+        // to a disjoint sub-region of `out`, so no atomics are needed. The
+        // inner E loop must remain sequential to correctly accumulate runs
+        // of equal indices.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+
+                if (E == 0)
+                  continue;
+
+                // Sequential pass over the sorted-ascending `index` row.
+                // Maintain a per-K accumulator that flushes to `out` when
+                // the index changes (or at the end of the row).
+                int64_t cur_idx = index_data[idx_off];
+
+                if (K == 1) {
+                  // Initialize accumulator from current `out` slot so the
+                  // `out=` accumulate contract is honored.
+                  opmath_t acc =
+                      static_cast<opmath_t>(out_data[out_off + cur_idx]);
+                  for (int64_t e = 0; e < E; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      out_data[out_off + cur_idx] = static_cast<scalar_t>(acc);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        acc =
+                            static_cast<opmath_t>(out_data[out_off + cur_idx]);
+                      }
+                    }
+                  }
+                } else {
+                  std::vector<opmath_t> acc(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    acc[k] = static_cast<opmath_t>(
+                        out_data[out_off + cur_idx * K + k]);
+                  for (int64_t e = 0; e < E; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      for (int64_t k = 0; k < K; ++k)
+                        out_data[out_off + cur_idx * K + k] =
+                            static_cast<scalar_t>(acc[k]);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        for (int64_t k = 0; k < K; ++k)
+                          acc[k] = static_cast<opmath_t>(
+                              out_data[out_off + cur_idx * K + k]);
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+// CPU implementation of `pyg::gather_coo`.
+//
+// COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
+//
+//   out[..., e, ...] = src[..., index[..., e], ...]
+//
+// Layout (mirrors `segment_sum_coo_kernel`):
+//   * B = product of leading dims of `index` before `dim`,
+//   * E = index.size(dim) (= out.size(dim)),
+//   * N = src.size(dim),
+//   * K = product of trailing dims of `src` past `index.dim()`.
+//
+// `out=` contract: **overwrite** the caller's buffer per element.
+at::Tensor gather_coo_kernel(const at::Tensor& src,
+                             const at::Tensor& index,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "gather_coo: src.dim() must be >= index.dim() (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0, "gather_coo: index must have at least 1 dimension");
+
+  // For the leading dims before `dim`, upstream requires src.size(i) ==
+  // index.size(i) (no broadcasting). Match that.
+  for (int64_t i = 0; i < dim; ++i) {
+    TORCH_CHECK(src.size(i) == index.size(i), "gather_coo: src.size(", i,
+                ") must match index.size(", i, ")");
+  }
+
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < src_c.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "gather_coo: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = index_c.size(dim);
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0 || index_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  const int64_t E = index_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_c.size(i);
+  const int64_t K = out.numel() / index_c.numel();
+  const int64_t N = src_c.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_coo_cpu", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dim only. Each `b` slice reads
+        // from a disjoint sub-region of `src` and writes to a disjoint
+        // sub-region of `out`.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * N * K;
+                const int64_t out_off = b * E * K;
+                const int64_t idx_off = b * E;
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[idx_off + e];
+                  if (K == 1) {
+                    out_data[out_off + e] = src_data[src_off + idx];
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      out_data[out_off + e * K + k] =
+                          src_data[src_off + idx * K + k];
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
+         TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -169,6 +169,167 @@ at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
   return out;
 }
 
+// CPU implementation of `pyg::segment_mean_coo`.
+//
+// Same layout/shape as `segment_sum_coo_kernel`: sequential pass over the
+// sorted-ascending `index`, accumulate runs of equal indices, but ALSO track
+// the per-bucket count and divide at the end. The count tensor is allocated
+// with shape `index.sizes()` with the last dim replaced by `N` (i.e. without
+// the trailing K dims) — this is a flat `B*N` count, matching upstream
+// `segment_coo_cpu.cpp:54-56`. Backward gathers this 1-D-per-row count and
+// `unsqueeze`s along K, so we keep the storage minimal here.
+//
+// `out=` contract: upstream MEAN does **not** honor an accumulate contract
+// (it overwrites buckets touched by `index`). We match that. Buckets not
+// touched by `index` are left at zero (fresh `out`) or untouched (supplied
+// `out`). This means the `out=` form of `segment_mean_coo` is rarely useful
+// directly, but the kernel still accepts it for API symmetry with sum.
+at::Tensor segment_mean_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_mean_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_mean_coo: index must have at least 1 dimension");
+
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_mean_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  // Count storage: shape `index_b.shape` with last dim replaced by `N`. This
+  // is `B*N` flat per the `dim` axis — no trailing K. Allocate as float to
+  // match `out`'s scalar type at division time, but use the same dtype as
+  // `out` so we can re-use the dispatcher branch.
+  auto count_sizes = index_b.sizes().vec();
+  count_sizes[dim] = N;
+  auto count = at::zeros(count_sizes, src_c.options());
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_coo_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* count_data = count.data_ptr<scalar_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+                const int64_t cnt_off = b * N;
+
+                if (E == 0)
+                  continue;
+
+                int64_t cur_idx = index_data[idx_off];
+                int64_t run_start = 0;
+
+                if (K == 1) {
+                  opmath_t acc = static_cast<opmath_t>(0);
+                  for (int64_t e = 0; e < E; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      out_data[out_off + cur_idx] = static_cast<scalar_t>(acc);
+                      count_data[cnt_off + cur_idx] =
+                          static_cast<scalar_t>(e + 1 - run_start);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        acc = static_cast<opmath_t>(0);
+                        run_start = e + 1;
+                      }
+                    }
+                  }
+                } else {
+                  std::vector<opmath_t> acc(K, static_cast<opmath_t>(0));
+                  for (int64_t e = 0; e < E; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                    const bool last = (e == E - 1);
+                    const int64_t next_idx =
+                        last ? cur_idx : index_data[idx_off + e + 1];
+                    if (last || next_idx != cur_idx) {
+                      for (int64_t k = 0; k < K; ++k)
+                        out_data[out_off + cur_idx * K + k] =
+                            static_cast<scalar_t>(acc[k]);
+                      count_data[cnt_off + cur_idx] =
+                          static_cast<scalar_t>(e + 1 - run_start);
+                      if (!last) {
+                        cur_idx = next_idx;
+                        for (int64_t k = 0; k < K; ++k)
+                          acc[k] = static_cast<opmath_t>(0);
+                        run_start = e + 1;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Buckets that received no entries have count == 0; clamp to 1 to avoid
+  // division by zero (the corresponding `out` slot is already 0 or
+  // user-supplied and untouched).
+  count.masked_fill_(count < static_cast<int64_t>(1), 1);
+
+  // Broadcast count along trailing K dims by unsqueezing once per trailing
+  // dim of `src` past `index.dim()`.
+  auto count_b = count;
+  for (int64_t i = 0; i < src_c.dim() - index_b.dim(); ++i)
+    count_b = count_b.unsqueeze(-1);
+  out.div_(count_b);
+
+  return out;
+}
+
 // CPU implementation of `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
@@ -269,6 +430,8 @@ at::Tensor gather_coo_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_coo_kernel.cpp
@@ -330,6 +330,166 @@ at::Tensor segment_mean_coo_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_min_coo`.
+//
+// Same (B, E, K) layout as `segment_sum_coo_kernel` with `dim = index.dim() -
+// 1`. Sequential pass over the sorted-ascending `index`: maintain a running
+// minimum value and its first-match argindex per bucket run. Two output
+// tensors:
+//   * `out`: the per-bucket minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty
+//     buckets (no contributing source element) are reset to `0` after
+//     the reduction loop (matched against the sentinel in `arg_out`,
+//     mirrors `scatter_min_kernel`).
+//   * `arg_out`: the source position that produced each per-bucket min,
+//     init to the sentinel `src.size(dim)` (one past the last valid
+//     index along `dim`). Has dtype `int64` (matches `index.options()`).
+//
+// **Determinism:** the inner E loop is sequential per `B` slice and uses
+// strict `<` on the comparison, so on ties the kernel preserves
+// *first-match* semantics. Parallelism is only over the leading `B` dim
+// where slices write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_min_coo: src.dim() must be >= index.dim() "
+              "(got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  const int64_t dim = index.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_min_coo: index must have at least 1 dimension");
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream
+  // `segment_coo_cpu.cpp:19-22`). Then force contiguous for the linear scan.
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i)
+    sizes[i] = src.size(i);
+  auto index_b = index.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_min_coo: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_b.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tmp = index_b.select(dim, index_b.size(dim) - 1);
+      tmp = tmp.numel() > 1 ? tmp.max() : tmp;
+      out_sizes[dim] = 1 + *tmp.data_ptr<int64_t>();
+    }
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`)
+  // and starts at the sentinel `src.size(dim)`. The sentinel both encodes
+  // "empty bucket" for the `masked_fill_` post-step and feeds into the
+  // backward's `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, index_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= index_b.size(i);
+  const int64_t K = src_c.numel() / index_b.numel();
+  const int64_t N = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_coo_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did
+        // not supply `optional_out` (otherwise the caller's state is the
+        // running state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* index_data = index_b.data_ptr<int64_t>();
+
+        // Parallelize over the leading (B) dim only. The inner E loop must
+        // remain sequential to preserve first-match argindex semantics on
+        // tied source values within a bucket run.
+        at::parallel_for(
+            0, B, at::internal::GRAIN_SIZE, [&](int64_t b_beg, int64_t b_end) {
+              for (int64_t b = b_beg; b < b_end; ++b) {
+                const int64_t src_off = b * E * K;
+                const int64_t out_off = b * N * K;
+                const int64_t idx_off = b * E;
+
+                if (E == 0)
+                  continue;
+
+                // Sequential pass over the sorted-ascending `index` row.
+                // For each element, look up the current bucket's running
+                // min/argindex (already in `out`/`arg_out`) and update
+                // when the new value is strictly smaller (first-match).
+                for (int64_t e = 0; e < E; ++e) {
+                  const int64_t idx = index_data[idx_off + e];
+                  if (K == 1) {
+                    const scalar_t v = src_data[src_off + e];
+                    auto* out_slot = out_data + out_off + idx;
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      arg_out_data[out_off + idx] = e;
+                    }
+                  } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + out_off + idx * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[out_off + idx * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty buckets retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the
+  // former, upstream resets the value to `0`; for the latter we leave
+  // the caller's value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_coo`.
 //
 // COO ops fix the gather axis at `dim = index.dim() - 1`. Per element:
@@ -432,6 +592,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_sum_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -1,0 +1,270 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1` (upstream
+// `segment_csr_cpu.cpp:24`). Each row `r ∈ [0, indptr.size(dim) - 1)`
+// consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]` and writes
+// the per-row sum to `out[..., r, ...]`. Empty rows leave the corresponding
+// `out` slot at its zero-initialized (or caller-supplied) value.
+//
+// Layout (upstream `segment_csr_cpu.cpp:54-56`): we factor the work into
+//   * N = out.size(dim) * (indptr.numel() / indptr.size(-1))
+//         — total number of "rows" across all leading indptr dims,
+//   * E = src.size(dim) — number of source entries along the reduction axis,
+//   * K = out.numel() / N — product of trailing dims of `src` past
+//         `indptr.dim()`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). Matches upstream and is what makes
+// `GatherCSR::backward` efficient.
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_sum_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` along its leading
+  // dims (upstream `segment_csr_cpu.cpp:19-22`). The last indptr dim
+  // (size = num_rows + 1) is preserved as-is. Then force contiguous so the
+  // kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_sum_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_sum_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Zero-init so empty rows (and the accumulate loop) produce the correct
+    // result without any per-row pre-fill.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  // `N` is the total row count across all leading indptr dims (upstream's
+  // factoring: `out.size(dim) * (indptr.numel() / indptr.size(-1))`).
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` slot (`out_data + n * K`) so no atomics are
+        // needed. The inner accumulate loop is sequential per row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                // `n` indexes into the flattened (leading, rows_per_slice)
+                // space; reconstruct the offsets into indptr and src.
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                // indptr layout: leading slices each of length
+                // `indptr.size(-1)`
+                // (= rows_per_slice + 1). Row `row` consumes
+                // `[indptr[row], indptr[row+1])`.
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                // `src` per-slice stride along `dim` is `E * K`; within a
+                // slice each row position is one `K`-block.
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  // Honor the `out=` accumulate contract: seed from the
+                  // current `out` slot.
+                  opmath_t acc = static_cast<opmath_t>(out_data[n]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                  }
+                  out_data[n] = static_cast<scalar_t>(acc);
+                } else {
+                  std::vector<opmath_t> acc(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    acc[k] = static_cast<opmath_t>(out_data[n * K + k]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                  }
+                  for (int64_t k = 0; k < K; ++k)
+                    out_data[n * K + k] = static_cast<scalar_t>(acc[k]);
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+// CPU implementation of `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
+// the value `src[..., r, ...]` is **broadcast** to every output position
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// Strategy: per-row linear pass (upstream `segment_csr_cpu.cpp:146-158`).
+// This avoids the per-output-position binary search the plan mentions: for
+// each row we read one `src` value (per K) and write it to a contiguous
+// stretch of `out`. Parallelism is over the flat row index `N`.
+//
+// Layout:
+//   * N = src.size(dim) * (indptr.numel() / indptr.size(-1)),
+//   * E = out.size(dim) — number of output positions along the gather axis,
+//   * K = src.numel() / N — product of trailing dims past `indptr.dim()`.
+//
+// `out=` contract: **overwrite** the caller's buffer per element. Positions
+// outside any `[indptr[r], indptr[r+1])` range (i.e. before `indptr[0]` or
+// after `indptr[-1]`) are left untouched.
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr: src.dim() must be >= indptr.dim() (got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0, "gather_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` along leading dims to match `src.shape[:dim]`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr: src.size(dim) must equal indptr.size(-1) - 1");
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < src_c.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "gather_csr: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // Output size along `dim` is the trailing entry of `indptr`. We read it
+      // from the flattened-last entry of the broadcast indptr (all leading
+      // slices share the same trailing value since the original indptr only
+      // varied along `dim`).
+      out_sizes[dim] = *indptr_b.flatten()[-1].data_ptr<int64_t>();
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // Layout: N = (rows_per_slice) * (leading slices); per src entry we write
+  // a contiguous stretch in `out` of length (row_end - row_start) * K.
+  const int64_t rows_per_slice = src_c.size(dim);
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = rows_per_slice * leading;
+  const int64_t K = src_c.numel() / N;
+  const int64_t E = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cpu", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over flat row index. Each row writes a disjoint
+        // stretch of `out` so no atomics / coordination needed.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t out_off = slice * E * K;
+
+                if (K == 1) {
+                  const scalar_t v = src_data[n];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    out_data[out_off + e] = v;
+                  }
+                } else {
+                  // Cache row value across the inner E loop to avoid repeated
+                  // loads from `src`. Matches upstream `vals[K]` cache pattern.
+                  std::vector<scalar_t> vals(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    vals[k] = src_data[n * K + k];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      out_data[out_off + e * K + k] = vals[k];
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -508,3 +508,153 @@ static inline __device__ double atomicMin(double* address, double val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
+
+// -----------------------------------------------------------------------------
+// `atomicMax` — Commit 5 (`scatter_max`).
+//
+// Symmetric to the `atomicMin` block above; same storage strategy per dtype,
+// only the comparison flips (`val > cur` instead of `val < cur`). See the
+// `atomicMin` block for the rationale on why we provide CAS-loop overloads
+// for every dtype in the
+// `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set — even
+// where CUDA provides a native `atomicMax` — so the kernel call site resolves
+// without integer-promotion ambiguity.
+
+namespace pyg_atomics_detail {
+
+// 1-byte CAS-loop max (uint8_t / int8_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMax1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t result;
+
+  do {
+    assumed = old;
+    const scalar_t cur = (scalar_t)((old >> shift) & 0xff);
+    const scalar_t new_val = val > cur ? val : cur;
+    result = (assumed & ~(0x000000ff << shift)) |
+             (((uint32_t)new_val & 0xff) << shift);
+    old = atomicCAS(address_as_ui, assumed, result);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+// 2-byte CAS-loop max (int16_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMax2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    const scalar_t cur =
+        (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+    const scalar_t new_val = val > cur ? val : cur;
+    const uint32_t lo = (uint32_t)new_val & 0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (lo << 16)
+                                 : (old & 0xffff0000) | lo;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+// 2-byte CAS-loop max for `at::Half` / `at::BFloat16`. Mirrors `atomicMinHalf`:
+// preserve the IEEE 754 bit pattern via `scalar_t::x`, compare as float to
+// avoid the operator-overload ambiguity from `cuda_fp16.hpp` / `cuda_bf16.hpp`.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMaxHalf(scalar_t* address,
+                                                scalar_t val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+  const float val_f = static_cast<float>(val);
+
+  do {
+    assumed = old;
+    scalar_t cur;
+    cur.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    const scalar_t chosen = val_f > static_cast<float>(cur) ? val : cur;
+    old = (size_t)address & 2 ? (old & 0xffff) | ((unsigned int)chosen.x << 16)
+                              : (old & 0xffff0000) | (unsigned int)chosen.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  scalar_t ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+}  // namespace pyg_atomics_detail
+
+// Integer overloads.
+static inline __device__ uint8_t atomicMax(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicMax1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicMax(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicMax1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicMax(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicMax2B<int16_t>(address, val);
+}
+// `int32_t` (== `int`) — CUDA's native `atomicMax(int*, int)` already
+// participates in overload resolution; no wrapper here (would collide on
+// Linux x86_64 where `int32_t` is `int`).
+//
+// `int64_t` is `long int` on Linux x86_64 (LP64); CUDA's native
+// `atomicMax(long long int*, long long int)` covers a *different* type, so
+// we provide our own CAS loop. The comparison is done in signed space on the
+// reinterpreted 64-bit word.
+static inline __device__ int64_t atomicMax(int64_t* address, int64_t val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const int64_t cur = (int64_t)assumed;
+    const int64_t new_val = val > cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, (unsigned long long int)new_val);
+  } while (assumed != old);
+  return (int64_t)old;
+}
+
+// Floating-point overloads.
+static inline __device__ at::Half atomicMax(at::Half* address, at::Half val) {
+  return pyg_atomics_detail::atomicMaxHalf<at::Half>(address, val);
+}
+static inline __device__ at::BFloat16 atomicMax(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  return pyg_atomics_detail::atomicMaxHalf<at::BFloat16>(address, val);
+}
+static inline __device__ float atomicMax(float* address, float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed;
+
+  do {
+    assumed = old;
+    const float cur = __int_as_float(assumed);
+    const float new_val = val > cur ? val : cur;
+    old = atomicCAS(address_as_i, assumed, __float_as_int(new_val));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+static inline __device__ double atomicMax(double* address, double val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const double cur = __longlong_as_double(assumed);
+    const double new_val = val > cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, __double_as_longlong(new_val));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -1,0 +1,148 @@
+#pragma once
+
+// Atomic helpers for `pyg::scatter_*` and `pyg::segment_*` CUDA kernels.
+//
+// This file is grown commit-by-commit as the migration of pytorch_scatter
+// kernels lands. Commit 1 (`scatter_sum`) introduces:
+//
+//   * 16-bit CAS-loop `atomicAdd` for `at::Half` and `at::BFloat16` (the
+//     primary helpers — CUDA's native `__half`/`__nv_bfloat16` `atomicAdd`
+//     intrinsics are gated on sm_70+/sm_80+ respectively, while the CAS-loop
+//     works on every architecture pyg-lib targets).
+//   * Narrow-int CAS-loop `atomicAdd` for `uint8_t`, `int8_t`, `int16_t`,
+//     plus a `int64_t` wrapper that forwards to CUDA's `unsigned long long`
+//     intrinsic. These are mandatory for the
+//     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set —
+//     without them the kernel fails to link for narrow integer dtypes.
+//
+// Pattern mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`: rewind the address
+// to the nearest 32-bit-aligned word, then CAS the full word while updating
+// only the bytes/halfword we care about. Selector `(size_t)address & 2` picks
+// high (offset 2) vs. low (offset 0) halfword; `(size_t)address & 3` picks
+// the byte position.
+//
+// The overloads are defined in the global namespace so they participate in
+// overload resolution alongside the built-in CUDA `atomicAdd(int*, int)`,
+// `atomicAdd(float*, float)`, etc. Defining them inside `pyg::ops` would
+// shadow the built-ins for any unqualified call site inside that namespace.
+
+#include <ATen/ATen.h>
+#include <cuda_runtime.h>
+
+// `atomicAdd(at::Half*, at::Half)` — CAS-loop on the enclosing 32-bit word.
+//
+// Notes:
+//   * `address - ((size_t)address & 2)` rewinds to the 4-byte-aligned word.
+//   * `at::Half::x` is `unsigned short` (the IEEE 754 binary16 bit pattern).
+//   * `hsum = old_half + val` uses `at::Half`'s `operator+`, which itself
+//     promotes to `float` for the actual addition — this matches the upstream
+//     pytorch_scatter behavior and keeps precision sane for accumulation.
+//   * Returns the previous value at `address`, mirroring CUDA's built-in
+//     `atomicAdd` return convention.
+static inline __device__ at::Half atomicAdd(at::Half* address, at::Half val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    at::Half hsum;
+    hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hsum = hsum + val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16)
+                              : (old & 0xffff0000) | hsum.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  at::Half ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+// `atomicAdd(at::BFloat16*, at::BFloat16)` — same CAS-loop pattern.
+static inline __device__ at::BFloat16 atomicAdd(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    at::BFloat16 hsum;
+    hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hsum = hsum + val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16)
+                              : (old & 0xffff0000) | hsum.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  at::BFloat16 ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+// Narrow-integer CAS-loop helpers (1-byte and 2-byte). Mirrors the
+// 1/2-byte specializations of `AtomicAddIntegerImpl` in
+// `pytorch_scatter/csrc/cuda/atomics.cuh:6-41`.
+
+namespace pyg_atomics_detail {
+
+template <typename scalar_t>
+static inline __device__ scalar_t atomicAdd1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t sum;
+
+  do {
+    assumed = old;
+    sum = (uint32_t)((scalar_t)((old >> shift) & 0xff) + val) & 0xff;
+    old = (assumed & ~(0x000000ff << shift)) | (sum << shift);
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+template <typename scalar_t>
+static inline __device__ scalar_t atomicAdd2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t sum;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    sum = (uint32_t)((size_t)address & 2 ? (scalar_t)(old >> 16) + val
+                                         : (scalar_t)(old & 0xffff) + val) &
+          0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (sum << 16)
+                                 : (old & 0xffff0000) | sum;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+}  // namespace pyg_atomics_detail
+
+static inline __device__ uint8_t atomicAdd(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicAdd1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicAdd(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicAdd1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicAdd(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicAdd2B<int16_t>(address, val);
+}
+
+// `atomicAdd(int64_t*, int64_t)` — CUDA's native `atomicAdd` is defined for
+// `unsigned long long int`, so we reinterpret the address. Signed overflow
+// wraps around on 2's-complement, which is what we want for sum accumulation
+// (and matches CPU behavior for the same dtype).
+static inline __device__ int64_t atomicAdd(int64_t* address, int64_t val) {
+  return (int64_t)atomicAdd((unsigned long long int*)address,
+                            (unsigned long long int)val);
+}

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -324,3 +324,187 @@ static inline __device__ double atomicMul(double* address, double val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
+
+// -----------------------------------------------------------------------------
+// `atomicMin` — Commit 4 (`scatter_min`).
+//
+// CUDA provides a native `atomicMin` for `int`, `unsigned int`, `long long
+// int`, and `unsigned long long int` only — none of the narrow ints, neither
+// floating-point dtype, and not `at::Half` / `at::BFloat16`. For uniform
+// overload resolution at the kernel call site (where `scalar_t` ranges over
+// the `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set),
+// we provide CAS-loop overloads for every dtype below — even where a native
+// `atomicMin` exists — so that `atomicMin(out_data + j, src[i])` resolves
+// without an integer-promotion ambiguity inside the kernel.
+//
+// Storage strategy mirrors the `atomicMul` block above:
+//   * 1-byte ints (uint8_t / int8_t)            -> CAS on 32-bit word, byte
+//                                                  selector `(addr & 3) * 8`.
+//   * 2-byte ints + at::Half + at::BFloat16     -> CAS on 32-bit word,
+//                                                  halfword selector
+//                                                  `addr & 2`. Floating-point
+//                                                  half/bfloat16 use a
+//                                                  dedicated helper that
+//                                                  preserves the IEEE bit
+//                                                  pattern via `scalar_t::x`.
+//   * int32_t                                   -> forwards to CUDA's
+//                                                  native `atomicMin`.
+//   * float                                     -> CAS on 32-bit word via
+//                                                  `__float_as_int` /
+//                                                  `__int_as_float`.
+//   * int64_t                                   -> CAS on 64-bit word
+//                                                  (signed comparison done
+//                                                  on the reinterpreted
+//                                                  signed value).
+//   * double                                    -> CAS on 64-bit word via
+//                                                  `__double_as_longlong` /
+//                                                  `__longlong_as_double`.
+
+namespace pyg_atomics_detail {
+
+// 1-byte CAS-loop min (uint8_t / int8_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMin1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t result;
+
+  do {
+    assumed = old;
+    const scalar_t cur = (scalar_t)((old >> shift) & 0xff);
+    const scalar_t new_val = val < cur ? val : cur;
+    result = (assumed & ~(0x000000ff << shift)) |
+             (((uint32_t)new_val & 0xff) << shift);
+    old = atomicCAS(address_as_ui, assumed, result);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+// 2-byte CAS-loop min (int16_t).
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMin2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    const scalar_t cur =
+        (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+    const scalar_t new_val = val < cur ? val : cur;
+    const uint32_t lo = (uint32_t)new_val & 0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (lo << 16)
+                                 : (old & 0xffff0000) | lo;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+// 2-byte CAS-loop min for `at::Half` / `at::BFloat16`. The integer-flavored
+// template above would clobber the IEEE 754 bit pattern because it casts the
+// half-word to/from `scalar_t` directly; here we stash the bits into
+// `scalar_t::x` (the underlying `unsigned short`), compare *as float*
+// (avoiding the `c10::Half`/`__half` operator overload ambiguity that
+// `cuda_fp16.hpp` introduces when both `__half::operator<` and the
+// built-in arithmetic `<` are visible), then write the chosen value's bit
+// pattern back.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMinHalf(scalar_t* address,
+                                                scalar_t val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+  const float val_f = static_cast<float>(val);
+
+  do {
+    assumed = old;
+    scalar_t cur;
+    cur.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    const scalar_t chosen = val_f < static_cast<float>(cur) ? val : cur;
+    old = (size_t)address & 2 ? (old & 0xffff) | ((unsigned int)chosen.x << 16)
+                              : (old & 0xffff0000) | (unsigned int)chosen.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  scalar_t ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+}  // namespace pyg_atomics_detail
+
+// Integer overloads.
+static inline __device__ uint8_t atomicMin(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicMin1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicMin(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicMin1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicMin(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicMin2B<int16_t>(address, val);
+}
+// `int32_t` (== `int` on every platform we target) — CUDA's native
+// `atomicMin(int*, int)` already participates in overload resolution, so we
+// do *not* define a wrapper here. (Doing so would collide on Linux x86_64
+// where `int32_t` is `int`.)
+//
+// `int64_t` is `long int` on Linux x86_64 (LP64); CUDA's native
+// `atomicMin(long long int*, long long int)` covers a *different* type, so
+// we provide our own CAS loop. The comparison is done in signed space on the
+// reinterpreted 64-bit word.
+static inline __device__ int64_t atomicMin(int64_t* address, int64_t val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const int64_t cur = (int64_t)assumed;
+    const int64_t new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, (unsigned long long int)new_val);
+  } while (assumed != old);
+  return (int64_t)old;
+}
+
+// Floating-point overloads.
+static inline __device__ at::Half atomicMin(at::Half* address, at::Half val) {
+  return pyg_atomics_detail::atomicMinHalf<at::Half>(address, val);
+}
+static inline __device__ at::BFloat16 atomicMin(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  return pyg_atomics_detail::atomicMinHalf<at::BFloat16>(address, val);
+}
+// float — CAS on the bit pattern. Safe for non-NaN inputs: IEEE 754 binary32
+// is monotone w.r.t. integer ordering for nonnegative values, but signed
+// comparison via `__int_as_float` then real `<` handles both signs correctly
+// (we compare floats, not the integer bit pattern).
+static inline __device__ float atomicMin(float* address, float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed;
+
+  do {
+    assumed = old;
+    const float cur = __int_as_float(assumed);
+    const float new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_i, assumed, __float_as_int(new_val));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+static inline __device__ double atomicMin(double* address, double val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    const double cur = __longlong_as_double(assumed);
+    const double new_val = val < cur ? val : cur;
+    old = atomicCAS(address_as_ull, assumed, __double_as_longlong(new_val));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}

--- a/pyg_lib/csrc/ops/cuda/atomics.cuh
+++ b/pyg_lib/csrc/ops/cuda/atomics.cuh
@@ -15,6 +15,14 @@
 //     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)` instantiation set —
 //     without them the kernel fails to link for narrow integer dtypes.
 //
+// Commit 2 (`scatter_mul`) adds:
+//
+//   * CAS-loop `atomicMul` for every dtype in
+//     `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16, ...)`. CUDA does not provide
+//     a native `atomicMul` for any dtype, so all overloads CAS on the
+//     enclosing 32-bit or 64-bit storage word. See the comment block above
+//     the overloads for the per-dtype storage strategy.
+//
 // Pattern mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`: rewind the address
 // to the nearest 32-bit-aligned word, then CAS the full word while updating
 // only the bytes/halfword we care about. Selector `(size_t)address & 2` picks
@@ -145,4 +153,174 @@ static inline __device__ int16_t atomicAdd(int16_t* address, int16_t val) {
 static inline __device__ int64_t atomicAdd(int64_t* address, int64_t val) {
   return (int64_t)atomicAdd((unsigned long long int*)address,
                             (unsigned long long int)val);
+}
+
+// -----------------------------------------------------------------------------
+// `atomicMul` — Commit 2 (`scatter_mul`).
+//
+// CUDA does not natively provide `atomicMul` for any dtype, so every overload
+// below is a CAS-loop on the enclosing 32-bit or 64-bit storage word.
+//
+// Storage strategy per dtype (mirrors `pytorch_scatter/csrc/cuda/atomics.cuh`'s
+// `AtomicMulIntegerImpl<scalar, size>` / `AtomicMulDecimalImpl<scalar, size>`
+// specializations):
+//   * 1-byte ints (uint8_t / int8_t)            -> CAS on 32-bit word, byte
+//                                                  selector `(addr & 3) * 8`.
+//   * 2-byte ints + at::Half + at::BFloat16     -> CAS on 32-bit word,
+//                                                  halfword selector `addr &
+//                                                  2`.
+//   * int32_t                                   -> CAS on 32-bit word.
+//   * float                                     -> CAS on 32-bit word via
+//                                                  `__float_as_int` /
+//                                                  `__int_as_float`.
+//   * int64_t                                   -> CAS on 64-bit word
+//                                                  (`unsigned long long`).
+//   * double                                    -> CAS on 64-bit word via
+//                                                  `__double_as_longlong` /
+//                                                  `__longlong_as_double`.
+//
+// As with the `atomicAdd` overloads above, these live in the global namespace
+// so they participate in overload resolution alongside the CUDA built-ins.
+
+namespace pyg_atomics_detail {
+
+// 1-byte CAS-loop multiply (uint8_t / int8_t). Selector chooses which byte of
+// the 32-bit word we're updating; the other three bytes are preserved.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMul1B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 3));
+  const uint32_t shift = ((size_t)address & 3) * 8;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t prod;
+
+  do {
+    assumed = old;
+    prod = (uint32_t)((scalar_t)((old >> shift) & 0xff) * val) & 0xff;
+    old = (assumed & ~(0x000000ff << shift)) | (prod << shift);
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+  return (scalar_t)((old >> shift) & 0xff);
+}
+
+// 2-byte CAS-loop multiply (int16_t / at::Half / at::BFloat16).
+// `at::Half` / `at::BFloat16` use this template via `scalar_t::operator*`,
+// which (like `operator+` in the `atomicAdd` overloads) promotes to `float`
+// for the actual multiply — matches upstream pytorch_scatter precision.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMul2B(scalar_t* address, scalar_t val) {
+  uint32_t* address_as_ui = (uint32_t*)((char*)address - ((size_t)address & 2));
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+  uint32_t prod;
+  uint32_t newval;
+
+  do {
+    assumed = old;
+    prod = (uint32_t)((size_t)address & 2 ? (scalar_t)(old >> 16) * val
+                                          : (scalar_t)(old & 0xffff) * val) &
+           0xffff;
+    newval = (size_t)address & 2 ? (old & 0xffff) | (prod << 16)
+                                 : (old & 0xffff0000) | prod;
+    old = atomicCAS(address_as_ui, assumed, newval);
+  } while (assumed != old);
+  return (size_t)address & 2 ? (scalar_t)(old >> 16) : (scalar_t)(old & 0xffff);
+}
+
+// 2-byte CAS-loop multiply for `at::Half` / `at::BFloat16`. The
+// integer-flavoured template above would clobber the IEEE 754 bit pattern
+// because it casts the half-word to/from `scalar_t` directly. Instead, we
+// stash the bits into `scalar_t::x` (the underlying `unsigned short`),
+// multiply via the operator overload (which promotes to float), then write
+// the result's bit pattern back.
+template <typename scalar_t>
+static inline __device__ scalar_t atomicMulHalf(scalar_t* address,
+                                                scalar_t val) {
+  unsigned int* address_as_ui =
+      (unsigned int*)((char*)address - ((size_t)address & 2));
+  unsigned int old = *address_as_ui;
+  unsigned int assumed;
+
+  do {
+    assumed = old;
+    scalar_t hprod;
+    hprod.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+    hprod = hprod * val;
+    old = (size_t)address & 2 ? (old & 0xffff) | (hprod.x << 16)
+                              : (old & 0xffff0000) | hprod.x;
+    old = atomicCAS(address_as_ui, assumed, old);
+  } while (assumed != old);
+
+  scalar_t ret;
+  ret.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+  return ret;
+}
+
+}  // namespace pyg_atomics_detail
+
+// Integer overloads.
+static inline __device__ uint8_t atomicMul(uint8_t* address, uint8_t val) {
+  return pyg_atomics_detail::atomicMul1B<uint8_t>(address, val);
+}
+static inline __device__ int8_t atomicMul(int8_t* address, int8_t val) {
+  return pyg_atomics_detail::atomicMul1B<int8_t>(address, val);
+}
+static inline __device__ int16_t atomicMul(int16_t* address, int16_t val) {
+  return pyg_atomics_detail::atomicMul2B<int16_t>(address, val);
+}
+static inline __device__ int32_t atomicMul(int32_t* address, int32_t val) {
+  uint32_t* address_as_ui = (uint32_t*)address;
+  uint32_t old = *address_as_ui;
+  uint32_t assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ui, assumed, (uint32_t)((int32_t)assumed * val));
+  } while (assumed != old);
+  return (int32_t)old;
+}
+static inline __device__ int64_t atomicMul(int64_t* address, int64_t val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    (unsigned long long int)((int64_t)assumed * val));
+  } while (assumed != old);
+  return (int64_t)old;
+}
+
+// Floating-point overloads.
+static inline __device__ at::Half atomicMul(at::Half* address, at::Half val) {
+  return pyg_atomics_detail::atomicMulHalf<at::Half>(address, val);
+}
+static inline __device__ at::BFloat16 atomicMul(at::BFloat16* address,
+                                                at::BFloat16 val) {
+  return pyg_atomics_detail::atomicMulHalf<at::BFloat16>(address, val);
+}
+static inline __device__ float atomicMul(float* address, float val) {
+  int* address_as_i = (int*)address;
+  int old = *address_as_i;
+  int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_i, assumed,
+                    __float_as_int(val * __int_as_float(assumed)));
+  } while (assumed != old);
+  return __int_as_float(old);
+}
+static inline __device__ double atomicMul(double* address, double val) {
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val * __longlong_as_double(assumed)));
+  } while (assumed != old);
+  return __longlong_as_double(old);
 }

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -5,6 +5,10 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
 
+#include <limits>
+#include <tuple>
+#include <type_traits>
+
 #include "atomics.cuh"
 
 namespace pyg {
@@ -263,6 +267,211 @@ at::Tensor scatter_mul_kernel(const at::Tensor& src,
   return out;
 }
 
+// ============================================================================
+// `scatter_min` — Commit 4.
+//
+// Two CUDA kernels, launched on the same stream so completion ordering is
+// implicit:
+//
+//   1. `scatter_min_value_cuda_kernel`. 1 thread per `src` element; performs
+//      `atomicMin(out + linear_offset, src[i])`. `out` is pre-initialized on
+//      the host to `numeric_limits<scalar_t>::max()` (when `out=None`); the
+//      caller is responsible for any non-default starting state when `out=`
+//      is supplied (mirrors the upstream `out.fill_(Reducer::init())` skip).
+//
+//   2. `scatter_arg_cuda_kernel`. 1 thread per `src` element; re-scans `src`
+//      and where `src[i] == out[linear_offset]`, performs
+//      `atomicMin(arg_out + linear_offset, i)` over `int64_t`. Initialising
+//      `arg_out` to the sentinel `src.size(dim)` makes any valid contributor
+//      `i < src.size(dim)` win the CAS; subsequent ties pick the *smallest*
+//      `i` (the "first match" argindex convention shared with the CPU
+//      kernel — note upstream's CUDA kernel races and returns *some* arg
+//      index, but mirroring CPU semantics on the GPU is the conservative
+//      port choice and costs only the int64_t atomic).
+//
+// After both kernels complete, the host clears the sentinel buckets via
+// `out.masked_fill_(arg_out == src.size(dim), 0)` so that empty buckets
+// produce `0` instead of `numeric_limits::max()`. This is skipped when
+// `out=` is supplied — the caller owns the buffer.
+
+// Value-pass kernel.
+template <typename scalar_t>
+__global__ void scatter_min_value_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    scalar_t* __restrict__ out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicMin(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// Arg-pass kernel. Reads `out_data` (now holding the per-bucket minima from
+// the value pass) and atomically lowers `arg_out_data[linear_offset]` to `e`
+// (the position within the reduction axis) whenever `src[i] == out[j]`.
+template <typename scalar_t>
+__global__ void scatter_min_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t e = (thread_idx / K) % E;
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    const int64_t j = b * N * K + idx * K + k;
+    // Equality compared bit-exactly. For `at::Half` / `at::BFloat16`, the
+    // `__half`/`__nv_bfloat16` operator overloads from `cuda_fp16.hpp` /
+    // `cuda_bf16.hpp` conflict with the built-in `arithmetic ==` once
+    // `c10::Half` is convertible to both — so we cast through the underlying
+    // bit pattern (`.x`) for half-precision types and use the natural
+    // operator for all other dtypes. Bit-exact equality is what we want
+    // here: the value pass wrote a specific bit pattern, and we are
+    // checking whether `src[i]` has that same bit pattern.
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[j].x;
+    } else {
+      match = src_data[thread_idx] == out_data[j];
+    }
+    if (match) {
+      atomicMin(arg_out_data + j, e);
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_min (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_min (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_min (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_min (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_min (CUDA): dim out of range");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  const int64_t E = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_min (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninitialized, then fill per-dtype with
+    // `std::numeric_limits<scalar_t>::max()`. We can't use `at::full` with
+    // a single host `Scalar` because the conversion of `f64 max` to e.g.
+    // int8_t would saturate/overflow; the per-dtype dispatch picks the
+    // correct `max()` for each scalar. (`std::numeric_limits` has
+    // specializations for `at::Half` and `at::BFloat16` provided by
+    // PyTorch via `<c10/util/Half.h>` / `<c10/util/BFloat16.h>`.)
+    out = at::empty(sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "scatter_min_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E = src.size(dim)`. Even when `out=` is supplied, `arg_out` is fresh
+  // (the schema returns it; the caller has no way to pre-allocate it).
+  auto arg_out =
+      at::full(out.sizes(), E, index_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors at all: every bucket is "empty" -> sentinel-mask to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_min_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // Value pass.
+        scatter_min_value_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        // Arg pass. Same stream -> the value-pass writes are visible.
+        scatter_min_arg_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, arg_out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E`, no contributor wrote to that
+  // bucket, so `out` still holds `numeric_limits::max()`. Reset to `0` to
+  // match the CPU kernel's contract. Only do this when we allocated `out`
+  // ourselves — if `out=` was provided, the caller's pre-existing values in
+  // empty buckets must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -270,6 +479,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(scatter_sum_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
          TORCH_FN(scatter_mul_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
+         TORCH_FN(scatter_min_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -1,0 +1,168 @@
+#include "../scatter.h"
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+
+#include "atomics.cuh"
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). ROCm warp=64 is not a target. Not used by this commit;
+// included here so subsequent commits in this family can rely on the same
+// constant without redefining it.
+#define WARP_SIZE 32
+
+// Convention 12: dynamic block sizing. Replicates the inline `threads()` /
+// `blocks()` pattern from
+// `pyg_lib/csrc/sampler/cuda/random_walk_kernel.cu:10-21` — there is no shared
+// helper in `pyg_lib/csrc/ops/cuda/` yet, so each new kernel file carries its
+// own copy. `maxThreadsPerBlock` is capped at 1024 because launching with more
+// threads than `maxThreadsPerBlock` would fail at runtime, and 1024 is the
+// upper bound on every supported arch.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  // `std::max(1, ...)` guards against pathological cases where the
+  // `cudaDeviceProp` struct is degenerate (e.g. local nvcc/runtime version
+  // mismatches that leave `multiProcessorCount` reading as 0/1 due to layout
+  // skew). Launching with `<<<0, ...>>>` is a `cudaErrorInvalidValue`; a
+  // single block is always a safe fallback for the work we have to do.
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// 1 thread per `src` element. Atomically accumulates into
+// `out[b * N * K + idx * K + k]` where `idx = index_data[thread_idx]`. The
+// index tensor must already be broadcast to `src.shape` and `.contiguous()`
+// (the dispatcher enforces both). Grid is a strided 1-D loop so we cover
+// `numel` correctly even when `numel > gridDim.x * blockDim.x`.
+template <typename scalar_t>
+__global__ void scatter_sum_cuda_kernel(const scalar_t* __restrict__ src_data,
+                                        const int64_t* __restrict__ index_data,
+                                        scalar_t* __restrict__ out_data,
+                                        int64_t E,
+                                        int64_t K,
+                                        int64_t N,
+                                        int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicAdd(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// CUDA implementation of `pyg::scatter_sum`. Mirrors the CPU kernel layout
+// (B, E, K) and the `out=` contract:
+//   * `optional_out` provided -> accumulate into the caller's buffer (no zero
+//     init). The buffer is `.contiguous()`-ified at the kernel boundary.
+//   * `optional_out` absent -> allocate `at::zeros(...)` so that
+//     `atomicAdd`-based accumulation starts from a clean slate.
+at::Tensor scatter_sum_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_sum (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_sum (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_sum (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_sum (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_sum (CUDA): dim out of range");
+
+  // Pin the current CUDA device to the input's device so subsequent
+  // `at::cuda::getCurrentDeviceProperties()` / `getCurrentCUDAStream()` calls
+  // resolve to the right device (matches upstream pytorch_scatter's
+  // `c10::cuda::MaybeSetDevice(src.get_device())`).
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary. The autograd
+  // wrapper calls `broadcast(index, src, dim)` (which produces an expanded,
+  // non-contiguous view); we materialize it here so the kernel can index by a
+  // single linear offset.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_sum (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Zero-init so the atomicAdd accumulation starts from a clean slate.
+    out = at::zeros(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_sum_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        scatter_sum_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
+         TORCH_FN(scatter_sum_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -472,6 +472,184 @@ std::tuple<at::Tensor, at::Tensor> scatter_min_kernel(
   return std::make_tuple(out, arg_out);
 }
 
+// ============================================================================
+// `scatter_max` — Commit 5.
+//
+// Symmetric to `scatter_min` above. Differences:
+//   * `out` is initialized to `numeric_limits<scalar_t>::lowest()` (instead of
+//     `::max()`).
+//   * Value pass uses `atomicMax` (instead of `atomicMin`).
+//   * Arg pass logic is *identical* to `scatter_min`: `atomicMin` on the
+//     argindex picks the smallest argindex on ties (matches upstream
+//     pytorch_scatter's deterministic first-match semantics on CUDA, and is
+//     consistent with the CPU kernel).
+
+// Value-pass kernel.
+template <typename scalar_t>
+__global__ void scatter_max_value_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    scalar_t* __restrict__ out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicMax(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// Arg-pass kernel. Identical to `scatter_min_arg_cuda_kernel` — reads
+// `out_data` (now holding per-bucket maxima) and atomically lowers
+// `arg_out_data[linear_offset]` to `e` whenever `src[i] == out[j]`. The
+// `atomicMin` on the argindex picks the smallest contributor `e` on ties.
+template <typename scalar_t>
+__global__ void scatter_max_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const int64_t* __restrict__ index_data,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    int64_t E,
+    int64_t K,
+    int64_t N,
+    int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t e = (thread_idx / K) % E;
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    const int64_t j = b * N * K + idx * K + k;
+    // See `scatter_min_arg_cuda_kernel` for the half-precision bit-pattern
+    // equality rationale.
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[j].x;
+    } else {
+      match = src_data[thread_idx] == out_data[j];
+    }
+    if (match) {
+      atomicMin(arg_out_data + j, e);
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> scatter_max_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_max (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_max (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_max (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_max (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_max (CUDA): dim out of range");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  const int64_t E = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_max (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninitialized, then fill per-dtype with
+    // `std::numeric_limits<scalar_t>::lowest()`. Symmetric to `scatter_min`'s
+    // `::max()` init — see that block for the rationale on per-dtype dispatch.
+    out = at::empty(sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "scatter_max_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::lowest()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E = src.size(dim)`. Same convention as `scatter_min`.
+  auto arg_out =
+      at::full(out.sizes(), E, index_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors at all: every bucket is "empty" -> sentinel-mask to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_max_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // Value pass.
+        scatter_max_value_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+        // Arg pass. Same stream -> the value-pass writes are visible.
+        scatter_max_arg_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, arg_out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E`, no contributor wrote to that
+  // bucket, so `out` still holds `numeric_limits::lowest()`. Reset to `0` to
+  // match the CPU kernel's contract. Skipped when `out=` was supplied.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -481,6 +659,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(scatter_mul_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_min"),
          TORCH_FN(scatter_min_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_max"),
+         TORCH_FN(scatter_max_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/scatter_kernel.cu
@@ -157,11 +157,119 @@ at::Tensor scatter_sum_kernel(const at::Tensor& src,
   return out;
 }
 
+// 1 thread per `src` element. Atomically multiplies into
+// `out[b * N * K + idx * K + k]` where `idx = index_data[thread_idx]`. Same
+// addressing scheme as `scatter_sum_cuda_kernel` — only the atomic differs.
+template <typename scalar_t>
+__global__ void scatter_mul_cuda_kernel(const scalar_t* __restrict__ src_data,
+                                        const int64_t* __restrict__ index_data,
+                                        scalar_t* __restrict__ out_data,
+                                        int64_t E,
+                                        int64_t K,
+                                        int64_t N,
+                                        int64_t numel) {
+  for (int64_t thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       thread_idx < numel; thread_idx += blockDim.x * gridDim.x) {
+    const int64_t b = thread_idx / (E * K);
+    const int64_t k = thread_idx % K;
+    const int64_t idx = index_data[thread_idx];
+    atomicMul(out_data + b * N * K + idx * K + k, src_data[thread_idx]);
+  }
+}
+
+// CUDA implementation of `pyg::scatter_mul`. Mirrors `scatter_sum_kernel` with
+// two differences:
+//   * Uses `atomicMul` (CAS-loop from `atomics.cuh`) for accumulation.
+//   * When `optional_out` is absent, the fresh buffer is filled with **ones**,
+//     not zeros — multiplicative identity. Mirrors upstream pytorch_scatter's
+//     `out.fill_(Reducer<scalar_t, REDUCE>::init())` for `REDUCE = MUL`.
+at::Tensor scatter_mul_kernel(const at::Tensor& src,
+                              const at::Tensor& index,
+                              int64_t dim,
+                              const std::optional<at::Tensor>& optional_out,
+                              std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(), "scatter_mul (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "scatter_mul (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_mul (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() == index.dim(),
+              "scatter_mul (CUDA): src.dim() must equal index.dim() after "
+              "broadcasting (got src.dim()=",
+              src.dim(), ", index.dim()=", index.dim(), ")");
+
+  dim = dim < 0 ? src.dim() + dim : dim;
+  TORCH_CHECK(dim >= 0 && dim < src.dim(),
+              "scatter_mul (CUDA): dim out of range");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Convention 16: `.contiguous()` at the kernel boundary. The autograd
+  // wrapper passes a `broadcast(index, src, dim)`-expanded (non-contiguous)
+  // view; materialize it so the kernel can index by a single linear offset.
+  auto src_c = src.contiguous();
+  auto index_c = index.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "scatter_mul (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      sizes[dim] = 0;
+    } else {
+      sizes[dim] = 1 + index_c.max().cpu().data_ptr<int64_t>()[0];
+    }
+    // Multiplicative identity (1) so `atomicMul` accumulation starts cleanly.
+    out = at::ones(sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  int64_t B = 1;
+  for (int64_t i = 0; i < dim; ++i)
+    B *= src_c.size(i);
+  const int64_t E = src_c.size(dim);
+  const int64_t K = src_c.numel() / (B * E);
+  const int64_t N = out.size(dim);
+  const int64_t numel = src_c.numel();
+
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "scatter_mul_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        const auto* index_data = index_c.data_ptr<int64_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        scatter_mul_cuda_kernel<scalar_t>
+            <<<blocks((int)numel), threads(), 0, stream>>>(
+                src_data, index_data, out_data, E, K, N, numel);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+
+  return out;
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_sum"),
          TORCH_FN(scatter_sum_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::scatter_mul"),
+         TORCH_FN(scatter_mul_kernel));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -326,6 +326,216 @@ at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
 }
 
 // ============================================================================
+// `segment_mean_coo` — Commit 7.
+//
+// Strategy: reuse the `segment_sum_coo_*` kernels to compute the per-bucket
+// sum into `out`, then run a tiny counting kernel that atomically increments
+// a per-bucket `int64_t` count buffer, then divide `out` by `count` (clamped
+// at 1 to avoid div-by-zero for empty buckets).
+//
+// Count storage choice: a **separate `int64_t` buffer** of shape
+// `[..., out.size(dim)]` (leading dims match `index`, the reduction axis is
+// `N = out.size(dim)`). Upstream `pytorch_scatter` (`segment_coo_cuda.cu:
+// 199-203, 264-278`) instead reuses the `arg_out` slot typed as the input's
+// `scalar_t` and runs the sum kernel with a `nullptr` src to get count-of-1
+// behavior. We deviate for two reasons:
+//
+//   1. Precision: counting in `Half`/`BFloat16` saturates at the dtype's
+//      max representable integer (2048 / 256 for `Half`/`BFloat16`).
+//   2. Simplicity: a dedicated 1-thread-per-`src`-row counting kernel is
+//      trivial and avoids the `HAS_VAL=false` plumbing.
+//
+// Count tensor is `int64_t`; `atomicAdd(int64_t*, int64_t)` is provided in
+// `atomics.cuh`.
+
+// Counting kernel — one thread per `index` entry, atomically increments
+// `count[batch_offset + idx]`. `count` has shape `[B, N]` (leading dims of
+// `index` with the reduction axis replaced by `N = out.size(dim)`).
+__global__ void segment_mean_coo_count_cuda_kernel(
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    int64_t* __restrict__ count_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    // `(row_idx / D) * N + idx` picks the count slot inside the per-batch
+    // count row, matching the `out_idx` arithmetic in `segment_sum_coo`.
+    int count_idx = (row_idx / D) * static_cast<int>(N) + static_cast<int>(idx);
+    atomicAdd(count_data + count_idx, static_cast<int64_t>(1));
+  }
+}
+
+at::Tensor segment_mean_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_mean_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_mean_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_mean_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_mean_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (same rule as the sum
+  // kernel; matches upstream `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Match `segment_sum_coo`'s `out=` handling: caller owns the buffer, no
+    // zero-init. The mean semantics with `out=` thus combine the caller's
+    // initial value with the new sum before division (mirrors upstream
+    // `segment_coo_cuda.cu:175-179, 264-278`).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_mean_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      // Auto-infer from the last (sorted-ascending) index along `dim`.
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Zero-init so the `atomicAdd` sum pass starts from a clean slate.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (index_c.numel() == 0) {
+    return out;
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  // Count buffer: shape `[..., N]` (leading dims of `index`, reduction axis
+  // replaced by `N`). Same shape rule upstream uses for the MEAN-reuse
+  // `arg_out` (`segment_coo_cuda.cu:200-203`).
+  auto count_sizes = index_c.sizes().vec();
+  count_sizes[dim] = N;
+  auto count = at::zeros(count_sizes, index_c.options());  // `int64_t`
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // -------- Pass 1: sum into `out`. Reuses the `segment_sum_coo_*` kernels.
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_sum_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Same `TB` ladder as `segment_sum_coo` — picks the best
+          // per-thread inner-loop length for the average run.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+      });
+
+  // -------- Pass 2: count into `count`. One thread per `index` entry.
+  {
+    const int T = threads();
+    const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+    segment_mean_coo_count_cuda_kernel<<<B, T, 0, stream>>>(
+        index_info, count.data_ptr<int64_t>(), E, N);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  // -------- Pass 3: divide. Clamp count to >=1 to keep zero-count buckets
+  // unchanged (mirrors upstream `arg_out.masked_fill_(arg_out < 1, 1)` at
+  // `segment_coo_cuda.cu:269-270`). Then unsqueeze trailing K dims and
+  // broadcast-divide.
+  count.clamp_min_(1);
+  auto count_b = count;
+  for (int64_t i = dim + 1; i < out.dim(); ++i) {
+    count_b = count_b.unsqueeze(-1);
+  }
+  if (out.is_floating_point()) {
+    out.true_divide_(count_b);
+  } else {
+    out.div_(count_b, "floor");
+  }
+
+  return out;
+}
+
+// ============================================================================
 // `gather_coo` — Commit 6.
 //
 // Trivial gather: `out[i] = src[index[i]]` along `dim = index.dim() - 1`,
@@ -473,6 +683,8 @@ at::Tensor gather_coo_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
          TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
+         TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -553,6 +553,18 @@ static inline __device__ scalar_t device_min(scalar_t a, scalar_t b) {
   }
 }
 
+// Per-thread (register-level) `max`. Symmetric to `device_min` above; see the
+// comment there for why we route half-precision through `float`.
+template <typename scalar_t>
+static inline __device__ scalar_t device_max(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) > static_cast<float>(b) ? a : b;
+  } else {
+    return a > b ? a : b;
+  }
+}
+
 // ============================================================================
 // `segment_min_coo` — Commit 8.
 //
@@ -935,6 +947,360 @@ std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
 }
 
 // ============================================================================
+// `segment_max_coo` — Commit 9.
+//
+// Symmetric to `segment_min_coo` (commit 8) — same two-pass structure (value
+// pass then arg pass on the same stream), same K==1 / K>1 split, same `TB`
+// ladder for the broadcast kernel. The only differences from the min path:
+//
+//   * `out` is initialized to `numeric_limits<scalar_t>::lowest()` (versus
+//     `::max()` for min) so the first contributor's `atomicMax` wins.
+//   * The warp-tree and broadcast inner loops use `device_max` (`>` rather
+//     than `<`) and write via `atomicMax`.
+//   * The arg pass still uses `atomicMin(arg_out + bucket, row_idx % D)` —
+//     ties resolve to the *first* matching position, matching the CPU
+//     kernel's deterministic semantics (strict `>` on the CPU means the
+//     first occurrence of the maximum wins; on CUDA we get the same effect
+//     by letting the lowest index win the CAS).
+
+// Value-pass K==1 kernel. Mirrors `segment_min_coo_cuda_kernel` with `>` and
+// `atomicMax`.
+template <typename scalar_t>
+__global__ void segment_max_coo_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int lane_idx = row_idx & (WARP_SIZE - 1);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int64_t next_idx;
+    int out_idx = (row_idx / D) * N + idx;
+
+    scalar_t val = src_data[row_idx];
+    scalar_t tmp;
+
+#pragma unroll
+    for (int i = 1; i < WARP_SIZE; i *= 2) {
+      // Warp-tree max reduction. Argindex is reconstructed in the arg pass
+      // by matching `src[i] == out[bucket]`.
+      tmp = SHFL_UP_SYNC(FULL_MASK, val, i);
+      next_idx = SHFL_UP_SYNC(FULL_MASK, idx, i);
+      if (lane_idx >= i && row_idx / D == (row_idx - i) / D) {
+        if (idx == next_idx) {
+          val = device_max(val, tmp);
+        }
+      }
+    }
+
+    // Tail-of-run lane writes via `atomicMax`.
+    next_idx = SHFL_DOWN_SYNC(FULL_MASK, idx, 1);
+    if (lane_idx == WARP_SIZE - 1 || row_idx / D != (row_idx + 1) / D ||
+        idx != next_idx) {
+      atomicMax(out_data + out_idx, val);
+    }
+  }
+}
+
+// Value-pass K>1 broadcast kernel. Mirrors
+// `segment_min_coo_broadcast_cuda_kernel` with `device_max` / `atomicMax`.
+template <typename scalar_t, int TB>
+__global__ void segment_max_coo_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int D = index_info.sizes[index_info.dims - 1];
+  int E_1 = E / D;
+  int E_2 = (D - 1) + TB - ((D - 1) % TB);
+
+  int row_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  int col_idx = blockIdx.y * blockDim.x + threadIdx.x;
+
+  int dim_start = (row_idx * TB) / E_2;
+  int row_start = (row_idx * TB) % E_2;
+
+  if (dim_start < E_1 && col_idx < K) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        dim_start * D + row_start, index_info);
+    int64_t idx1 = index_info.data[offset];
+    int64_t idx2;
+
+    scalar_t val = src_data[K * (dim_start * D + row_start) + col_idx];
+
+#pragma unroll
+    for (int i = 1; i < TB; ++i) {
+      if (row_start + i >= D)
+        break;
+
+      idx2 =
+          index_info.data[offset + i * index_info.strides[index_info.dims - 1]];
+      if (idx1 == idx2) {
+        scalar_t cand = src_data[K * (dim_start * D + row_start + i) + col_idx];
+        val = device_max(val, cand);
+      } else {
+        atomicMax(out_data + (dim_start * N + idx1) * K + col_idx, val);
+        val = src_data[K * (dim_start * D + row_start + i) + col_idx];
+      }
+      idx1 = idx2;
+    }
+
+    atomicMax(out_data + (dim_start * N + idx1) * K + col_idx, val);
+  }
+}
+
+// Arg-pass K==1 kernel. Identical to the min variant — the arg pass only
+// cares about *matching* values, not the direction of the comparison.
+template <typename scalar_t>
+__global__ void segment_max_coo_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx = (row_idx / D) * static_cast<int>(N) + static_cast<int>(idx);
+
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[row_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[row_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+// Arg-pass K>1 broadcast kernel. Identical to the min variant.
+template <typename scalar_t>
+__global__ void segment_max_coo_arg_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < static_cast<int>(E) && col_idx < static_cast<int>(K)) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx =
+        ((row_idx / D) * static_cast<int>(N) + static_cast<int>(idx)) *
+            static_cast<int>(K) +
+        col_idx;
+
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[thread_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_max_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_max_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_max_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_max_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_max_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream convention;
+  // matches the sum/mean/min kernels above and `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  // Sentinel for `arg_out` (matches `scatter_max`'s sentinel).
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no init. With `out=` supplied, the caller's
+    // initial values participate in the `atomicMax` reduction.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_max_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninit then fill with per-dtype `lowest()`. Same rationale as
+    // the min kernel — `at::full` with a single host `Scalar` can't represent
+    // each dtype's lowest correctly.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_max_coo_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::lowest()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E_dim = src.size(dim)` (matches the min kernel).
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          index_c.options().dtype(at::ScalarType::Long));
+
+  if (index_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors -> every bucket is empty; reset to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_max_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // -------- Value pass.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_max_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Same `TB` ladder as `segment_sum_coo` / `segment_min_coo`.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_max_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_max_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_max_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_max_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+
+        // -------- Arg pass. Same stream -> value-pass writes visible.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_max_coo_arg_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, index_info, out_data, arg_out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E * K + T - 1) / T));
+          segment_max_coo_arg_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data,
+                                    arg_out_data, E, K, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that bucket, so `out` still holds `numeric_limits::lowest()`. Reset to
+  // `0` to match the CPU kernel's contract. Skipped when `out=` is
+  // supplied — the caller's pre-existing values in empty buckets must be
+  // preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
+// ============================================================================
 // `gather_coo` — Commit 6.
 //
 // Trivial gather: `out[i] = src[index[i]]` along `dim = index.dim() - 1`,
@@ -1086,6 +1452,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_mean_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
          TORCH_FN(segment_min_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_coo"),
+         TORCH_FN(segment_max_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -535,6 +535,405 @@ at::Tensor segment_mean_coo_kernel(
   return out;
 }
 
+// Per-thread (register-level) `min` for the warp-tree and broadcast inner
+// loops. We do **not** use the built-in `<` operator on `at::Half` /
+// `at::BFloat16`: when `cuda_fp16.hpp` is included alongside `c10::Half`,
+// both an `operator<(__half, __half)` and the built-in `arithmetic <
+// arithmetic` participate in overload resolution and nvcc rejects the call as
+// ambiguous (same reason `atomicMinHalf` in `atomics.cuh` compares via
+// `static_cast<float>`). We dispatch on the dtype: half-precision goes through
+// `float`; everything else uses the natural operator.
+template <typename scalar_t>
+static inline __device__ scalar_t device_min(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) < static_cast<float>(b) ? a : b;
+  } else {
+    return a < b ? a : b;
+  }
+}
+
+// ============================================================================
+// `segment_min_coo` — Commit 8.
+//
+// Two CUDA kernels, launched on the same stream so completion ordering is
+// implicit:
+//
+//   1. Value pass — same structure as `segment_sum_coo`:
+//        * K==1: `segment_min_coo_cuda_kernel<scalar_t>` with `SHFL_UP_SYNC`
+//          warp-tree reduction over `val` only. The shuffle does **not**
+//          propagate `(value, idx)` pairs — argindex is assigned in a
+//          separate post-pass. At run boundaries the tail lane writes via
+//          `atomicMin(out_data + out_idx, val)` (CAS-loop helper from
+//          commit 4 in `atomics.cuh`).
+//        * K>1: `segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>` with
+//          the same `TB ∈ {4, 8, 16, 32}` ladder as `segment_sum_coo`.
+//
+//   2. Arg pass — `segment_min_coo_arg_cuda_kernel<scalar_t>` (and a
+//      broadcast variant for K>1) re-scans `src` and, where `src[i] ==
+//      out[bucket]`, performs `atomicMin(arg_out + bucket, i_within_dim)`
+//      over `int64_t`. Initialising `arg_out` to the sentinel
+//      `src.size(dim)` makes any valid contributor win the CAS and produces
+//      deterministic "first match" semantics (mirrors `scatter_min`'s
+//      arg pass).
+//
+// After both kernels: when we allocated `out` ourselves, we clear empty
+// buckets via `out.masked_fill_(arg_out == src.size(dim), 0)` so empty
+// buckets produce `0` instead of `numeric_limits::max()`.
+
+// Value-pass K==1 kernel. Mirrors `segment_sum_coo_cuda_kernel` but reduces
+// via `min` and writes via `atomicMin`. The shuffle propagates `val` only.
+template <typename scalar_t>
+__global__ void segment_min_coo_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int lane_idx = row_idx & (WARP_SIZE - 1);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int64_t next_idx;
+    int out_idx = (row_idx / D) * N + idx;
+
+    scalar_t val = src_data[row_idx];
+    scalar_t tmp;
+
+#pragma unroll
+    for (int i = 1; i < WARP_SIZE; i *= 2) {
+      // Warp-tree min reduction: same control flow as the sum kernel, but
+      // the per-pair update is `val = min(val, tmp)`. Argindex is NOT
+      // propagated through the shuffle — it is reconstructed in the arg
+      // pass by matching `src[i] == out[bucket]`.
+      tmp = SHFL_UP_SYNC(FULL_MASK, val, i);
+      next_idx = SHFL_UP_SYNC(FULL_MASK, idx, i);
+      if (lane_idx >= i && row_idx / D == (row_idx - i) / D) {
+        if (idx == next_idx) {
+          val = device_min(val, tmp);
+        }
+      }
+    }
+
+    // Tail-of-run lane writes via `atomicMin`. Conditions identical to the
+    // sum kernel: last lane in warp, outer-batch boundary, or next-row
+    // index differs.
+    next_idx = SHFL_DOWN_SYNC(FULL_MASK, idx, 1);
+    if (lane_idx == WARP_SIZE - 1 || row_idx / D != (row_idx + 1) / D ||
+        idx != next_idx) {
+      atomicMin(out_data + out_idx, val);
+    }
+  }
+}
+
+// Value-pass K>1 broadcast kernel. Mirrors
+// `segment_sum_coo_broadcast_cuda_kernel` but the per-thread accumulator is
+// `min` instead of `sum`, and the cross-thread atomic write is `atomicMin`.
+template <typename scalar_t, int TB>
+__global__ void segment_min_coo_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int D = index_info.sizes[index_info.dims - 1];
+  int E_1 = E / D;
+  int E_2 = (D - 1) + TB - ((D - 1) % TB);
+
+  int row_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  int col_idx = blockIdx.y * blockDim.x + threadIdx.x;
+
+  int dim_start = (row_idx * TB) / E_2;
+  int row_start = (row_idx * TB) % E_2;
+
+  if (dim_start < E_1 && col_idx < K) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        dim_start * D + row_start, index_info);
+    int64_t idx1 = index_info.data[offset];
+    int64_t idx2;
+
+    scalar_t val = src_data[K * (dim_start * D + row_start) + col_idx];
+
+#pragma unroll
+    for (int i = 1; i < TB; ++i) {
+      if (row_start + i >= D)
+        break;
+
+      idx2 =
+          index_info.data[offset + i * index_info.strides[index_info.dims - 1]];
+      if (idx1 == idx2) {
+        scalar_t cand = src_data[K * (dim_start * D + row_start + i) + col_idx];
+        val = device_min(val, cand);
+      } else {
+        atomicMin(out_data + (dim_start * N + idx1) * K + col_idx, val);
+        val = src_data[K * (dim_start * D + row_start + i) + col_idx];
+      }
+      idx1 = idx2;
+    }
+
+    atomicMin(out_data + (dim_start * N + idx1) * K + col_idx, val);
+  }
+}
+
+// Arg-pass K==1 kernel. Re-scans `src` and lowers `arg_out[bucket]` to
+// `row_idx % D` (position within the reduction axis) where `src[i] ==
+// out[bucket]`. Uses `atomicMin` so the *smallest* `e` wins on ties —
+// matches `scatter_min_arg_cuda_kernel`'s deterministic semantics.
+template <typename scalar_t>
+__global__ void segment_min_coo_arg_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx = (row_idx / D) * static_cast<int>(N) + static_cast<int>(idx);
+
+    // Bit-exact equality. For `at::Half` / `at::BFloat16` we cast through
+    // `.x` for the same reason as `scatter_min_arg_cuda_kernel` (see the
+    // detailed comment there). The value pass wrote a specific bit pattern;
+    // we are checking for that exact pattern in `src`.
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[row_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[row_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+// Arg-pass K>1 broadcast kernel. One thread per `(row, col)` — re-reads
+// `out[bucket, col]` and lowers `arg_out[bucket, col]` to `row_idx % D` on
+// match.
+template <typename scalar_t>
+__global__ void segment_min_coo_arg_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    const scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < static_cast<int>(E) && col_idx < static_cast<int>(K)) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int out_idx =
+        ((row_idx / D) * static_cast<int>(N) + static_cast<int>(idx)) *
+            static_cast<int>(K) +
+        col_idx;
+
+    bool match;
+    if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                  std::is_same_v<scalar_t, at::BFloat16>) {
+      match = src_data[thread_idx].x == out_data[out_idx].x;
+    } else {
+      match = src_data[thread_idx] == out_data[out_idx];
+    }
+    if (match) {
+      atomicMin(arg_out_data + out_idx, static_cast<int64_t>(row_idx % D));
+    }
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_min_coo_kernel(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& optional_out,
+    std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_min_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_min_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_min_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_min_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream convention;
+  // matches the sum/mean kernels above and `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  // `E_dim = src.size(dim)` is the sentinel value for `arg_out` (matches
+  // `scatter_min`'s sentinel). It is also the per-row D of `src` along the
+  // reduction axis.
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no init. The min semantics with `out=` thus
+    // combine the caller's initial value with the computed minima via
+    // `atomicMin` (matches upstream `segment_coo_cuda.cu:175-179`).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_min_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Allocate uninit then fill with per-dtype `max()`. Same rationale as
+    // `scatter_min_kernel` (see `scatter_kernel.cu`): `at::full` with a
+    // single host `Scalar` can't represent each dtype's max correctly.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_min_coo_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always allocated and always initialized to the sentinel
+  // `E_dim = src.size(dim)`. Even when `out=` is supplied, `arg_out` is
+  // fresh (the schema returns it; the caller has no way to pre-allocate).
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          index_c.options().dtype(at::ScalarType::Long));
+
+  if (index_c.numel() == 0) {
+    if (!out_was_provided) {
+      // No contributors at all -> every bucket is empty; reset to 0.
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        // -------- Value pass.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_min_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Same `TB` ladder as `segment_sum_coo`.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_min_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+
+        // -------- Arg pass. Same stream -> value-pass writes visible.
+        if (K == 1) {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_min_coo_arg_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, index_info, out_data, arg_out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E * K + T - 1) / T));
+          segment_min_coo_arg_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data,
+                                    arg_out_data, E, K, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-bucket cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that bucket, so `out` still holds `numeric_limits::max()`. Reset to `0`
+  // to match the CPU kernel's contract. Skipped when `out=` is supplied —
+  // the caller's pre-existing values in empty buckets must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // ============================================================================
 // `gather_coo` — Commit 6.
 //
@@ -685,6 +1084,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_sum_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_coo"),
          TORCH_FN(segment_mean_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_coo"),
+         TORCH_FN(segment_min_coo_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_coo_kernel.cu
@@ -1,0 +1,480 @@
+#include "../segment_coo.h"
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+
+#include "atomics.cuh"
+#include "shuffle.cuh"
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). Already defined by `scatter_kernel.cu` in its own TU; we
+// redefine guarded here so the two TUs stay independent.
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+// Full-warp mask for `__shfl_*_sync` — every lane participates.
+#define FULL_MASK 0xffffffff
+
+// Convention 12: dynamic block sizing. Replicates the inline `threads()` /
+// `blocks()` pattern from `scatter_kernel.cu` (which itself is a copy of
+// `pyg_lib/csrc/sampler/cuda/random_walk_kernel.cu`). Each new kernel file in
+// `pyg_lib/csrc/ops/cuda/` carries its own copy until a shared helper lands.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// ============================================================================
+// `segment_sum_coo` — Commit 6.
+//
+// Two CUDA kernel variants:
+//
+//   1. `segment_sum_coo_cuda_kernel` (K==1, no trailing feature dims). One
+//   thread
+//      per `src` entry. `SHFL_UP_SYNC` performs a warp-level tree reduction
+//      across equal indices within a single warp. Lanes that hold the tail of
+//      a run (next-lane index differs or warp boundary) atomically write the
+//      accumulated value into `out[index]`. Port of upstream
+//      `pytorch_scatter/csrc/cuda/segment_coo_cuda.cu:14-53` — see also the
+//      design note in `PLAN_PYTORCH_SCATTER.md:363-366`.
+//
+//   2. `segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>` (K>1). Each thread
+//      processes a single column and `TB` consecutive index entries. The
+//      host-side dispatcher chooses `TB ∈ {4, 8, 16, 32}` based on the
+//      average run length `avg_len = index.size(dim) / dim_size`. Port of
+//      upstream `segment_coo_cuda.cu:76-127, 225-248`.
+
+// K==1 kernel — one thread per `src` entry, warp-reduce equal-index runs.
+//
+// `index_info` is `at::cuda::detail::TensorInfo<int64_t, int>` so we can
+// resolve a possibly-strided `index` view through `IndexToOffset` without
+// materializing a contiguous copy. The dispatcher passes the linear-strided
+// `.contiguous()` index, but the TensorInfo handle is the cheapest way to
+// reuse upstream's offset arithmetic verbatim.
+template <typename scalar_t>
+__global__ void segment_sum_coo_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int lane_idx = row_idx & (WARP_SIZE - 1);
+  int D = index_info.sizes[index_info.dims - 1];
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int64_t idx = index_info.data[offset];
+    int64_t next_idx;
+    int out_idx = (row_idx / D) * N + idx;
+
+    scalar_t val = src_data[row_idx];
+    scalar_t tmp;
+
+#pragma unroll
+    for (int i = 1; i < WARP_SIZE; i *= 2) {
+      // Parallel reduction inside a single warp. `SHFL_UP_SYNC` pulls the
+      // value/index from lane `lane_idx - i`; if that lane belongs to the
+      // same outer-batch and shares the same `idx`, we fold it into `val`.
+      tmp = SHFL_UP_SYNC(FULL_MASK, val, i);
+      next_idx = SHFL_UP_SYNC(FULL_MASK, idx, i);
+      if (lane_idx >= i && row_idx / D == (row_idx - i) / D) {
+        // Upstream asserts `idx >= next_idx` (sorted-index UB contract).
+        if (idx == next_idx) {
+          val = val + tmp;
+        }
+      }
+    }
+
+    // The lane that holds the *tail* of a run writes the accumulated value
+    // to `out`. Conditions for being a tail:
+    //   * last lane in the warp (`lane_idx == WARP_SIZE - 1`), or
+    //   * boundary in the outer-batch dimension (`row_idx / D != (row_idx +
+    //     1) / D`), or
+    //   * next-row's index differs from this row's.
+    next_idx = SHFL_DOWN_SYNC(FULL_MASK, idx, 1);
+    if (lane_idx == WARP_SIZE - 1 || row_idx / D != (row_idx + 1) / D ||
+        idx != next_idx) {
+      atomicAdd(out_data + out_idx, val);
+    }
+  }
+}
+
+// K>1 broadcast kernel. Each thread owns one column `(col_idx)` and `TB`
+// consecutive index entries starting at `(dim_start, row_start)`. We sweep
+// the `TB` entries in registers, accumulating equal-index runs and writing
+// out to `out` via `atomicAdd` whenever the run ends (next index differs or
+// we hit the `TB` boundary). Port of upstream
+// `segment_coo_broadcast_kernel`.
+//
+// `TB` is a compile-time literal (4, 8, 16, or 32) so the `#pragma unroll`
+// over the inner loop bites and the per-thread register pressure stays
+// predictable.
+template <typename scalar_t, int TB>
+__global__ void segment_sum_coo_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int D = index_info.sizes[index_info.dims - 1];
+  int E_1 = E / D;
+  // Round `D-1` up to a multiple of `TB`. The thread that lands on
+  // `dim_start * D + row_start + i` for `i ∈ [0, TB)` only does work while
+  // `row_start + i < D`.
+  int E_2 = (D - 1) + TB - ((D - 1) % TB);
+
+  int row_idx = blockIdx.x * blockDim.y + threadIdx.y;
+  int col_idx = blockIdx.y * blockDim.x + threadIdx.x;
+
+  int dim_start = (row_idx * TB) / E_2;
+  int row_start = (row_idx * TB) % E_2;
+
+  if (dim_start < E_1 && col_idx < K) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        dim_start * D + row_start, index_info);
+    int64_t idx1 = index_info.data[offset];
+    int64_t idx2;
+
+    scalar_t val = src_data[K * (dim_start * D + row_start) + col_idx];
+
+#pragma unroll
+    for (int i = 1; i < TB; ++i) {
+      if (row_start + i >= D)
+        break;
+
+      idx2 =
+          index_info.data[offset + i * index_info.strides[index_info.dims - 1]];
+      // Upstream asserts `idx1 <= idx2` (sorted-index UB contract).
+      if (idx1 == idx2) {
+        val = val + src_data[K * (dim_start * D + row_start + i) + col_idx];
+      } else {
+        atomicAdd(out_data + (dim_start * N + idx1) * K + col_idx, val);
+        val = src_data[K * (dim_start * D + row_start + i) + col_idx];
+      }
+      idx1 = idx2;
+    }
+
+    atomicAdd(out_data + (dim_start * N + idx1) * K + col_idx, val);
+  }
+}
+
+at::Tensor segment_sum_coo_kernel(const at::Tensor& src,
+                                  const at::Tensor& index,
+                                  const std::optional<at::Tensor>& optional_out,
+                                  std::optional<int64_t> dim_size) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_sum_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "segment_sum_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_sum_coo (CUDA): src and index must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "segment_sum_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index` up to `src.shape[:index.dim()]` (upstream convention;
+  // matches `segment_coo_cpu.cpp` and `segment_coo_cuda.cu:164-168`).
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim(); ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  // COO ops do not take `dim` from Python — it is always `index.dim() - 1`.
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Accumulate-into contract: caller owns the buffer, no zero-init.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_sum_coo (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (dim_size.has_value()) {
+      out_sizes[dim] = dim_size.value();
+    } else if (index_c.numel() == 0) {
+      out_sizes[dim] = 0;
+    } else {
+      // Auto-infer from the last index along `dim` — sorted-index contract
+      // means this is the maximum index. Mirrors upstream
+      // `segment_coo_cuda.cu:187-189`.
+      auto tail = index_c.select(dim, index_c.size(dim) - 1);
+      tail = tail.numel() > 1 ? tail.max() : tail;
+      out_sizes[dim] = 1 + tail.cpu().data_ptr<int64_t>()[0];
+    }
+    // Zero-init so the `atomicAdd` accumulation starts from a clean slate.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (index_c.numel() == 0) {
+    return out;
+  }
+
+  const auto E = index_c.numel();
+  const auto E_2 = index_c.size(dim);
+  const auto E_1 = E / E_2;
+  const auto K = src_c.numel() / E;
+  const auto N = out.size(dim);
+  const float avg_len = static_cast<float>(E_2) / static_cast<float>(N);
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per `src` entry; warp-reduce equal-index runs in
+          // shuffle, then a single `atomicAdd` per run's tail. The launch
+          // grid uses the dynamic `threads()` / `blocks(E)` helpers; the
+          // shuffle reduction depends only on warp lanes (warp-relative
+          // indices via `row_idx & 31`), not block geometry, so any block
+          // size that is a multiple of WARP_SIZE works. `threads()` always
+          // returns a multiple of 32 on every supported arch.
+          const int T = threads();
+          const int B = std::max(1, static_cast<int>((E + T - 1) / T));
+          segment_sum_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // Broadcast path. Pick `TB ∈ {4, 8, 16, 32}` from `avg_len` — the
+          // larger the average run, the more entries each thread should
+          // sweep before writing out. Mirrors upstream
+          // `segment_coo_cuda.cu:225-248`.
+          //
+          // The grid geometry is `(rows_blocks, cols_blocks)` with block
+          // `(32, 8)`: 32 threads along `K` (one warp per column tile) and
+          // 8 threads along the row axis. We launch enough row blocks to
+          // cover `E_1 * ceil(E_2 / TB)` row-positions in groups of 8.
+          const dim3 block_dim(32, 8);
+          const dim3 grid_cols((K + 31) / 32);
+          if (avg_len <= 8.0f) {
+            constexpr int TB = 4;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 16.0f) {
+            constexpr int TB = 8;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else if (avg_len <= 32.0f) {
+            constexpr int TB = 16;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          } else {
+            constexpr int TB = 32;
+            const dim3 grid_dim((E_1 * ((E_2 + TB - 1) / TB) + 7) / 8,
+                                grid_cols.x);
+            segment_sum_coo_broadcast_cuda_kernel<scalar_t, TB>
+                <<<grid_dim, block_dim, 0, stream>>>(src_data, index_info,
+                                                     out_data, E, K, N);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
+        }
+      });
+
+  return out;
+}
+
+// ============================================================================
+// `gather_coo` — Commit 6.
+//
+// Trivial gather: `out[i] = src[index[i]]` along `dim = index.dim() - 1`,
+// with broadcasting over the trailing feature dims. Two kernel variants:
+//
+//   * K==1: one thread per output element, straight `__ldg`-load gather.
+//   * K>1: one thread per `(row, col)` pair, same load pattern.
+//
+// `out=` contract: overwrite (not accumulate). When `out=` is supplied we
+// write into the caller's buffer; otherwise we allocate `at::empty(...)`.
+// No zero-init in either case — every output element is written exactly once.
+
+template <typename scalar_t>
+__global__ void gather_coo_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t N) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (row_idx < E) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int row = static_cast<int>(index_info.data[offset]);
+
+    // `(row_idx / D) * N` picks the outer-batch slice of `src` and `row`
+    // is the index within that slice. `D = index.size(dim)`.
+    offset =
+        (row_idx / index_info.sizes[index_info.dims - 1]) * static_cast<int>(N);
+    out_data[row_idx] = src_data[offset + row];
+  }
+}
+
+template <typename scalar_t>
+__global__ void gather_coo_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> index_info,
+    scalar_t* __restrict__ out_data,
+    size_t E,
+    size_t K,
+    size_t N) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx < static_cast<int>(E * K)) {
+    int offset = at::cuda::detail::IndexToOffset<int64_t, int, -1>::get(
+        row_idx, index_info);
+    int row = static_cast<int>(index_info.data[offset]);
+
+    offset = (row_idx / index_info.sizes[index_info.dims - 1]) *
+             static_cast<int>(N) * static_cast<int>(K);
+    out_data[thread_idx] =
+        src_data[offset + static_cast<int>(K) * row + col_idx];
+  }
+}
+
+at::Tensor gather_coo_kernel(const at::Tensor& src,
+                             const at::Tensor& index,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(), "gather_coo (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(index.is_cuda(),
+              "gather_coo (CUDA): index must be a CUDA tensor");
+  TORCH_CHECK(src.device() == index.device(),
+              "gather_coo (CUDA): src and index must be on the same device");
+  TORCH_CHECK(src.dim() >= index.dim(),
+              "gather_coo (CUDA): src.dim() must be >= index.dim() (got ",
+              src.dim(), " vs ", index.dim(), ")");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `index`'s leading dims up to `src.shape[:index.dim() - 1]`.
+  // Upstream uses `index.dim() - 1` as the broadcast bound (not `index.dim()`)
+  // because `index.size(dim)` is the output's *reduction-axis* extent, not a
+  // batch dim. Matches `segment_coo_cuda.cu:337-340`.
+  auto sizes = index.sizes().vec();
+  for (int64_t i = 0; i < index.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto index_b = index.expand(sizes);
+
+  const auto dim = index_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto index_c = index_b.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    // Overwrite contract: every output element is written exactly once.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < src_c.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "gather_coo (CUDA): out.size(", i, ") must match src.size(",
+                    i, ")");
+      }
+    }
+    TORCH_CHECK(index_c.size(dim) == out.size(dim),
+                "gather_coo (CUDA): out.size(", dim, ") must match index.size(",
+                dim, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = index_c.size(dim);
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (index_c.numel() == 0) {
+    return out;
+  }
+
+  const auto E = index_c.numel();
+  const auto K = out.numel() / E;
+  const auto N = src_c.size(dim);
+
+  auto index_info = at::cuda::detail::getTensorInfo<int64_t, int>(index_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_coo_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          const int T = threads();
+          const int B = blocks(static_cast<int>(E));
+          gather_coo_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = blocks(static_cast<int>(E * K));
+          gather_coo_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, index_info, out_data, E, K, N);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_coo"),
+         TORCH_FN(segment_sum_coo_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_coo"), TORCH_FN(gather_coo_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -1,0 +1,450 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 12: dynamic block sizing — replicates the inline `threads()` /
+// `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
+// Each `.cu` file in `pyg_lib/csrc/ops/cuda/` carries its own copy until a
+// shared helper lands.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// Strided-offset helper specialised for `indptr` row pointers.
+//
+// `at::cuda::detail::IndexToOffset` walks all dims of a `TensorInfo` and is
+// suitable for COO `index` (where the last dim's size matches the number of
+// reduced rows). For CSR `indptr` we need the **same arithmetic with the last
+// dim's effective size reduced by 1** — `indptr` has `rows + 1` entries per
+// batch (one trailing sentinel), but we only index `[0, rows)` from the
+// kernel. Port of upstream `pytorch_scatter/csrc/cuda/index_info.cuh:7-19`.
+struct IndexPtrToOffset {
+  static __host__ __device__ __forceinline__ int get(
+      int idx,
+      const at::cuda::detail::TensorInfo<int64_t, int>& info) {
+    int offset = idx % (info.sizes[info.dims - 1] - 1);
+    offset *= info.strides[info.dims - 1];
+    idx /= info.sizes[info.dims - 1] - 1;
+    for (int i = info.dims - 2; i >= 0; --i) {
+      offset += (idx % info.sizes[i]) * info.strides[i];
+      idx /= info.sizes[i];
+    }
+    return offset;
+  }
+};
+
+// ============================================================================
+// `segment_sum_csr` — Commit 10.
+//
+// Two CUDA kernel variants:
+//
+//   1. `segment_sum_csr_cuda_kernel` (K==1, no trailing feature dims). One
+//      thread per row; sequential inner loop summing
+//      `src[indptr[r] : indptr[r+1]]` into `out[r]`. Port of upstream
+//      `pytorch_scatter/csrc/cuda/segment_csr_cuda.cu:15-60` with `TB == 1`
+//      — TB==1 means single thread per row, so the warp-tree shuffle path is
+//      dead code and is omitted entirely. The `SHFL_DOWN_SYNC` reduction only
+//      fires for the min/max ops (commits 12/13) where TB > 1.
+//
+//   2. `segment_sum_csr_broadcast_cuda_kernel` (K>1, trailing feature dims).
+//      One thread per `(row, col)` pair; each thread sequentially walks the
+//      row's source range. Port of upstream `segment_csr_cuda.cu:62-95`.
+//      Per the upstream comment at line 70, shared-memory reuse was tried
+//      and discarded — the syncthreads overhead exceeded the benefit, so we
+//      keep the same "no shared memory" design here.
+//
+// Accumulation is in `at::opmath_type<scalar_t>` registers; the final cast
+// back to `scalar_t` matches upstream behaviour for `Half`/`BFloat16`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we
+// **accumulate** into it (no zero-init). Matches the upstream `segment_csr`
+// contract and is what makes `GatherCSR::backward` efficient (`at::zeros` +
+// `segment_sum_csr(out=grad_in)` deposits the gradient in-place).
+
+// K==1 kernel — one thread per row.
+template <typename scalar_t>
+__global__ void segment_sum_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Compute the strided indptr offset for this row.
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Upstream
+  // computes this via
+  //   `(row_idx / (indptr.size(-1) - 1)) * E`
+  // where `E = src.size(dim)`. Mirrors `segment_csr_cuda.cu:38-43`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(src_data[batch_offset + src_idx]);
+  }
+
+  // Accumulate into `out`. The dispatcher zero-inits a freshly allocated
+  // `out`; when the caller supplies `out=`, we **add** to it (accumulate
+  // contract used by `GatherCSR::backward`). For empty rows
+  // (`row_end == row_start`), `val == 0` so the existing value is preserved.
+  out_data[row_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[row_idx]) + val);
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair.
+template <typename scalar_t>
+__global__ void segment_sum_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` includes the trailing `K` extent.
+  // Mirrors `segment_csr_cuda.cu:85`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx]);
+  }
+
+  // Accumulate-into contract (see K==1 kernel above).
+  out_data[thread_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[thread_idx]) + val);
+}
+
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_sum_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_sum_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_sum_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // CSR convention: `indptr` is `expand`-broadcast up to
+  // `src.shape[:indptr.dim()-1]` so the leading batch dims match. The last
+  // dim of `indptr` is the row pointer itself and stays at its native size.
+  // Mirrors `segment_csr_cuda.cu:108-112`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  // CSR ops fix the reduction axis at the last `indptr` dim.
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Accumulate-into contract: caller owns the buffer, no zero-init.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_sum_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_sum_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Zero-init so the in-kernel `+=` accumulation produces the correct
+    // result for a freshly allocated buffer.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  // `N` is the total number of rows across all leading batch dims (upstream
+  // `segment_csr_cuda.cu:144`). `K` is the product of trailing feature dims
+  // past the reduction axis (upstream line 145). `E` is `src.size(dim)`.
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row, sequential inner sum. No SHFL — TB == 1
+          // means there's only one lane per row.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          segment_sum_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col). Sequential row scan in inner loop.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_sum_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+// ============================================================================
+// `gather_csr` — Commit 10.
+//
+// Symmetric inverse of `segment_sum_csr`: for each row `r`, broadcast
+// `src[r]` to every output position `[indptr[r], indptr[r+1])` along the
+// reduction axis. Two kernel variants:
+//
+//   * K==1: one thread per row writes the row value to all `[row_start,
+//     row_end)` output positions. Port of upstream `segment_csr_cuda.cu:
+//     171-192` with `TB == 1`. (Upstream uses TB=4 to get more parallelism
+//     for long rows; we mirror that ladder via the dynamic block-size
+//     dispatch — see comment below.)
+//   * K>1: one thread per `(row, col)` pair, same write pattern with the
+//     trailing `K` extent. Port of upstream `segment_csr_cuda.cu:194-217`.
+//
+// `out=` contract: **overwrite** (not accumulate) — every output element is
+// written exactly once. Matches upstream `gather_csr`. The output sizing
+// rule allocates the same shape as `src` with the reduction axis replaced
+// by `indptr[..., -1]` (upstream lines 245-253).
+
+template <typename scalar_t>
+__global__ void gather_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = __ldg(src_data + row_idx);
+
+  // Per-batch slice offset into `out` along the reduction axis. Mirrors
+  // upstream `segment_csr_cuda.cu:187`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + out_idx] = val;
+  }
+}
+
+template <typename scalar_t>
+__global__ void gather_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = src_data[thread_idx];
+
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + static_cast<int>(K) * out_idx + col_idx] = val;
+  }
+}
+
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(), "gather_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "gather_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr (CUDA): src and indptr must be on the same device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "gather_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `indptr` leading dims up to `src.shape[:indptr.dim()-1]`.
+  // Mirrors upstream `segment_csr_cuda.cu:229-232`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr (CUDA): src.size(", dim,
+              ") must be 0 or equal to indptr.size(-1) - 1 (got ",
+              src.size(dim), " vs ", indptr_b.size(dim) - 1, ")");
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    // Overwrite contract: every output element is written exactly once.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "gather_csr (CUDA): out.size(", i, ") must match src.size(",
+                    i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // `out.size(dim) = indptr[..., -1]` — the total number of "gathered"
+      // entries. Mirrors upstream `segment_csr_cuda.cu:247-252`. Reading
+      // the last entry of a contiguous flat `indptr` costs one D->H sync
+      // but is one-off (host-side allocation path).
+      out_sizes[dim] = indptr_c.flatten()[-1].cpu().data_ptr<int64_t>()[0];
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // `N` = total number of input rows across all batch dims (upstream
+  // `segment_csr_cuda.cu:261`). `K` = trailing feature-dim extent. `E` =
+  // `out.size(dim)` — the per-batch output length.
+  const auto N = src_c.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = src_c.numel() / N;
+  const auto E = out.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row writes the row value to all output positions
+          // in `[row_start, row_end)`.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          gather_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col); same write pattern with the trailing
+          // `K` extent.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          gather_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/shuffle.cuh
+++ b/pyg_lib/csrc/ops/cuda/shuffle.cuh
@@ -1,0 +1,147 @@
+#pragma once
+
+// Warp-shuffle helpers for `pyg::segment_*` CUDA kernels.
+//
+// Port of upstream `pytorch_scatter/csrc/cuda/utils.cuh:16-46`. CUDA's built-in
+// `__shfl_up_sync` / `__shfl_down_sync` intrinsics are templated over the
+// arithmetic dtypes (int, float, double, ...) but do **not** natively support
+// `at::Half` / `at::BFloat16`. We provide thin overloads that bit-cast the
+// half-precision value through the underlying `unsigned short` storage so the
+// compiler can resolve the shuffle to the native 32-bit `__shfl_*_sync`
+// variant.
+//
+// The `SHFL_UP_SYNC` / `SHFL_DOWN_SYNC` macros expand to the `_sync` variants
+// on CUDA and to the deprecated unsync `__shfl_*` builtins on ROCm (where the
+// `_sync` family is not available). Mirrors the upstream `#ifdef USE_ROCM`
+// split.
+
+#include <ATen/ATen.h>
+#include <cuda_runtime.h>
+
+// `warp_mask_t`: 32-bit on CUDA, 64-bit on ROCm. The mask is the first
+// argument of `__shfl_*_sync` and selects which lanes of the warp participate.
+// On CUDA we always use the full mask `0xffffffff`; on ROCm the wavefront is
+// 64-wide so the mask is 64-bit.
+#ifdef USE_ROCM
+using warp_mask_t = unsigned long long;
+#else
+using warp_mask_t = unsigned int;
+#endif
+
+// `at::Half` shuffle overloads. CUDA's `__shfl_*_sync` does not have a native
+// overload for `__half` on older toolkits (the 32-bit-wide `__shfl_xor_sync`
+// for `__half` was added in CUDA 9, but the `_up`/`_down` variants still want
+// an integral or floating-point lane value). We bit-cast through `unsigned
+// short` — `at::Half::x` is the IEEE 754 binary16 bit pattern stored as
+// `uint16_t` — which lets the compiler resolve to the 32-bit `__shfl_sync`
+// instruction (widened/narrowed automatically).
+//
+// The four-argument overload (mask, value, delta, width) is what the
+// `SHFL_UP_SYNC` / `SHFL_DOWN_SYNC` macros expand to from `__shfl_*_sync`
+// (which itself has an optional fourth `width` parameter defaulting to
+// `warpSize = 32`). We provide a 3-arg overload that forwards to the 4-arg one
+// with the default width.
+__device__ __inline__ at::Half __shfl_up_sync(const warp_mask_t mask,
+                                              const at::Half var,
+                                              const unsigned int delta,
+                                              const int width) {
+  // `at::Half::x` is `unsigned short`; pass it through `__shfl_up_sync(...,
+  // unsigned int, ...)`. The implicit widening to `unsigned int` is lossless.
+  at::Half ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_up_sync(mask, static_cast<unsigned int>(var.x), delta, width));
+  return ret;
+}
+
+__device__ __inline__ at::Half __shfl_up_sync(const warp_mask_t mask,
+                                              const at::Half var,
+                                              const unsigned int delta) {
+  return __shfl_up_sync(mask, var, delta, warpSize);
+}
+
+__device__ __inline__ at::Half __shfl_down_sync(const warp_mask_t mask,
+                                                const at::Half var,
+                                                const unsigned int delta,
+                                                const int width) {
+  at::Half ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_down_sync(mask, static_cast<unsigned int>(var.x), delta, width));
+  return ret;
+}
+
+__device__ __inline__ at::Half __shfl_down_sync(const warp_mask_t mask,
+                                                const at::Half var,
+                                                const unsigned int delta) {
+  return __shfl_down_sync(mask, var, delta, warpSize);
+}
+
+// `at::BFloat16` shuffle overloads. Mirror the `at::Half` overloads above.
+// `at::BFloat16::x` is also `uint16_t`, holding the BF16 bit pattern.
+__device__ __inline__ at::BFloat16 __shfl_up_sync(const warp_mask_t mask,
+                                                  const at::BFloat16 var,
+                                                  const unsigned int delta,
+                                                  const int width) {
+  at::BFloat16 ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_up_sync(mask, static_cast<unsigned int>(var.x), delta, width));
+  return ret;
+}
+
+__device__ __inline__ at::BFloat16 __shfl_up_sync(const warp_mask_t mask,
+                                                  const at::BFloat16 var,
+                                                  const unsigned int delta) {
+  return __shfl_up_sync(mask, var, delta, warpSize);
+}
+
+__device__ __inline__ at::BFloat16 __shfl_down_sync(const warp_mask_t mask,
+                                                    const at::BFloat16 var,
+                                                    const unsigned int delta,
+                                                    const int width) {
+  at::BFloat16 ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_down_sync(mask, static_cast<unsigned int>(var.x), delta, width));
+  return ret;
+}
+
+__device__ __inline__ at::BFloat16 __shfl_down_sync(const warp_mask_t mask,
+                                                    const at::BFloat16 var,
+                                                    const unsigned int delta) {
+  return __shfl_down_sync(mask, var, delta, warpSize);
+}
+
+// ROCm fallback uses the unsync `__shfl_up` / `__shfl_down` instead.
+#ifdef USE_ROCM
+__device__ __inline__ at::Half __shfl_up(const at::Half var,
+                                         const unsigned int delta) {
+  at::Half ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_up(static_cast<unsigned int>(var.x), delta));
+  return ret;
+}
+__device__ __inline__ at::Half __shfl_down(const at::Half var,
+                                           const unsigned int delta) {
+  at::Half ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_down(static_cast<unsigned int>(var.x), delta));
+  return ret;
+}
+__device__ __inline__ at::BFloat16 __shfl_up(const at::BFloat16 var,
+                                             const unsigned int delta) {
+  at::BFloat16 ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_up(static_cast<unsigned int>(var.x), delta));
+  return ret;
+}
+__device__ __inline__ at::BFloat16 __shfl_down(const at::BFloat16 var,
+                                               const unsigned int delta) {
+  at::BFloat16 ret;
+  ret.x = static_cast<unsigned short>(
+      __shfl_down(static_cast<unsigned int>(var.x), delta));
+  return ret;
+}
+#define SHFL_UP_SYNC(mask, var, delta) __shfl_up(var, delta)
+#define SHFL_DOWN_SYNC(mask, var, delta) __shfl_down(var, delta)
+#else
+#define SHFL_UP_SYNC __shfl_up_sync
+#define SHFL_DOWN_SYNC __shfl_down_sync
+#endif

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -123,6 +123,36 @@ PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_max(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_max"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_max: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_max: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_max", "")
+                       .typed<decltype(scatter_max)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
@@ -135,6 +165,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_min(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_max(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
 }
 

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -1,0 +1,45 @@
+#include "scatter.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor scatter_sum(const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& out,
+                               std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_sum"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_sum: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_sum: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_sum", "")
+                       .typed<decltype(scatter_sum)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -93,6 +93,36 @@ PYG_API at::Tensor scatter_mean(const at::Tensor& src,
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_min"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_min: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_min: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_min", "")
+                       .typed<decltype(scatter_min)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
@@ -103,6 +133,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_mean(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_min(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
 }
 
 }  // namespace ops

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -35,9 +35,41 @@ PYG_API at::Tensor scatter_sum(const at::Tensor& src,
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API at::Tensor scatter_mul(const at::Tensor& src,
+                               const at::Tensor& index,
+                               int64_t dim,
+                               const std::optional<at::Tensor>& out,
+                               std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_mul"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_mul: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_mul: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_mul", "")
+                       .typed<decltype(scatter_mul)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_mul(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
 }
 

--- a/pyg_lib/csrc/ops/scatter.cpp
+++ b/pyg_lib/csrc/ops/scatter.cpp
@@ -64,12 +64,44 @@ PYG_API at::Tensor scatter_mul(const at::Tensor& src,
   return op.call(src, index, dim, out, dim_size);
 }
 
+PYG_API at::Tensor scatter_mean(const at::Tensor& src,
+                                const at::Tensor& index,
+                                int64_t dim,
+                                const std::optional<at::Tensor>& out,
+                                std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"scatter_mean"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "scatter_mean: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 3};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "scatter_mean: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::scatter_mean", "")
+                       .typed<decltype(scatter_mean)>();
+  return op.call(src, index, dim, out, dim_size);
+}
+
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_sum(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::scatter_mul(Tensor src, Tensor index, int dim=-1, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::scatter_mean(Tensor src, Tensor index, int dim=-1, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
 }
 

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the indices specified in `index`
+// along a given axis `dim`.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// the symmetric-pair backwards (`gather_coo` / `gather_csr`) efficient.
+PYG_API at::Tensor scatter_sum(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -21,5 +21,20 @@ PYG_API at::Tensor scatter_sum(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Multiplies all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim`.
+//
+// When `out` is not provided, a fresh ones-initialized buffer is allocated
+// (so that the multiplicative reduction starts from the multiplicative
+// identity). When `out` *is* provided, the operation multiplies into the
+// caller's buffer (no ones-init); the caller is responsible for any non-
+// default starting state. This matches the upstream contract.
+PYG_API at::Tensor scatter_mul(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 }  // namespace ops
 }  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -84,5 +84,33 @@ PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Reduces all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim` using a maximum reduction, and returns
+// both the per-bucket maximum value and the source position that produced
+// it (`arg_out`).
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::lowest()` so that the running max is
+// updated on the first contributing element. Empty buckets (no
+// contributing source element) are reset to `0` after the reduction loop;
+// the matching slot in `arg_out` keeps the sentinel value `src.size(dim)`
+// (one past the last valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state and the caller is responsible for any non-default starting value.
+// This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties. The CUDA kernel is not guaranteed to match on ties (any valid
+// argmax is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_max(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 }  // namespace ops
 }  // namespace pyg

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -49,6 +50,34 @@ PYG_API at::Tensor scatter_mul(
 // When `out` is provided, the accumulation happens in the caller's buffer
 // (no zero-init), matching the upstream `scatter_sum` contract.
 PYG_API at::Tensor scatter_mean(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+// Reduces all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim` using a minimum reduction, and returns
+// both the per-bucket minimum value and the source position that produced
+// it (`arg_out`).
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::max()` so that the running min is updated
+// on the first contributing element. Empty buckets (no contributing source
+// element) are reset to `0` after the reduction loop; the matching slot in
+// `arg_out` keeps the sentinel value `src.size(dim)` (one past the last
+// valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state and the caller is responsible for any non-default starting value.
+// This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties. The CUDA kernel is not guaranteed to match on ties (any valid
+// argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> scatter_min(
     const at::Tensor& src,
     const at::Tensor& index,
     int64_t dim = -1,

--- a/pyg_lib/csrc/ops/scatter.h
+++ b/pyg_lib/csrc/ops/scatter.h
@@ -36,5 +36,24 @@ PYG_API at::Tensor scatter_mul(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Averages all values from `src` into `out` at the indices specified in
+// `index` along a given axis `dim`.
+//
+// Implemented as two `scatter_sum` calls: one to accumulate the per-bucket
+// sum, and one (over a ones tensor sized to match `index`) to compute the
+// per-bucket count. The final result is the sum divided by the count, with
+// empty buckets producing `0` (the count is `masked_fill`-ed up to `1` so
+// the division does not generate NaNs). Integer dtypes use floor division
+// to match the upstream contract; floating dtypes use true division.
+//
+// When `out` is provided, the accumulation happens in the caller's buffer
+// (no zero-init), matching the upstream `scatter_sum` contract.
+PYG_API at::Tensor scatter_mean(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    int64_t dim = -1,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 }  // namespace ops
 }  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -91,6 +91,35 @@ PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
   return op.call(src, index, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_max_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_max_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_max_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_max_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_max_coo", "")
+                       .typed<decltype(segment_max_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
 PYG_API at::Tensor gather_coo(const at::Tensor& src,
                               const at::Tensor& index,
                               const std::optional<at::Tensor>& out) {
@@ -127,6 +156,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::segment_min_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_max_coo(Tensor src, Tensor index, "
       "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -1,0 +1,73 @@
+#include "segment_coo.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor segment_sum_coo(const at::Tensor& src,
+                                   const at::Tensor& index,
+                                   const std::optional<at::Tensor>& out,
+                                   std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_sum_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_sum_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_sum_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_sum_coo", "")
+                       .typed<decltype(segment_sum_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
+PYG_API at::Tensor gather_coo(const at::Tensor& src,
+                              const at::Tensor& index,
+                              const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"gather_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "gather_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "gather_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::gather_coo", "")
+                       .typed<decltype(gather_coo)>();
+  return op.call(src, index, out);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_sum_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -34,6 +34,34 @@ PYG_API at::Tensor segment_sum_coo(const at::Tensor& src,
   return op.call(src, index, out, dim_size);
 }
 
+PYG_API at::Tensor segment_mean_coo(const at::Tensor& src,
+                                    const at::Tensor& index,
+                                    const std::optional<at::Tensor>& out,
+                                    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_mean_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_mean_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_mean_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_mean_coo", "")
+                       .typed<decltype(segment_mean_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
 PYG_API at::Tensor gather_coo(const at::Tensor& src,
                               const at::Tensor& index,
                               const std::optional<at::Tensor>& out) {
@@ -64,6 +92,9 @@ PYG_API at::Tensor gather_coo(const at::Tensor& src,
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::segment_sum_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_mean_coo(Tensor src, Tensor index, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_coo.cpp
+++ b/pyg_lib/csrc/ops/segment_coo.cpp
@@ -62,6 +62,35 @@ PYG_API at::Tensor segment_mean_coo(const at::Tensor& src,
   return op.call(src, index, out, dim_size);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out,
+    std::optional<int64_t> dim_size) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg index_arg{index, "index", 1};
+  at::CheckedFrom c{"segment_min_coo"};
+
+  at::checkAllDefined(c, {src_arg, index_arg});
+  TORCH_CHECK(src.device() == index.device(),
+              "segment_min_coo: src and index must be on the same device "
+              "(got src=",
+              src.device(), ", index=", index.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_min_coo: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_min_coo", "")
+                       .typed<decltype(segment_min_coo)>();
+  return op.call(src, index, out, dim_size);
+}
+
 PYG_API at::Tensor gather_coo(const at::Tensor& src,
                               const at::Tensor& index,
                               const std::optional<at::Tensor>& out) {
@@ -96,6 +125,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::segment_mean_coo(Tensor src, Tensor index, "
       "Tensor? out=None, int? dim_size=None) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "pyg::segment_min_coo(Tensor src, Tensor index, "
+      "Tensor? out=None, int? dim_size=None) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "pyg::gather_coo(Tensor src, Tensor index, Tensor? out=None) -> Tensor"));
 }

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the segment positions specified in
+// `index` along the implicit axis `dim = index.dim() - 1`.
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter`
+// fixes the reduction axis at `index.dim() - 1` (the last index dim). The
+// `index` tensor must be **sorted ascending** along that axis; unsorted input
+// is undefined behavior.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// the symmetric-pair backward of `gather_coo` efficient (the backward
+// allocates `at::zeros(src_shape)` and calls `segment_sum_coo` with it as
+// `out=` to deposit the gradient in-place).
+PYG_API at::Tensor segment_sum_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+// Gathers values from `src` at positions specified in `index`, along the
+// implicit axis `dim = index.dim() - 1`. Concretely:
+//
+//   out[..., i, ...] = src[..., index[..., i], ...]   along `dim`
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the gather axis at `index.dim() - 1`.
+//
+// When `out` is not provided, a fresh buffer is allocated. When `out` *is*
+// provided, the operation **overwrites** the caller's buffer per element
+// (matches upstream `pytorch_scatter`).
+PYG_API at::Tensor gather_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -79,6 +79,37 @@ PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Reduces all values from `src` into `out` at the segment positions specified
+// in `index` along the implicit axis `dim = index.dim() - 1` using a maximum
+// reduction, and returns both the per-bucket maximum value and the source
+// position that produced it (`arg_out`).
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `index.dim() - 1`. The `index` tensor must be
+// **sorted ascending** along that axis.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::lowest()` so that the running max is updated
+// on the first contributing element. Empty buckets (no contributing source
+// element) are reset to `0` after the reduction loop; the matching slot in
+// `arg_out` keeps the sentinel value `src.size(dim)` (one past the last
+// valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state (no lowest-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `>` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmax is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_max_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 // Gathers values from `src` at positions specified in `index`, along the
 // implicit axis `dim = index.dim() - 1`. Concretely:
 //

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -27,6 +27,26 @@ PYG_API at::Tensor segment_sum_coo(
     const std::optional<at::Tensor>& out = std::nullopt,
     std::optional<int64_t> dim_size = std::nullopt);
 
+// Computes the mean of all values from `src` at the segment positions
+// specified in `index` along the implicit axis `dim = index.dim() - 1`. The
+// per-bucket count is computed internally during the sequential pass and
+// applied as a final division.
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `index.dim() - 1`. The `index` tensor must be
+// **sorted ascending** along that axis.
+//
+// `out=` contract: unlike `segment_sum_coo` (which accumulates), the mean
+// kernel **overwrites** `out` at every bucket touched by `index` (matches
+// upstream `segment_coo_cpu.cpp` for the MEAN reducer). Buckets not visited
+// by any `index` entry are left at their original value when `out=` is
+// supplied, or zero-initialized otherwise.
+PYG_API at::Tensor segment_mean_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
 // Gathers values from `src` at positions specified in `index`, along the
 // implicit axis `dim = index.dim() - 1`. Concretely:
 //

--- a/pyg_lib/csrc/ops/segment_coo.h
+++ b/pyg_lib/csrc/ops/segment_coo.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -42,6 +43,37 @@ PYG_API at::Tensor segment_sum_coo(
 // by any `index` entry are left at their original value when `out=` is
 // supplied, or zero-initialized otherwise.
 PYG_API at::Tensor segment_mean_coo(
+    const at::Tensor& src,
+    const at::Tensor& index,
+    const std::optional<at::Tensor>& out = std::nullopt,
+    std::optional<int64_t> dim_size = std::nullopt);
+
+// Reduces all values from `src` into `out` at the segment positions specified
+// in `index` along the implicit axis `dim = index.dim() - 1` using a minimum
+// reduction, and returns both the per-bucket minimum value and the source
+// position that produced it (`arg_out`).
+//
+// COO ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `index.dim() - 1`. The `index` tensor must be
+// **sorted ascending** along that axis.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized
+// to `numeric_limits<scalar_t>::max()` so that the running min is updated
+// on the first contributing element. Empty buckets (no contributing source
+// element) are reset to `0` after the reduction loop; the matching slot in
+// `arg_out` keeps the sentinel value `src.size(dim)` (one past the last
+// valid index along `dim`).
+//
+// When `out` *is* provided, the caller's buffer is used as the running
+// state (no max-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `<` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_coo(
     const at::Tensor& src,
     const at::Tensor& index,
     const std::optional<at::Tensor>& out = std::nullopt,

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -1,0 +1,73 @@
+#include "segment_csr.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor segment_sum_csr(const at::Tensor& src,
+                                   const at::Tensor& indptr,
+                                   const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_sum_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_sum_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_sum_csr", "")
+                       .typed<decltype(segment_sum_csr)>();
+  return op.call(src, indptr, out);
+}
+
+PYG_API at::Tensor gather_csr(const at::Tensor& src,
+                              const at::Tensor& indptr,
+                              const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"gather_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "gather_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::gather_csr", "")
+                       .typed<decltype(gather_csr)>();
+  return op.call(src, indptr, out);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_sum_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the segments specified by the
+// compressed row pointer `indptr` along the implicit axis
+// `dim = indptr.dim() - 1`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row sum into `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) leave the corresponding `out` slot at its
+// zero-initialized value (or unchanged if a caller-supplied `out=` is given).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// `GatherCSR::backward` efficient (the backward allocates
+// `at::zeros(src_shape)` and calls `segment_sum_csr` with it as `out=` to
+// deposit the gradient in-place).
+PYG_API at::Tensor segment_sum_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Gathers values from `src` at the row positions encoded in `indptr`, along
+// the implicit axis `dim = indptr.dim() - 1`. Concretely, for each row `r`,
+// the value `src[..., r, ...]` is broadcast to all output positions
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the gather axis at `indptr.dim() - 1`. The output size along `dim` is
+// determined by the last entry of `indptr` (i.e. `indptr[..., -1]`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated. When `out` *is*
+// provided, the operation **overwrites** the caller's buffer per element
+// (matches upstream `pytorch_scatter`).
+PYG_API at::Tensor gather_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/utils.h
+++ b/pyg_lib/csrc/ops/utils.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace pyg {
+namespace ops {
+
+// Broadcasts `src` so that its shape matches `other`. Mirrors the helper at
+// `pytorch_scatter/csrc/scatter.cpp:25-33`. The result records `unsqueeze` /
+// `expand` operations on the autograd graph and is used inside autograd
+// `forward` methods before kernel dispatch so that the broadcast index keeps
+// gradient connectivity (where applicable) and so that downstream kernels can
+// assume an index tensor whose shape matches `other`.
+//
+// Algorithm:
+//   * If `src` is 1-D, prepend `dim` singleton dims (`src.unsqueeze(0)` x dim).
+//   * Append singleton dims until `src.dim() == other.dim()`.
+//   * `src.expand(other.sizes())`.
+//
+// The returned tensor is *not* contiguous; the caller is responsible for
+// `.contiguous()` if the kernel requires it.
+inline at::Tensor broadcast(const at::Tensor& src,
+                            const at::Tensor& other,
+                            int64_t dim) {
+  auto out = src;
+  if (out.dim() == 1) {
+    for (int64_t i = 0; i < dim; ++i)
+      out = out.unsqueeze(0);
+  }
+  for (int64_t i = out.dim(); i < other.dim(); ++i)
+    out = out.unsqueeze(-1);
+  out = out.expand(other.sizes());
+  return out;
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -559,6 +559,32 @@ def segment_mean_coo(
     return torch.ops.pyg.segment_mean_coo(src, index, out, dim_size)
 
 
+def segment_min_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. The reduction axis is
+    ``index.dim() - 1``. Empty buckets yield value ``0`` and argindex
+    ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_min_coo(src, index, out, dim_size)
+
+
 def gather_coo(
     src: Tensor,
     index: Tensor,
@@ -826,6 +852,7 @@ __all__ = [
     'segment_sum_coo',
     'segment_add_coo',
     'segment_mean_coo',
+    'segment_min_coo',
     'gather_coo',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -631,6 +631,56 @@ def gather_coo(
     return torch.ops.pyg.gather_coo(src, index, out)
 
 
+def segment_sum_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``sum`` as the reduction.
+
+    The reduction axis is ``indptr.dim() - 1`` and the output size along that
+    axis is ``indptr.size(-1) - 1`` (no explicit ``dim_size`` arg).
+
+    If :obj:`out` is not given, a new zero-initialized tensor is allocated.
+    If :obj:`out` is given, values are **accumulated** into it.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_sum_csr(src, indptr, out)
+
+
+segment_add_csr = segment_sum_csr
+
+
+def gather_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Gathers values from :obj:`src` to all positions encoded by the CSR
+    :obj:`indptr`: for each row ``r``, broadcasts ``src[r]`` to all output
+    positions in ``[indptr[r], indptr[r+1])``. Symmetric inverse of
+    :func:`segment_sum_csr`.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor (overwritten if given).
+
+    Returns:
+        Broadcast tensor of shape ``src.shape`` with ``indptr.dim()-1`` axis
+        replaced by ``indptr[-1]``.
+    """
+    return torch.ops.pyg.gather_csr(src, indptr, out)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -881,6 +931,9 @@ __all__ = [
     'segment_min_coo',
     'segment_max_coo',
     'gather_coo',
+    'segment_sum_csr',
+    'segment_add_csr',
+    'gather_csr',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -499,6 +499,59 @@ def scatter_max(
     return torch.ops.pyg.scatter_max(src, index, dim, out, dim_size)
 
 
+def segment_sum_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``sum`` as the reduction.
+
+    Unlike :func:`scatter_sum`, the reduction axis is always
+    ``index.dim() - 1`` (so no :obj:`dim` argument is exposed). The
+    :obj:`index` must be sorted in ascending order along that axis.
+
+    If :obj:`out` is not given, a new zero-initialized tensor is allocated.
+    If :obj:`out` is given, values are **accumulated** into it (no zero-init).
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis. Auto-inferred from :obj:`index.max() + 1` if
+            :obj:`None`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_sum_coo(src, index, out, dim_size)
+
+
+segment_add_coo = segment_sum_coo
+
+
+def gather_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Gathers values from :obj:`src` at positions specified by :obj:`index`
+    along axis ``index.dim() - 1``. This is the symmetric inverse of
+    :func:`segment_sum_coo`.
+
+    Args:
+        src: The source tensor.
+        index: The COO indices to gather.
+        out: The destination tensor (overwritten if given).
+
+    Returns:
+        ``out[i] = src[index[i]]`` along the gather axis.
+    """
+    return torch.ops.pyg.gather_coo(src, index, out)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -743,6 +796,9 @@ __all__ = [
     'scatter_mean',
     'scatter_min',
     'scatter_max',
+    'segment_sum_coo',
+    'segment_add_coo',
+    'gather_coo',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -411,6 +411,34 @@ def scatter_mul(
     return torch.ops.pyg.scatter_mul(src, index, dim, out, dim_size)
 
 
+def scatter_mean(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``mean`` as the reduction. Empty buckets yield zero.
+
+    For floating-point inputs, division is exact. For integer inputs,
+    floor-division is used (matching upstream ``pytorch_scatter``).
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.scatter_mean(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -652,6 +680,7 @@ __all__ = [
     'scatter_sum',
     'scatter_add',
     'scatter_mul',
+    'scatter_mean',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -350,6 +350,38 @@ def softmax_csr(
     return torch.ops.pyg.softmax_csr(src, ptr, dim)
 
 
+def scatter_sum(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``sum`` as the reduction.
+
+    If :obj:`out` is not given, a new tensor is allocated and zero-initialized.
+    If :obj:`out` is given, values are **accumulated** into it (no zero-init).
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`. If :obj:`dim_size` is
+            also :obj:`None`, a minimal sized output is returned.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.scatter_sum(src, index, dim, out, dim_size)
+
+
+scatter_add = scatter_sum
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -588,6 +620,8 @@ __all__ = [
     'sampled_div',
     'index_sort',
     'softmax_csr',
+    'scatter_sum',
+    'scatter_add',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -585,6 +585,32 @@ def segment_min_coo(
     return torch.ops.pyg.segment_min_coo(src, index, out, dim_size)
 
 
+def segment_max_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``max`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. The reduction axis is
+    ``index.dim() - 1``. Empty buckets yield value ``0`` and argindex
+    ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_max_coo(src, index, out, dim_size)
+
+
 def gather_coo(
     src: Tensor,
     index: Tensor,
@@ -853,6 +879,7 @@ __all__ = [
     'segment_add_coo',
     'segment_mean_coo',
     'segment_min_coo',
+    'segment_max_coo',
     'gather_coo',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -469,6 +469,36 @@ def scatter_min(
     return torch.ops.pyg.scatter_min(src, index, dim, out, dim_size)
 
 
+def scatter_max(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``max`` as the reduction.
+
+    Returns a tuple ``(values, argindex)`` where ``argindex[i]`` is the index
+    along ``dim`` of the source element that contributed to ``values[i]``.
+    Empty buckets yield value ``0`` and argindex ``src.size(dim)`` (sentinel).
+    Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.scatter_max(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -712,6 +742,7 @@ __all__ = [
     'scatter_mul',
     'scatter_mean',
     'scatter_min',
+    'scatter_max',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -532,6 +532,33 @@ def segment_sum_coo(
 segment_add_coo = segment_sum_coo
 
 
+def segment_mean_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a sorted COO :obj:`index`, using ``mean`` as the reduction. Empty
+    buckets yield zero.
+
+    The reduction axis is ``index.dim() - 1``. For integer dtypes,
+    floor-division is used.
+
+    Args:
+        src: The source tensor.
+        index: Sorted COO indices.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, the output size along the
+            reduction axis. Auto-inferred from :obj:`index.max() + 1` if
+            :obj:`None`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_mean_coo(src, index, out, dim_size)
+
+
 def gather_coo(
     src: Tensor,
     index: Tensor,
@@ -798,6 +825,7 @@ __all__ = [
     'scatter_max',
     'segment_sum_coo',
     'segment_add_coo',
+    'segment_mean_coo',
     'gather_coo',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -382,6 +382,35 @@ def scatter_sum(
 scatter_add = scatter_sum
 
 
+def scatter_mul(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``mul`` as the reduction.
+
+    If :obj:`out` is not given, a new tensor is allocated and initialized to
+    ones (the multiplicative identity). If :obj:`out` is given, values are
+    **multiplied** into it (no ones-init).
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.scatter_mul(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -622,6 +651,7 @@ __all__ = [
     'softmax_csr',
     'scatter_sum',
     'scatter_add',
+    'scatter_mul',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -439,6 +439,36 @@ def scatter_mean(
     return torch.ops.pyg.scatter_mean(src, index, dim, out, dim_size)
 
 
+def scatter_min(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` at the
+    indices specified in the :obj:`index` tensor along a given axis
+    :obj:`dim`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)`` where ``argindex[i]`` is the index
+    along ``dim`` of the source element that contributed to ``values[i]``.
+    Empty buckets yield value ``0`` and argindex ``src.size(dim)`` (sentinel).
+    Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        index: The indices of elements to scatter.
+        dim: The axis along which to index.
+        out: The destination tensor for the values.
+        dim_size: If :obj:`out` is not given, automatically create output with
+            size :obj:`dim_size` at dimension :obj:`dim`.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.scatter_min(src, index, dim, out, dim_size)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -681,6 +711,7 @@ __all__ = [
     'scatter_add',
     'scatter_mul',
     'scatter_mean',
+    'scatter_min',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import os.path as osp
 from importlib.util import find_spec
@@ -12,6 +13,7 @@ from pyg_lib import get_home_dir
 
 
 def withSeed(func: Callable) -> Callable:
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         torch.manual_seed(12345)
         func(*args, **kwargs)

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -69,10 +69,8 @@ def test_scatter_add_is_scatter_sum_alias():
     ],
 )
 def test_scatter_sum_forward_dtypes(dtype, device):
-    if device.type == 'cpu' and dtype == torch.float16:
-        # CPU half-precision arithmetic is supported but tolerances are loose;
-        # we still run it to check parity.
-        pass
+    # Seed for deterministic random inputs across dtypes.
+    torch.manual_seed(0)
     if dtype in (torch.int32, torch.int64):
         src = torch.randint(-10, 10, (8, 4), dtype=dtype, device=device)
     else:
@@ -81,7 +79,11 @@ def test_scatter_sum_forward_dtypes(dtype, device):
 
     out = pyg_lib.ops.scatter_sum(src, index, dim=0)
     expected = _scatter_sum_ref(src, index, dim=0)
-    torch.testing.assert_close(out, expected)
+    # Half/bfloat16 accumulation drifts further than the default rtol allows.
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected)
 
 
 @withCUDA
@@ -568,3 +570,270 @@ def test_scatter_mul_gradient_at_src_zero(device):
         grad2[5],
         torch.tensor(5.0, dtype=torch.double, device=device),
     )
+
+
+# ---------------------------------------------------------------------------
+# scatter_mean
+# ---------------------------------------------------------------------------
+
+
+def _scatter_mean_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference implementation of :func:`scatter_mean`.
+
+    Mirrors the contract of ``pyg_lib.ops.scatter_mean``:
+      * Index is broadcast to ``src`` along ``dim``.
+      * Computes scatter_sum of ``src`` and divides by per-bucket counts.
+      * Empty buckets (count == 0) are masked-filled to 1 to avoid div-by-0;
+        the numerator is also zero there, so the result is zero.
+      * Floats use true-division; integers use floor-division (matches the
+        upstream ``div(_, rounding_mode="floor")`` semantics).
+      * If ``out`` is :obj:`None`, an output of the appropriate shape is
+        zero-initialised before the scatter_sum.
+      * If ``out`` is provided, the sum accumulates into it *before* division.
+      * If ``dim_size`` is :obj:`None`, infer from ``index.max() + 1``.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+
+    # Numerator: scatter_sum into (a clone of) ``out``.
+    if out is None:
+        if dim_size is None:
+            dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+        size = list(src.size())
+        size[dim] = dim_size
+        numer = torch.zeros(size, dtype=src.dtype, device=src.device)
+    else:
+        # Don't mutate the caller's tensor in the reference.
+        numer = out.clone()
+    numer.scatter_add_(dim, bcast_index, src)
+
+    # Denominator: per-bucket counts. Use a 1-D scatter_sum-of-ones along
+    # ``dim``; then broadcast to ``numer.shape`` for the division.
+    ones = torch.ones(src.size(dim), dtype=src.dtype, device=src.device)
+    count = torch.zeros(numer.size(dim), dtype=src.dtype, device=src.device)
+    count.scatter_add_(0, index, ones)
+    count.masked_fill_(count < 1, 1)
+    # Broadcast count along ``dim`` to ``numer.shape``.
+    view = [1] * numer.dim()
+    view[dim] = -1
+    count = count.view(view).expand_as(numer)
+
+    if numer.is_floating_point():
+        return numer / count
+    else:
+        return torch.div(numer, count, rounding_mode='floor')
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_mean_forward_dtypes(dtype, device):
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0)
+    expected = _scatter_mean_ref(src, index, dim=0)
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.int32, torch.int64])
+def test_scatter_mean_forward_integer_floor_div(dtype, device):
+    """Integer dtype: per-bucket result is the floor of sum/count."""
+    src = torch.randint(-10, 10, (8, 4), dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0)
+    expected = _scatter_mean_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_forward_dim_neg1(device):
+    src = torch.randn(3, 8, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=-1)
+    expected = _scatter_mean_ref(src, index, dim=-1)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_forward_dim_nonneg(device):
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0)
+    expected = _scatter_mean_ref(src, index, dim=0)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_forward_dim_middle(device):
+    src = torch.randn(3, 6, 5, device=device)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=1)
+    expected = _scatter_mean_ref(src, index, dim=1)
+    assert out.size() == (3, 3, 5)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0)
+    expected = _scatter_mean_ref(src, index, dim=0)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4
+    assert out.size(-1) == 4
+    expected = _scatter_mean_ref(src, index, dim=-1)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are empty
+    and must yield exactly zero (count masked-filled to 1, then 0/1 = 0).
+    This is the key contract that distinguishes scatter_mean from a naive
+    sum/count which would produce NaN.
+    """
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=-1, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _scatter_mean_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Empty trailing buckets at positions 4, 5 must be exactly zero, not NaN.
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+    assert torch.isfinite(out).all(), (
+        f'scatter_mean produced non-finite values: {out}'
+    )
+
+
+@withCUDA
+def test_scatter_mean_empty_bucket_in_middle(device):
+    """Empty buckets anywhere (not just trailing) must yield zero, not NaN."""
+    # index skips bucket 2 entirely.
+    src = torch.randn(6, 3, device=device)
+    index = torch.tensor([0, 1, 0, 1, 3, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0, dim_size=4)
+    assert out.size() == (4, 3)
+    expected = _scatter_mean_ref(src, index, dim=0, dim_size=4)
+    torch.testing.assert_close(out, expected)
+    # Bucket 2 has no contributors — expect a zero row.
+    torch.testing.assert_close(out[2], torch.zeros(3, device=device))
+    assert torch.isfinite(out).all()
+
+
+@withCUDA
+def test_scatter_mean_out_accumulates_then_divides(device):
+    """When ``out`` is provided, the numerator accumulates into it before the
+    final divide by per-bucket counts.
+    """
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out_init = torch.randn(4, 4, device=device)
+    out = out_init.clone()
+    result = pyg_lib.ops.scatter_mean(src, index, dim=0, out=out)
+
+    expected = _scatter_mean_ref(src, index, dim=0, out=out_init)
+    torch.testing.assert_close(result, expected)
+    # The op should also have updated ``out`` in-place.
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mean_empty_input(device):
+    """An empty source with an empty index should yield an all-zero output
+    (every bucket is empty -> count masked to 1 -> 0/1 = 0).
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.scatter_mean(src, index, dim=0, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_scatter_mean_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mean(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mean_backward_gradcheck_dim_middle(device):
+    src = torch.randn(
+        2,
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mean(s, index, dim=1)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mean_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets in the output. Empty buckets have zero gradient w.r.t. ``src``.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mean(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 
 def _broadcast_index(
@@ -835,5 +835,445 @@ def test_scatter_mean_backward_gradcheck_with_dim_size(device):
 
     def fn(s):
         return pyg_lib.ops.scatter_mean(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter_min
+# ---------------------------------------------------------------------------
+
+
+def _scatter_min_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference implementation of :func:`scatter_min`.
+
+    Returns a tuple ``(value, argindex)``:
+      * ``value[j]`` is the minimum of ``src`` entries whose broadcast index
+        equals ``j`` along ``dim``.
+      * ``argindex[j]`` is the position along ``dim`` of *any* entry that
+        attains that minimum. On CPU the upstream contract is first-match;
+        we match that here.
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (the upstream sentinel).
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Walk over ``src`` along ``dim`` and, for each output position, track the
+    # running min and the position of its first-match.
+    # We implement this with a per-element Python loop for clarity.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            # Recover the multi-index for the "other" dims.
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                # First contribution into this bucket; always take it.
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v < cur):  # strict less: first-match tie-break
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    # Empty buckets: value == 0 (already initialized), argindex stays at
+    # sentinel == src.size(dim).
+    return value, argindex
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_min_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        # A unique-value integer fixture covering the chosen buckets.
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        # Build a unique-valued float tensor via a randperm permutation.
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(value, ref_value, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_neg1(device):
+    # Unique values along dim=-1 ensure deterministic argindex.
+    torch.manual_seed(0)
+    src = (torch.randperm(3 * 8, device=device).to(torch.float32) - 12).view(
+        3,
+        8,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_nonneg(device):
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_forward_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(3 * 6 * 5, device=device).to(torch.float32) - 40
+    ).view(3, 6, 5)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=1)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=1)
+    assert value.size() == (3, 3, 5)
+    assert arg.size() == (3, 3, 5)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_min_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.scatter_min(
+        src,
+        index,
+        dim=-1,
+        dim_size=6,
+    )
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Empty trailing buckets at positions 2, 4, 5 must have value 0 and
+    # argindex == sentinel.
+    empty_positions = [2, 4, 5]
+    for p in empty_positions:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_scatter_min_empty_bucket_in_middle(device):
+    """Empty buckets anywhere (not just trailing) yield value 0 + sentinel
+    argindex.
+    """
+    # index skips bucket 2 entirely.
+    src = torch.tensor(
+        [[1.0, 2.0, 3.0],
+         [-1.0, 4.0, 5.0],
+         [6.0, -3.0, 7.0],
+         [8.0, 9.0, -10.0],
+         [11.0, 12.0, 13.0],
+         [14.0, 15.0, 16.0]],
+        device=device,
+    )  # yapf: disable
+    index = torch.tensor([0, 1, 0, 1, 3, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=4)
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0, dim_size=4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 2 has no contributors -> zero row + sentinel arg row.
+    torch.testing.assert_close(
+        value[2],
+        torch.zeros(3, device=device),
+    )
+    torch.testing.assert_close(
+        arg[2],
+        torch.full((3,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_scatter_min_out_overrides_init_buffer(device):
+    """When ``out`` is provided, the op writes the per-bucket min into it
+    (per the contract: out is initialized to numeric_limits::max() internally,
+    callers supplying ``out`` are responsible for any non-default initial
+    state).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    # Pre-fill out with something that should NOT contaminate the min — the
+    # per-bucket min of src is strictly less than these values for every
+    # non-empty bucket.
+    out = torch.full((4,), 100.0, device=device)
+    result_value, result_arg = pyg_lib.ops.scatter_min(
+        src,
+        index,
+        dim=0,
+        out=out,
+    )
+
+    # The non-empty buckets should match the reference exactly.
+    ref_value, ref_arg = _scatter_min_ref(src, index, dim=0, dim_size=4)
+    # Non-empty buckets: 0 (idx 0,2), 1 (idx 1,3,4), 3 (idx 5).
+    # Bucket 2 is empty; with out=, the upstream contract leaves the caller's
+    # value in place when nothing is written. We only assert the non-empty
+    # buckets match the reference.
+    non_empty = [0, 1, 3]
+    for p in non_empty:
+        torch.testing.assert_close(result_value[p], ref_value[p])
+        torch.testing.assert_close(result_arg[p], ref_arg[p])
+
+
+@withCUDA
+def test_scatter_min_empty_input(device):
+    """An empty source with an empty index yields an all-zero value tensor
+    and an all-sentinel argindex tensor.
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_scatter_min_argindex_ties_returns_valid(device):
+    """Tied values: only assert the returned argindex is *a valid* argmin,
+    not a specific tie-breaker. CUDA atomic ordering is non-deterministic.
+    """
+    # Construct a deliberate tie: indices 0 and 2 both map to bucket 0 with
+    # value 1.0; indices 1 and 4 both map to bucket 1 with value 2.0.
+    src = torch.tensor(
+        [1.0, 2.0, 1.0, 5.0, 2.0, 7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Value tensor must equal the true per-bucket min regardless of tie-break.
+    expected_value = torch.tensor(
+        [1.0, 2.0, 0.0, 7.0],
+        device=device,
+    )
+    torch.testing.assert_close(value, expected_value)
+    # Argindex on bucket 0 must be 0 or 2 (both have value 1.0).
+    assert int(arg[0].item()) in (0, 2)
+    # Argindex on bucket 1 must be one of the value-2.0 positions: 1 or 4.
+    assert int(arg[1].item()) in (1, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == src.size(0)
+    # Bucket 3 has a unique value at position 5.
+    assert int(arg[3].item()) == 5
+    # All non-sentinel argindexes must in fact attain the bucket's min value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == src.size(0):
+            continue  # empty bucket
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'min is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_scatter_min_arg_non_differentiable(device):
+    """The argindex output must have ``requires_grad=False`` even when the
+    value output participates in autograd.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_min(src, index, dim=-1)
+    # Value tensor must require grad (forwarded from src).
+    assert value.requires_grad
+    # Argindex must NOT require grad — it's non-differentiable.
+    assert not arg.requires_grad
+    # And it must be an integer tensor.
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is non-differentiable and
+    excluded by extracting ``[0]`` from the tuple.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    # Unique-valued src via randperm avoids ties (which would break gradcheck).
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=0)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(2 * 6 * 3, device=device).to(torch.double) - 18)
+        .view(2, 6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=1)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_min_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets. Their argindex points at the sentinel (== src.size(dim)) and
+    the ``+1``/``narrow`` backward pattern in the implementation drops that
+    slot — so the gradient w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_min(s, index, dim=-1, dim_size=6)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -231,3 +231,340 @@ def test_scatter_sum_backward_gradcheck_with_dim_size(device):
         return pyg_lib.ops.scatter_sum(s, index, dim=-1, dim_size=6)
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter_mul
+# ---------------------------------------------------------------------------
+
+
+def _scatter_mul_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference implementation of :func:`scatter_mul`.
+
+    Mirrors the contract of ``pyg_lib.ops.scatter_mul``:
+      * Index is broadcast to ``src`` along ``dim``.
+      * If ``out`` is :obj:`None`, an output of the appropriate shape is
+        initialized to **ones** (not zeros).
+      * If ``out`` is provided, the op multiplies into it (no ones-init).
+      * If ``dim_size`` is :obj:`None`, infer from ``index.max() + 1``.
+
+    Implemented via an explicit per-element scalar walk along ``dim`` so we
+    avoid relying on ``Tensor.scatter_reduce_(reduce="prod")`` whose
+    initialization semantics differ from upstream's ones-init.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if out is None:
+        if dim_size is None:
+            dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+        size = list(src.size())
+        size[dim] = dim_size
+        out = torch.ones(size, dtype=src.dtype, device=src.device)
+    else:
+        out = out.clone()  # don't mutate caller's tensor in the reference
+
+    # Walk over ``src`` along ``dim`` and multiply each slice into ``out``.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            # Recover the multi-index for the "other" dims.
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out[tuple(out_idx)] = out[tuple(out_idx)] * flat_src[k]
+    return out
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_mul_forward_dtypes(dtype, device):
+    if dtype in (torch.int32, torch.int64):
+        # Keep values small so the product doesn't blow up integer ranges.
+        src = torch.randint(-3, 4, (8, 4), dtype=dtype, device=device)
+    else:
+        # Keep values O(1) so fp16/bf16 products stay well within range.
+        src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    # Looser tolerances for low-precision floats; chained multiplies amplify
+    # rounding error relative to a single scatter_add pass.
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_neg1(device):
+    src = torch.randn(3, 8, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1)
+    expected = _scatter_mul_ref(src, index, dim=-1)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_nonneg(device):
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_forward_dim_middle(device):
+    src = torch.randn(3, 6, 5, device=device)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=1)
+    expected = _scatter_mul_ref(src, index, dim=1)
+    assert out.size() == (3, 3, 5)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    expected = _scatter_mul_ref(src, index, dim=0)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4
+    assert out.size(-1) == 4
+    expected = _scatter_mul_ref(src, index, dim=-1)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_dim_size_explicit(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets remain at
+    the ones-init (no src elements multiply into them).
+    """
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=-1, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _scatter_mul_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Empty buckets keep the ones-init (NOT zero, unlike scatter_sum).
+    torch.testing.assert_close(out[4:], torch.ones(2, device=device))
+
+
+@withCUDA
+def test_scatter_mul_out_multiplies_into_buffer(device):
+    """When ``out`` is provided, mul into it without ones-init."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out_init = torch.randn(4, 4, device=device)
+    out = out_init.clone()
+    result = pyg_lib.ops.scatter_mul(src, index, dim=0, out=out)
+
+    # Multiply-into semantics: result == out_init * scatter_mul into ones.
+    factor = _scatter_mul_ref(
+        src,
+        index,
+        dim=0,
+        dim_size=4,
+    )  # ones-initialized
+    expected = out_init * factor
+    torch.testing.assert_close(result, expected)
+    # The op should also have updated ``out`` in-place.
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_mul_empty_input(device):
+    """An empty source with an empty index should yield ones-initialised
+    output (no multiplies happened).
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.ones(3, 4, device=device))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck(device):
+    # Avoid src == 0 in this base gradcheck — the upstream-matched
+    # ``where(src != 0, ..., 0)`` rule deliberately deviates from the true
+    # mathematical gradient at zeros, which would otherwise trip finite-diff.
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    # Push values away from zero so the analytical == numerical comparison
+    # uses the smooth branch of the autograd rule everywhere.
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck_dim_middle(device):
+    src = torch.randn(
+        2,
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=1)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets in the output. Empty buckets stay at the ones-init; their
+    gradient w.r.t. ``src`` is zero because no ``src`` element flows into them.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    with torch.no_grad():
+        src.add_(src.sign() * 0.5)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_mul(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_mul_gradient_at_src_zero(device):
+    """The mathematical gradient of a product is unstable at zero entries;
+    upstream returns zero (we replicate via ``torch.where(src != 0, ...)``).
+
+    Verify that the returned gradient at positions where ``src == 0`` is
+    finite (zero), not NaN/inf, and that the gradient at non-zero positions
+    is unaffected.
+    """
+    # Mix zeros into the source.
+    src = torch.tensor(
+        [2.0, 0.0, 3.0, 0.0, 5.0, 0.0],
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 2, 2], device=device)
+
+    out = pyg_lib.ops.scatter_mul(src, index, dim=0)
+    # Sum so we have a scalar loss; ``grad_out`` is all-ones.
+    out.sum().backward()
+
+    grad = src.grad
+    assert grad is not None
+    # No NaNs and no infinities anywhere.
+    assert torch.isfinite(grad).all(), (
+        f'grad contains non-finite values: {grad}'
+    )
+    # Positions where src == 0 must have grad == 0 (the upstream convention).
+    zero_mask = src.detach() == 0
+    torch.testing.assert_close(
+        grad[zero_mask],
+        torch.zeros_like(grad[zero_mask]),
+    )
+    # Sanity-check non-zero positions: for bucket {2, 0} with grad_out=1,
+    # grad_src for src==2 = (grad_out * out_bucket) / src_at_2 where
+    # out_bucket = 2 * 0 = 0, so grad = 0. Same for all buckets containing
+    # a zero entry. So actually all grads should be zero here.
+    # Construct a different fixture where the non-zero grad path matters:
+    src2 = torch.tensor(
+        [2.0, 0.0, 3.0, 4.0, 5.0, 6.0],
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index2 = torch.tensor([0, 0, 1, 1, 2, 2], device=device)
+    out2 = pyg_lib.ops.scatter_mul(src2, index2, dim=0)
+    out2.sum().backward()
+    grad2 = src2.grad
+    assert grad2 is not None
+    assert torch.isfinite(grad2).all()
+    # src2[1] == 0 -> grad2[1] must be 0 by the upstream rule.
+    torch.testing.assert_close(
+        grad2[1],
+        torch.zeros((), dtype=torch.double, device=device),
+    )
+    # Bucket {3, 4}: product 12; grad[2] = 12/3 = 4, grad[3] = 12/4 = 3.
+    torch.testing.assert_close(
+        grad2[2],
+        torch.tensor(4.0, dtype=torch.double, device=device),
+    )
+    torch.testing.assert_close(
+        grad2[3],
+        torch.tensor(3.0, dtype=torch.double, device=device),
+    )
+    # Bucket {5, 6}: product 30; grad[4] = 30/5 = 6, grad[5] = 30/6 = 5.
+    torch.testing.assert_close(
+        grad2[4],
+        torch.tensor(6.0, dtype=torch.double, device=device),
+    )
+    torch.testing.assert_close(
+        grad2[5],
+        torch.tensor(5.0, dtype=torch.double, device=device),
+    )

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -1277,3 +1277,443 @@ def test_scatter_min_backward_gradcheck_with_dim_size(device):
         return pyg_lib.ops.scatter_min(s, index, dim=-1, dim_size=6)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter_max
+# ---------------------------------------------------------------------------
+
+
+def _scatter_max_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference implementation of :func:`scatter_max`.
+
+    Returns a tuple ``(value, argindex)``:
+      * ``value[j]`` is the maximum of ``src`` entries whose broadcast index
+        equals ``j`` along ``dim``.
+      * ``argindex[j]`` is the position along ``dim`` of *any* entry that
+        attains that maximum. On CPU the upstream contract is first-match;
+        we match that here.
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (the upstream sentinel).
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Walk over ``src`` along ``dim`` and, for each output position, track the
+    # running max and the position of its first-match.
+    # We implement this with a per-element Python loop for clarity.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            # Recover the multi-index for the "other" dims.
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                # First contribution into this bucket; always take it.
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v > cur):  # strict greater: first-match tie-break
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    # Empty buckets: value == 0 (already initialized), argindex stays at
+    # sentinel == src.size(dim).
+    return value, argindex
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_max_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        # A unique-value integer fixture covering the chosen buckets.
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        # Build a unique-valued float tensor via a randperm permutation.
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=0)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=0)
+    if dtype in (torch.float16, torch.bfloat16):
+        torch.testing.assert_close(value, ref_value, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_forward_dim_neg1(device):
+    # Unique values along dim=-1 ensure deterministic argindex.
+    torch.manual_seed(0)
+    src = (torch.randperm(3 * 8, device=device).to(torch.float32) - 12).view(
+        3,
+        8,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=-1)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=-1)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_forward_dim_nonneg(device):
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=0)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=0)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_forward_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(3 * 6 * 5, device=device).to(torch.float32) - 40
+    ).view(3, 6, 5)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=1)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=1)
+    assert value.size() == (3, 3, 5)
+    assert arg.size() == (3, 3, 5)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=0)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=0)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=-1)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_scatter_max_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.scatter_max(
+        src,
+        index,
+        dim=-1,
+        dim_size=6,
+    )
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Empty trailing buckets at positions 2, 4, 5 must have value 0 and
+    # argindex == sentinel.
+    empty_positions = [2, 4, 5]
+    for p in empty_positions:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_scatter_max_empty_bucket_in_middle(device):
+    """Empty buckets anywhere (not just trailing) yield value 0 + sentinel
+    argindex.
+    """
+    # index skips bucket 2 entirely.
+    src = torch.tensor(
+        [[1.0, 2.0, 3.0],
+         [-1.0, 4.0, 5.0],
+         [6.0, -3.0, 7.0],
+         [8.0, 9.0, -10.0],
+         [11.0, 12.0, 13.0],
+         [14.0, 15.0, 16.0]],
+        device=device,
+    )  # yapf: disable
+    index = torch.tensor([0, 1, 0, 1, 3, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=0, dim_size=4)
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=0, dim_size=4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 2 has no contributors -> zero row + sentinel arg row.
+    torch.testing.assert_close(
+        value[2],
+        torch.zeros(3, device=device),
+    )
+    torch.testing.assert_close(
+        arg[2],
+        torch.full((3,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_scatter_max_out_overrides_init_buffer(device):
+    """When ``out`` is provided, the op writes the per-bucket max into it
+    (per the contract: out is initialized to numeric_limits::lowest()
+    internally; callers supplying ``out`` are responsible for any non-default
+    initial state).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    # Pre-fill out with something that should NOT contaminate the max — the
+    # per-bucket max of src is strictly greater than these values for every
+    # non-empty bucket.
+    out = torch.full((4,), -100.0, device=device)
+    result_value, result_arg = pyg_lib.ops.scatter_max(
+        src,
+        index,
+        dim=0,
+        out=out,
+    )
+
+    # The non-empty buckets should match the reference exactly.
+    ref_value, ref_arg = _scatter_max_ref(src, index, dim=0, dim_size=4)
+    # Non-empty buckets: 0 (idx 0,2), 1 (idx 1,3,4), 3 (idx 5).
+    # Bucket 2 is empty; with out=, the upstream contract leaves the caller's
+    # value in place when nothing is written. We only assert the non-empty
+    # buckets match the reference.
+    non_empty = [0, 1, 3]
+    for p in non_empty:
+        torch.testing.assert_close(result_value[p], ref_value[p])
+        torch.testing.assert_close(result_arg[p], ref_arg[p])
+
+
+@withCUDA
+def test_scatter_max_empty_input(device):
+    """An empty source with an empty index yields an all-zero value tensor
+    and an all-sentinel argindex tensor.
+    """
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=0, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_scatter_max_argindex_ties_returns_valid(device):
+    """Tied values: only assert the returned argindex is *a valid* argmax,
+    not a specific tie-breaker. CUDA atomic ordering is non-deterministic.
+    """
+    # Construct a deliberate tie: indices 0 and 2 both map to bucket 0 with
+    # value 1.0; indices 1 and 4 both map to bucket 1 with value 2.0.
+    src = torch.tensor(
+        [1.0, 2.0, 1.0, -5.0, 2.0, -7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=-1)
+    # Value tensor must equal the true per-bucket max regardless of tie-break.
+    expected_value = torch.tensor(
+        [1.0, 2.0, 0.0, -7.0],
+        device=device,
+    )
+    torch.testing.assert_close(value, expected_value)
+    # Argindex on bucket 0 must be 0 or 2 (both have value 1.0).
+    assert int(arg[0].item()) in (0, 2)
+    # Argindex on bucket 1 must be one of the value-2.0 positions: 1 or 4.
+    assert int(arg[1].item()) in (1, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == src.size(0)
+    # Bucket 3 has a unique value at position 5.
+    assert int(arg[3].item()) == 5
+    # All non-sentinel argindexes must in fact attain the bucket's max value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == src.size(0):
+            continue  # empty bucket
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'max is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_scatter_max_arg_non_differentiable(device):
+    """The argindex output must have ``requires_grad=False`` even when the
+    value output participates in autograd.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    value, arg = pyg_lib.ops.scatter_max(src, index, dim=-1)
+    # Value tensor must require grad (forwarded from src).
+    assert value.requires_grad
+    # Argindex must NOT require grad — it's non-differentiable.
+    assert not arg.requires_grad
+    # And it must be an integer tensor.
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+@withCUDA
+def test_scatter_max_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is non-differentiable and
+    excluded by extracting ``[0]`` from the tuple.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    # Unique-valued src via randperm avoids ties (which would break gradcheck).
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_max(s, index, dim=0)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_max_backward_gradcheck_dim_middle(device):
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(2 * 6 * 3, device=device).to(torch.double) - 18)
+        .view(2, 6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_max(s, index, dim=1)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_max_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets. Their argindex points at the sentinel (== src.size(dim)) and
+    the ``+1``/``narrow`` backward pattern in the implementation drops that
+    slot — so the gradient w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_max(s, index, dim=-1, dim_size=6)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -1,0 +1,233 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+
+def _broadcast_index(
+    index: torch.Tensor,
+    src: torch.Tensor,
+    dim: int,
+) -> torch.Tensor:
+    """Broadcasts a 1-D :obj:`index` to the shape of :obj:`src` along
+    :obj:`dim`. Mirrors the helper used by upstream pytorch_scatter and the
+    C++ ``broadcast`` util in ``pyg_lib/csrc/ops/utils.h``.
+    """
+    if index.dim() == src.dim():
+        return index
+    if dim < 0:
+        dim = dim + src.dim()
+    size = [1] * src.dim()
+    size[dim] = -1
+    return index.view(size).expand_as(src)
+
+
+def _scatter_sum_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference implementation of :func:`scatter_sum`.
+
+    Mirrors the contract of ``pyg_lib.ops.scatter_sum``:
+      * Index is broadcast to ``src`` along ``dim``.
+      * If ``out`` is :obj:`None`, an output of the appropriate shape is
+        zero-initialized.
+      * If ``out`` is provided, the op accumulates into it (no zeroing).
+      * If ``dim_size`` is :obj:`None`, infer from ``index.max() + 1``.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if out is None:
+        if dim_size is None:
+            dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+        size = list(src.size())
+        size[dim] = dim_size
+        out = torch.zeros(size, dtype=src.dtype, device=src.device)
+    out.scatter_add_(dim, bcast_index, src)
+    return out
+
+
+def test_scatter_add_is_scatter_sum_alias():
+    assert pyg_lib.ops.scatter_add is pyg_lib.ops.scatter_sum
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+    ],
+)
+def test_scatter_sum_forward_dtypes(dtype, device):
+    if device.type == 'cpu' and dtype == torch.float16:
+        # CPU half-precision arithmetic is supported but tolerances are loose;
+        # we still run it to check parity.
+        pass
+    if dtype in (torch.int32, torch.int64):
+        src = torch.randint(-10, 10, (8, 4), dtype=dtype, device=device)
+    else:
+        src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_neg1(device):
+    src = torch.randn(3, 8, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1)
+    expected = _scatter_sum_ref(src, index, dim=-1)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_nonneg(device):
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_forward_dim_middle(device):
+    src = torch.randn(3, 6, 5, device=device)
+    index = torch.tensor([0, 2, 1, 0, 2, 1], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=1)
+    expected = _scatter_sum_ref(src, index, dim=1)
+    assert out.size() == (3, 3, 5)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_broadcasting_1d_index(device):
+    """1-D ``index`` broadcasts to 2-D ``src`` along ``dim``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 2, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    expected = _scatter_sum_ref(src, index, dim=0)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1)
+    # Auto-inferred dim_size = index.max() + 1 = 4
+    assert out.size(-1) == 4
+    expected = _scatter_sum_ref(src, index, dim=-1)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_dim_size_explicit(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    # Larger than implicit dim_size — trailing buckets are empty (zeros).
+    out = pyg_lib.ops.scatter_sum(src, index, dim=-1, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _scatter_sum_ref(src, index, dim=-1, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Empty buckets should be exactly zero.
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+
+
+@withCUDA
+def test_scatter_sum_out_accumulates(device):
+    """When ``out`` is provided, the op accumulates into it without zeroing."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out_init = torch.randn(4, 4, device=device)
+    out = out_init.clone()
+    result = pyg_lib.ops.scatter_sum(src, index, dim=0, out=out)
+
+    # Accumulate semantics: result == out_init + scatter_sum into zeros.
+    delta = _scatter_sum_ref(src, index, dim=0, dim_size=4)  # zero-initialized
+    expected = out_init + delta
+    torch.testing.assert_close(result, expected)
+    # The op should also have updated ``out`` in-place.
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_sum_empty_input(device):
+    """An empty source with an empty index should yield an empty output."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.scatter_sum(src, index, dim=0, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck_dim_middle(device):
+    src = torch.randn(
+        2,
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 0, 1, 2, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=1)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_sum_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with an explicit (larger) ``dim_size`` exercising empty
+    buckets in the output.
+    """
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_sum(s, index, dim=-1, dim_size=6)
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -1074,3 +1074,386 @@ def test_segment_min_coo_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_max_coo — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_max_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference for :func:`segment_max_coo`.
+
+    COO ops always reduce along ``dim = index.dim() - 1`` with a sorted
+    ``index``. Returns ``(value, argindex)``:
+      * ``value[..., j, ...]`` is the maximum of ``src`` entries whose
+        broadcast index equals ``j`` along ``dim``.
+      * ``argindex[..., j, ...]`` is the position along ``dim`` of the
+        *first-match* max entry (CPU upstream contract).
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (upstream sentinel).
+    """
+    dim = index.dim() - 1
+    bcast_index = _broadcast_index(index, src)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Per-element Python loop over src along the reduction dim, tracking
+    # running max + first-match argindex per output position.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v > cur):
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_max_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_max_coo_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    # Sorted ascending index — required by segment_*_coo.
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_coo_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_coo_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_coo_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index, dim_size=6)
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _segment_max_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Trailing empty buckets at positions 4, 5 must have value 0 and
+    # argindex == sentinel.
+    for p in [4, 5]:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_segment_max_coo_empty_rows_in_middle(device):
+    """Empty rows fixture: row 1 has no entries -> value 0 + sentinel arg."""
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    # Row 1 entirely skipped.
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    ref_value, ref_arg = _segment_max_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 has no contributors -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_segment_max_coo_empty_input(device):
+    """Empty source + empty index -> all-zero value, all-sentinel arg."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_max_coo_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Bucket 0: positions 0, 1, 2 all with value 1.0 (tied max).
+    # Bucket 1: positions 3, 4 with value 2.0 (tied max).
+    # Bucket 2: empty.
+    # Bucket 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 0, 0, 1, 1, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index, dim_size=4)
+    # Value must equal the true per-bucket max regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Bucket 0 arg must be in {0, 1, 2}; bucket 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Bucket 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must in fact attain the bucket's max value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'max is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_segment_max_coo_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_max_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_max_coo_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_max_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_max_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` exercising empty
+    trailing rows. Their argindex points at the sentinel and the
+    ``+1``/``narrow`` backward pattern drops that slot — so the gradient
+    w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_max_coo(s, index, dim_size=6)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_max_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck (row 1 has no entries)."""
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_max_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_max_coo_backward_empty_input(device):
+    """Empty ``src`` and ``index`` — exercises the ``numel() > 0`` guard.
+    Backward must not crash on empty grad and must return a correctly-shaped
+    zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    value, arg = pyg_lib.ops.segment_max_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on empty grad.
+    value.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -52,6 +52,37 @@ def _segment_sum_coo_ref(
     return out
 
 
+def _segment_mean_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_mean_coo`.
+
+    Computes per-bucket sums via :func:`_segment_sum_coo_ref`, then divides by
+    per-bucket counts. Counts for empty buckets are masked to 1 so empty
+    buckets yield exactly 0 (matching upstream semantics).
+    """
+    dim = index.dim() - 1
+    summed = _segment_sum_coo_ref(src, index, dim_size=dim_size)
+    if dim_size is None:
+        dim_size = summed.size(dim)
+    # Count per bucket: scatter-add of ones along the COO dim.
+    counts = torch.zeros(dim_size, dtype=src.dtype, device=src.device)
+    if index.numel() > 0:
+        counts.scatter_add_(
+            0,
+            index.reshape(-1),
+            torch.ones(index.numel(), dtype=src.dtype, device=src.device),
+        )
+    # Shape counts for broadcasting along ``dim``.
+    shape = [1] * summed.dim()
+    shape[dim] = dim_size
+    counts = counts.view(shape)
+    safe_counts = counts.masked_fill(counts == 0, 1)
+    return summed / safe_counts
+
+
 def _gather_coo_ref(
     src: torch.Tensor,
     index: torch.Tensor,
@@ -464,3 +495,199 @@ def test_gather_coo_gradgradcheck(device):
         return pyg_lib.ops.gather_coo(s, index)
 
     assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_mean_coo_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_1d(device):
+    src = torch.randn(8, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_k1_small_trailing(device):
+    """K==1 path: no trailing feature dims (purely 1-D)."""
+    src = torch.randn(10, device=device)
+    index = torch.tensor([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert out.size(-1) == 4
+    expected = _segment_mean_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_coo_dim_size_explicit(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _segment_mean_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Trailing empty buckets should be exactly zero (count masked to 1).
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+
+
+@withCUDA
+def test_segment_mean_coo_empty_rows_in_middle(device):
+    """Row 1 has no entries — its output must be zero (count = 0 -> 0/1)."""
+    src = torch.randn(5, 4, device=device)
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index)
+    expected = _segment_mean_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_mean_coo_empty_input(device):
+    """Empty source and index — output is all-zero of the requested shape."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` -> empty trailing rows."""
+    src = torch.randn(
+        5,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index, dim_size=5)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_coo_backward_empty_input(device):
+    """Empty ``src`` and ``index`` — exercises the ``numel() > 0`` guard in
+    backward. The forward is well-defined (all-zero output); the backward
+    must not crash on the empty grad and should return a correctly-shaped
+    zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.segment_mean_coo(src, index, dim_size=3)
+    assert out.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on an empty grad.
+    out.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -1,0 +1,466 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _broadcast_index(
+    index: torch.Tensor,
+    src: torch.Tensor,
+) -> torch.Tensor:
+    """Broadcasts ``index`` up to the shape of ``src`` along the COO dim
+    (``index.dim() - 1``). Mirrors the upstream / C++ ``broadcast`` util.
+    """
+    dim = index.dim() - 1
+    if index.dim() == src.dim():
+        return index
+    size = [1] * src.dim()
+    size[dim] = -1
+    # ``index`` is 1-D in the broadcast case; reshape then expand.
+    return index.view(size).expand_as(src)
+
+
+def _segment_sum_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    out: torch.Tensor = None,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_sum_coo`.
+
+    COO ops always reduce along ``dim = index.dim() - 1``. With a sorted
+    ``index``, segment-sum is equivalent to scatter-sum, so the reference is
+    a plain ``zeros + scatter_add_``.
+    """
+    dim = index.dim() - 1
+    bcast_index = _broadcast_index(index, src)
+    if out is None:
+        if dim_size is None:
+            if index.numel() > 0:
+                dim_size = int(index.max().item()) + 1
+            else:
+                dim_size = 0
+        size = list(src.size())
+        size[dim] = dim_size
+        out = torch.zeros(size, dtype=src.dtype, device=src.device)
+    out.scatter_add_(dim, bcast_index, src)
+    return out
+
+
+def _gather_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`gather_coo`.
+
+    ``out[..., i, ...] = src[..., index[i], ...]`` along ``dim = index.dim()
+    - 1``. With a 1-D ``index`` and multi-D ``src``, the index is broadcast
+    along the last dim, equivalent to ``src.index_select(dim, index)``.
+    """
+    dim = index.dim() - 1
+    if index.dim() == src.dim():
+        result = torch.gather(src, dim, index)
+    else:
+        # 1-D index path: pick rows / cols along ``dim``.
+        result = src.index_select(dim, index)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+
+
+def test_segment_add_coo_is_segment_sum_coo_alias():
+    assert pyg_lib.ops.segment_add_coo is pyg_lib.ops.segment_sum_coo
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_sum_coo_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    # Sorted ascending — required by segment_*_coo.
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_forward_1d(device):
+    src = torch.randn(8, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    src = torch.randn(6, 4, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_forward_k1_small_trailing(device):
+    """K==1 path: no trailing feature dims (purely 1-D)."""
+    src = torch.randn(10, device=device)
+    index = torch.tensor([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_forward_matches_scatter_sum(device):
+    """Sorted ``index`` -> segment_sum_coo is equivalent to scatter_sum."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out_coo = pyg_lib.ops.segment_sum_coo(src, index)
+    out_scatter = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    torch.testing.assert_close(out_coo, out_scatter)
+
+
+@withCUDA
+def test_segment_sum_coo_dim_size_auto_infer(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert out.size(-1) == 4
+    expected = _segment_sum_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_coo_dim_size_explicit(device):
+    src = torch.randn(6, device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index, dim_size=6)
+    assert out.size(-1) == 6
+    expected = _segment_sum_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(out, expected)
+    # Trailing empty buckets should be exactly zero.
+    torch.testing.assert_close(out[4:], torch.zeros(2, device=device))
+
+
+@withCUDA
+def test_segment_sum_coo_empty_rows_in_middle(device):
+    """Row 1 has no entries — its output must be zero."""
+    src = torch.randn(5, 4, device=device)
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_sum_coo_empty_input(device):
+    """Empty source and index — output is all-zero of the requested shape."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.segment_sum_coo(src, index, dim_size=3)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_segment_sum_coo_sorted_smoke(device):
+    """Sorted-ascending index is the supported contract — smoke test that
+    a long, well-formed sorted index produces the reference result.
+    """
+    torch.manual_seed(1)
+    src = torch.randn(32, 3, device=device)
+    # Long sorted run with varying segment sizes.
+    index = torch.tensor(
+        [0] * 5 + [1] * 1 + [2] * 8 + [3] * 4 + [4] * 7 + [5] * 7,
+        device=device,
+    )
+    assert index.numel() == 32
+
+    out = pyg_lib.ops.segment_sum_coo(src, index)
+    expected = _segment_sum_coo_ref(src, index)
+    torch.testing.assert_close(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_coo_backward_gradcheck(device):
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` -> empty trailing rows."""
+    src = torch.randn(
+        5,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_coo(s, index, dim_size=5)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gather_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_gather_coo_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(4, 3, dtype=dtype, device=device)
+    index = torch.tensor([0, 1, 1, 2, 3, 3, 0, 2], device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    expected = _gather_coo_ref(src, index)
+    assert out.size() == (8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_coo_forward_1d(device):
+    src = torch.randn(5, device=device)
+    index = torch.tensor([0, 0, 1, 2, 2, 2, 3, 4, 4], device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    expected = _gather_coo_ref(src, index)
+    assert out.size() == (9,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src``; output trailing dim
+    matches ``src``'s trailing dim.
+    """
+    src = torch.randn(4, 8, device=device)
+    index = torch.tensor([0, 1, 1, 2, 3, 3, 0, 2], device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    expected = _gather_coo_ref(src, index)
+    assert out.size() == (8, 8)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_coo_forward_k1_small_trailing(device):
+    """K==1 path: 1-D src, 1-D index."""
+    src = torch.tensor([10.0, 20.0, 30.0, 40.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 3, 3, 0, 2], device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    expected = torch.tensor(
+        [10.0, 20.0, 20.0, 30.0, 40.0, 40.0, 10.0, 30.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    src = torch.randn(5, 64, device=device)
+    index = torch.tensor([0, 0, 1, 2, 2, 2, 3, 4, 4, 4, 4], device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    expected = _gather_coo_ref(src, index)
+    assert out.size() == (11, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_coo_forward_inverse_of_segment_sum_signature(device):
+    """``segment_sum_coo`` output rows have shape ``[N, *trailing]``; passing
+    it through ``gather_coo`` with the same ``index`` recovers a tensor of
+    shape ``[E, *trailing]`` (the backward of segment_sum_coo).
+    """
+    src = torch.randn(8, 3, device=device)
+    index = torch.tensor([0, 0, 1, 1, 2, 2, 2, 3], device=device)
+
+    summed = pyg_lib.ops.segment_sum_coo(src, index)  # [4, 3]
+    scattered = pyg_lib.ops.gather_coo(summed, index)  # [8, 3]
+    assert scattered.size() == (8, 3)
+    expected = _gather_coo_ref(summed, index)
+    torch.testing.assert_close(scattered, expected)
+
+
+@withCUDA
+def test_gather_coo_empty_index(device):
+    """Empty index -> empty output (shape ``[0, *trailing]``)."""
+    src = torch.randn(3, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    out = pyg_lib.ops.gather_coo(src, index)
+    assert out.size() == (0, 4)
+
+
+# ---------------------------------------------------------------------------
+# gather_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_gather_coo_backward_gradcheck(device):
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 1, 2, 3, 3, 0, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_coo_backward_gradcheck_1d(device):
+    src = torch.randn(
+        5,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 2, 2, 2, 3, 4, 4], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_coo(s, index)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gradgradcheck — symmetric pair (each op's backward calls the other)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_coo_gradgradcheck(device):
+    """``SegmentSumCOO.backward`` invokes ``gather_coo``; gradgradcheck
+    exercises ``gather_coo``'s backward (which in turn invokes
+    ``segment_sum_coo``).
+    """
+    src = torch.randn(
+        6,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_coo(s, index)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_coo_gradgradcheck(device):
+    """``GatherCOO.backward`` invokes ``segment_sum_coo``; gradgradcheck
+    exercises ``segment_sum_coo``'s backward (which in turn invokes
+    ``gather_coo``).
+    """
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.tensor([0, 1, 1, 2, 3, 3, 0, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_coo(s, index)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 # ---------------------------------------------------------------------------
 # Reference implementations
@@ -688,6 +688,389 @@ def test_segment_mean_coo_backward_empty_input(device):
     assert out.size() == (3, 4)
     # Sum to a scalar and backprop — exercises backward on an empty grad.
     out.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_min_coo_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim_size: int = None,
+):
+    """Pure-PyTorch reference for :func:`segment_min_coo`.
+
+    COO ops always reduce along ``dim = index.dim() - 1`` with a sorted
+    ``index``. Returns ``(value, argindex)``:
+      * ``value[..., j, ...]`` is the minimum of ``src`` entries whose
+        broadcast index equals ``j`` along ``dim``.
+      * ``argindex[..., j, ...]`` is the position along ``dim`` of the
+        *first-match* min entry (CPU upstream contract).
+      * Empty buckets get ``value == 0`` and ``argindex == src.size(dim)``
+        (upstream sentinel).
+    """
+    dim = index.dim() - 1
+    bcast_index = _broadcast_index(index, src)
+
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+
+    sentinel = src.size(dim)
+    out_size = list(src.size())
+    out_size[dim] = dim_size
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    # Per-element Python loop over src along the reduction dim, tracking
+    # running min + first-match argindex per output position.
+    other_shape = list(src.size())
+    del other_shape[dim]
+    for i in range(src.size(dim)):
+        src_slice = src.select(dim, i)
+        idx_slice = bcast_index.select(dim, i)
+        flat_src = src_slice.reshape(-1)
+        flat_idx = idx_slice.reshape(-1)
+        for k in range(flat_idx.numel()):
+            j = int(flat_idx[k].item())
+            if j < 0 or j >= dim_size:
+                continue
+            coord = []
+            rem = k
+            for s in reversed(other_shape):
+                coord.append(rem % s)
+                rem //= s
+            coord = list(reversed(coord))
+            out_idx = list(coord)
+            out_idx.insert(dim, j)
+            out_idx_t = tuple(out_idx)
+            if argindex[out_idx_t].item() == sentinel:
+                value[out_idx_t] = flat_src[k]
+                argindex[out_idx_t] = i
+            else:
+                cur = value[out_idx_t]
+                v = flat_src[k]
+                if bool(v < cur):
+                    value[out_idx_t] = v
+                    argindex[out_idx_t] = i
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_min_coo_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    # Sorted ascending index — required by segment_*_coo.
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_2d_broadcast_index(device):
+    """1-D ``index`` broadcasts over a 2-D ``src`` along ``dim = 0``."""
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 4, device=device).to(torch.float32) - 12).view(
+        6,
+        4,
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    index = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 4, 4, 4], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_dim_size_auto_infer(device):
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    # Auto-inferred dim_size = index.max() + 1 = 4.
+    assert value.size(-1) == 4
+    assert arg.size(-1) == 4
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_coo_dim_size_explicit_empty_buckets(device):
+    """Explicit ``dim_size`` larger than implicit — trailing buckets are
+    empty. Upstream convention: value == 0, argindex == sentinel
+    (== src.size(dim)).
+    """
+    src = torch.tensor([5.0, -1.0, 3.0, -7.0, 2.0, 9.0], device=device)
+    index = torch.tensor([0, 1, 1, 2, 2, 3], device=device)
+    sentinel = src.size(-1)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=6)
+    assert value.size(-1) == 6
+    assert arg.size(-1) == 6
+    ref_value, ref_arg = _segment_min_coo_ref(src, index, dim_size=6)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Trailing empty buckets at positions 4, 5 must have value 0 and
+    # argindex == sentinel.
+    for p in [4, 5]:
+        assert value[p].item() == 0
+        assert arg[p].item() == sentinel
+
+
+@withCUDA
+def test_segment_min_coo_empty_rows_in_middle(device):
+    """Empty rows fixture: row 1 has no entries -> value 0 + sentinel arg."""
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    # Row 1 entirely skipped.
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    ref_value, ref_arg = _segment_min_coo_ref(src, index)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 has no contributors -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+def test_segment_min_coo_empty_input(device):
+    """Empty source + empty index -> all-zero value, all-sentinel arg."""
+    src = torch.empty(0, 4, device=device)
+    index = torch.empty(0, dtype=torch.long, device=device)
+    sentinel = src.size(0)  # 0
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, torch.zeros(3, 4, device=device))
+    torch.testing.assert_close(
+        arg,
+        torch.full((3, 4), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_min_coo_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Bucket 0: positions 0, 1, 2 all with value 1.0 (tied min).
+    # Bucket 1: positions 3, 4 with value 2.0 (tied min).
+    # Bucket 2: empty.
+    # Bucket 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    index = torch.tensor([0, 0, 0, 1, 1, 3], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=4)
+    # Value must equal the true per-bucket min regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Bucket 0 arg must be in {0, 1, 2}; bucket 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Bucket 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Bucket 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must in fact attain the bucket's min value.
+    for j in range(value.size(0)):
+        a = int(arg[j].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[j].item(), (
+            f'arg[{j}]={a} points to src value {src[a].item()} but bucket '
+            f'min is {value[j].item()}'
+        )
+
+
+@withCUDA
+def test_segment_min_coo_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(6, dtype=torch.double, device=device, requires_grad=True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_min_coo — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(6 * 3, device=device).to(torch.double) - 9)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck_with_dim_size(device):
+    """Gradcheck with explicit (larger) ``dim_size`` exercising empty
+    trailing rows. Their argindex points at the sentinel and the
+    ``+1``/``narrow`` backward pattern drops that slot — so the gradient
+    w.r.t. ``src`` for empty buckets is zero.
+    """
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(6, device=device).to(torch.double) - 3
+    ).requires_grad_(True)
+    index = torch.tensor([0, 0, 1, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index, dim_size=6)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck (row 1 has no entries)."""
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 0, 2, 2, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_coo(s, index)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_coo_backward_empty_input(device):
+    """Empty ``src`` and ``index`` — exercises the ``numel() > 0`` guard.
+    Backward must not crash on empty grad and must return a correctly-shaped
+    zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    index = torch.empty(0, dtype=torch.long, device=device)
+
+    value, arg = pyg_lib.ops.segment_min_coo(src, index, dim_size=3)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on empty grad.
+    value.sum().backward()
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1,0 +1,536 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _csr_to_coo(indptr: torch.Tensor) -> torch.Tensor:
+    """Converts a 1-D ``indptr`` to a 1-D COO ``index`` of length
+    ``indptr[-1]`` via ``torch.repeat_interleave``. For example,
+    ``indptr = [0, 2, 2, 5]`` maps to ``[0, 0, 2, 2, 2]``.
+    """
+    num_rows = indptr.numel() - 1
+    arange = torch.arange(num_rows, device=indptr.device)
+    return torch.repeat_interleave(arange, indptr.diff())
+
+
+def _segment_sum_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_sum_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. The reference converts ``indptr`` (any
+    leading-dim broadcast handled by simply taking the last row of strides:
+    indptr is required to be either truly 1-D w.r.t. its trailing rows, or
+    consistent across leading dims) to a COO index and falls back to
+    ``torch.zeros + scatter_add_``.
+    """
+    # CSR reduces along the trailing dim of ``indptr``.
+    dim = indptr.dim() - 1
+    num_rows = indptr.size(-1) - 1
+
+    # Compute the output shape: src shape with src.size(dim) -> num_rows.
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+
+    if out is None:
+        out = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+
+    if indptr.dim() == 1:
+        # 1-D indptr path: convert to a 1-D COO index and scatter_add along
+        # the reduction dim.
+        coo_index = _csr_to_coo(indptr)
+        # Broadcast coo_index to src's shape if needed.
+        if coo_index.dim() < src.dim():
+            view = [1] * src.dim()
+            view[dim] = -1
+            bcast = coo_index.view(view).expand_as(src)
+        else:
+            bcast = coo_index
+        out.scatter_add_(dim, bcast, src)
+    else:
+        # Multi-dim indptr: iterate the leading dims explicitly.
+        # ``indptr`` shares all leading dims with ``src``; the trailing dim
+        # describes per-leading-coord row boundaries.
+        leading_shape = indptr.shape[:-1]
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            out_slice = out[tuple(leading_idx)]
+            coo_index = _csr_to_coo(row_ptr)
+            if coo_index.dim() < src_slice.dim():
+                view = [1] * src_slice.dim()
+                view[0] = -1
+                bcast = coo_index.view(view).expand_as(src_slice)
+            else:
+                bcast = coo_index
+            out_slice.scatter_add_(0, bcast, src_slice)
+    return out
+
+
+def _gather_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`gather_csr`.
+
+    For each output position ``i`` along ``dim = indptr.dim() - 1``,
+    ``out[..., i, ...] = src[..., r, ...]`` where ``r`` is the row containing
+    ``i`` (i.e. the unique ``r`` with ``indptr[r] <= i < indptr[r+1]``).
+
+    Computed by repeat-interleaving ``src`` along ``dim`` by row-lengths
+    ``indptr.diff()``.
+    """
+    dim = indptr.dim() - 1
+    if indptr.dim() == 1:
+        repeats = indptr.diff()
+        result = torch.repeat_interleave(src, repeats, dim=dim)
+    else:
+        # Multi-dim indptr: handle the leading dims explicitly.
+        leading_shape = indptr.shape[:-1]
+        pieces = []
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            pieces.append(
+                torch.repeat_interleave(src_slice, row_ptr.diff(), dim=0),
+            )
+        # Stack back along the leading dim — assumes one leading dim.
+        result = torch.stack(pieces, dim=0).view(
+            *leading_shape,
+            *pieces[0].shape,
+        )
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+
+
+def test_segment_add_csr_is_segment_sum_csr_alias():
+    assert pyg_lib.ops.segment_add_csr is pyg_lib.ops.segment_sum_csr
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_sum_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_1d(device):
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k1_small_trailing(device):
+    """K==1 path: 1-D src, 1-D indptr — exercises the per-row CUDA kernel."""
+    src = torch.randn(10, device=device)
+    indptr = torch.tensor([0, 2, 4, 6, 8, 10], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_matches_segment_coo(device):
+    """The plan's primary parity test: ``segment_sum_csr`` must agree with
+    ``segment_sum_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+    """
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    out_csr = pyg_lib.ops.segment_sum_csr(src, indptr)
+    out_coo = pyg_lib.ops.segment_sum_coo(src, coo_index)
+    torch.testing.assert_close(out_csr, out_coo)
+
+
+@withCUDA
+def test_segment_sum_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty and its output row must be zero.
+    """
+    src = torch.randn(5, 4, device=device)
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_all_rows_empty(device):
+    """All rows empty -> output is all-zero of the expected shape."""
+    src = torch.empty(0, 4, device=device)
+    indptr = torch.tensor([0, 0, 0, 0], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_indptr_broadcast_via_expand(device):
+    """Indptr broadcasting: an expanded (non-contiguous) ``indptr`` should
+    work — the dispatcher must call ``.contiguous()`` at the kernel boundary.
+    """
+    torch.manual_seed(0)
+    # Two "graphs" sharing the same row layout. The natural way to express
+    # this is to expand a 1-D indptr to (B, R+1) and let the kernel reduce
+    # over the trailing dim for each batch entry.
+    src = torch.randn(2, 8, 4, device=device)
+    base_indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    # Sanity: the input is intentionally non-contiguous.
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_stress_short_and_huge_rows(device):
+    """Mix of many short rows and a few huge rows — exercises both fast paths
+    in the CUDA kernel (per-row sequential vs broadcast).
+    """
+    torch.manual_seed(0)
+    # 50 single-element rows, 1 small row, 2 huge rows.
+    row_lengths = [1] * 50 + [3] + [200, 500]
+    indptr_vals = [0]
+    for r in row_lengths:
+        indptr_vals.append(indptr_vals[-1] + r)
+    indptr = torch.tensor(indptr_vals, device=device)
+    total = indptr_vals[-1]
+    src = torch.randn(total, 8, device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (len(row_lengths), 8)
+    # Loose tolerance: huge rows accumulate in different orders on CUDA vs CPU.
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+
+@withCUDA
+def test_segment_sum_csr_with_out_argument(device):
+    """``out=...`` overrides allocation; output should be written in place."""
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    out = torch.zeros(4, 4, device=device)
+
+    result = pyg_lib.ops.segment_sum_csr(src, indptr, out=out)
+    expected = _segment_sum_csr_ref(src, indptr)
+    torch.testing.assert_close(out, expected)
+    # The returned tensor should be the same storage as ``out``.
+    assert result.data_ptr() == out.data_ptr()
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck(device):
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_gather_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(4, 3, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_1d(device):
+    src = torch.tensor([10.0, 20.0, 30.0, 40.0], device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    # Expected: row 0 (val 10) repeated 2x, row 1 (val 20) 3x, row 2 (val 30)
+    # 1x, row 3 (val 40) 2x.
+    expected = torch.tensor(
+        [10.0, 10.0, 20.0, 20.0, 20.0, 30.0, 40.0, 40.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    src = torch.randn(5, 64, device=device)
+    indptr = torch.tensor([0, 2, 3, 7, 10, 12], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (12, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_empty_rows(device):
+    """Empty-row fixture: ``indptr = [0, 2, 2, 5]`` — row 1 contributes
+    nothing to the gathered output.
+    """
+    src = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        device=device,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (5, 2)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_inverse_of_segment_sum_signature(device):
+    """``segment_sum_csr`` output rows have shape ``[N, *trailing]``; passing
+    it through ``gather_csr`` with the same ``indptr`` recovers a tensor of
+    shape ``[E, *trailing]`` (the backward of segment_sum_csr).
+    """
+    src = torch.randn(8, 3, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    summed = pyg_lib.ops.segment_sum_csr(src, indptr)  # [4, 3]
+    scattered = pyg_lib.ops.gather_csr(summed, indptr)  # [8, 3]
+    assert scattered.size() == (8, 3)
+    expected = _gather_csr_ref(summed, indptr)
+    torch.testing.assert_close(scattered, expected)
+
+
+@withCUDA
+def test_gather_csr_indptr_broadcast_via_expand(device):
+    """Expanded (non-contiguous) ``indptr`` — dispatcher must
+    ``.contiguous()`` at the kernel boundary.
+    """
+    src = torch.randn(2, 4, 3, device=device)
+    base_indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck(device):
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries, so its
+    gradient contribution is zero.
+    """
+    src = torch.randn(
+        3,
+        2,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gradgradcheck — symmetric pair (each op's backward calls the other)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck(device):
+    """``SegmentSumCSR.backward`` invokes ``gather_csr``; gradgradcheck
+    exercises ``gather_csr``'s backward (which in turn invokes
+    ``segment_sum_csr``).
+    """
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_gradgradcheck(device):
+    """``GatherCSR.backward`` invokes ``segment_sum_csr``; gradgradcheck
+    exercises ``segment_sum_csr``'s backward (which in turn invokes
+    ``gather_csr``).
+    """
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck_empty_rows(device):
+    """Gradgradcheck on the empty-rows fixture — exercises the symmetric
+    backward pair in the presence of zero-length rows.
+    """
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))


### PR DESCRIPTION
Symmetric to `segment_min_coo`: `>` comparison with
`numeric_limits::lowest()` init. CUDA uses `atomicMax` (commit 5) for the
value pass; arg pass still uses `atomicMin` on argindex for deterministic
first-match on ties. Backward is the same `+1`/`narrow` pattern.
