### PR TITLE
Add `segment_sum_csr` + `gather_csr` (symmetric pair)

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -1,0 +1,143 @@
+#include "../segment_csr.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr`; backward is exactly `gather_csr(grad_out, indptr)` — the
+// symmetric-pair inverse of forward (each `grad_out[r]` is broadcast back to
+// every source position `i ∈ [indptr[r], indptr[r+1])`).
+//
+// `out=` contract: the C++ dispatcher accumulates into the caller's buffer
+// when `out=` is supplied. `mark_dirty` lets gradcheck pick up the in-place
+// mutation; the backward gradient itself is computed the same way regardless.
+class SegmentSumCSR : public torch::autograd::Function<SegmentSumCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = segment_sum_csr(src, indptr, optional_out);
+
+    // Save `indptr` for backward's `gather_csr` call. The gather kernel
+    // applies the same broadcast convention, so we save the *original*
+    // (possibly pre-broadcast) `indptr`.
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `grad_src[..., i, ...] = grad_out[..., r, ...]` where `r` is the row
+    // such that `i ∈ [indptr[r], indptr[r+1])` — exactly `gather_csr`.
+    // We allocate a `grad_in` buffer the size of `src` and let `gather_csr`
+    // fill it via the `out=` overwrite contract. Positions in `grad_in` that
+    // are not covered by any `[indptr[r], indptr[r+1])` range (e.g. when
+    // `src` has trailing entries past `indptr[-1]`) remain uninitialized;
+    // upstream `segment_csr.cpp:75-76` uses `torch::empty` here for the same
+    // reason — those positions never received any contribution in forward,
+    // so their gradient is undefined.
+    auto grad_in = at::empty(src_shape, grad_out.options());
+    gather_csr(grad_out, indptr, grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_sum_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  return SegmentSumCSR::apply(src, indptr, optional_out)[0];
+}
+
+// Autograd Function for `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr` and `src.sizes()`; backward allocates `at::zeros(src_shape)` and
+// calls `segment_sum_csr(grad_out, indptr, /*out=*/grad_in)`, which
+// accumulates each `grad_out` entry into its source position via the `out=`
+// accumulate contract. This is the inverse of forward.
+class GatherCSR : public torch::autograd::Function<GatherCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = gather_csr(src, indptr, optional_out);
+
+    // Backward needs `indptr` (to know which `grad_out` entries map to which
+    // source row) and `src.sizes()` (to allocate the right-shaped `grad_in`).
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // Allocate the gradient buffer at `src.shape` and use the `out=`
+    // accumulate contract of `segment_sum_csr` to deposit each `grad_out`
+    // entry at its source row. This is the inverse of forward: each
+    // `grad_in[r]` accumulates `grad_out[i]` for all `i ∈ [indptr[r],
+    // indptr[r+1])`.
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    segment_sum_csr(grad_out, indptr, /*out=*/grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor gather_csr_autograd(const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+  return GatherCSR::apply(src, indptr, optional_out)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
+         TORCH_FN(gather_csr_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -1,0 +1,270 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1` (upstream
+// `segment_csr_cpu.cpp:24`). Each row `r ∈ [0, indptr.size(dim) - 1)`
+// consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]` and writes
+// the per-row sum to `out[..., r, ...]`. Empty rows leave the corresponding
+// `out` slot at its zero-initialized (or caller-supplied) value.
+//
+// Layout (upstream `segment_csr_cpu.cpp:54-56`): we factor the work into
+//   * N = out.size(dim) * (indptr.numel() / indptr.size(-1))
+//         — total number of "rows" across all leading indptr dims,
+//   * E = src.size(dim) — number of source entries along the reduction axis,
+//   * K = out.numel() / N — product of trailing dims of `src` past
+//         `indptr.dim()`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). Matches upstream and is what makes
+// `GatherCSR::backward` efficient.
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_sum_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` along its leading
+  // dims (upstream `segment_csr_cpu.cpp:19-22`). The last indptr dim
+  // (size = num_rows + 1) is preserved as-is. Then force contiguous so the
+  // kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_sum_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_sum_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Zero-init so empty rows (and the accumulate loop) produce the correct
+    // result without any per-row pre-fill.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  // `N` is the total row count across all leading indptr dims (upstream's
+  // factoring: `out.size(dim) * (indptr.numel() / indptr.size(-1))`).
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` slot (`out_data + n * K`) so no atomics are
+        // needed. The inner accumulate loop is sequential per row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                // `n` indexes into the flattened (leading, rows_per_slice)
+                // space; reconstruct the offsets into indptr and src.
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                // indptr layout: leading slices each of length
+                // `indptr.size(-1)`
+                // (= rows_per_slice + 1). Row `row` consumes
+                // `[indptr[row], indptr[row+1])`.
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                // `src` per-slice stride along `dim` is `E * K`; within a
+                // slice each row position is one `K`-block.
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  // Honor the `out=` accumulate contract: seed from the
+                  // current `out` slot.
+                  opmath_t acc = static_cast<opmath_t>(out_data[n]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                  }
+                  out_data[n] = static_cast<scalar_t>(acc);
+                } else {
+                  std::vector<opmath_t> acc(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    acc[k] = static_cast<opmath_t>(out_data[n * K + k]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                  }
+                  for (int64_t k = 0; k < K; ++k)
+                    out_data[n * K + k] = static_cast<scalar_t>(acc[k]);
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+// CPU implementation of `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
+// the value `src[..., r, ...]` is **broadcast** to every output position
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// Strategy: per-row linear pass (upstream `segment_csr_cpu.cpp:146-158`).
+// This avoids the per-output-position binary search the plan mentions: for
+// each row we read one `src` value (per K) and write it to a contiguous
+// stretch of `out`. Parallelism is over the flat row index `N`.
+//
+// Layout:
+//   * N = src.size(dim) * (indptr.numel() / indptr.size(-1)),
+//   * E = out.size(dim) — number of output positions along the gather axis,
+//   * K = src.numel() / N — product of trailing dims past `indptr.dim()`.
+//
+// `out=` contract: **overwrite** the caller's buffer per element. Positions
+// outside any `[indptr[r], indptr[r+1])` range (i.e. before `indptr[0]` or
+// after `indptr[-1]`) are left untouched.
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr: src.dim() must be >= indptr.dim() (got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0, "gather_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` along leading dims to match `src.shape[:dim]`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr: src.size(dim) must equal indptr.size(-1) - 1");
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < src_c.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "gather_csr: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // Output size along `dim` is the trailing entry of `indptr`. We read it
+      // from the flattened-last entry of the broadcast indptr (all leading
+      // slices share the same trailing value since the original indptr only
+      // varied along `dim`).
+      out_sizes[dim] = *indptr_b.flatten()[-1].data_ptr<int64_t>();
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // Layout: N = (rows_per_slice) * (leading slices); per src entry we write
+  // a contiguous stretch in `out` of length (row_end - row_start) * K.
+  const int64_t rows_per_slice = src_c.size(dim);
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = rows_per_slice * leading;
+  const int64_t K = src_c.numel() / N;
+  const int64_t E = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cpu", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over flat row index. Each row writes a disjoint
+        // stretch of `out` so no atomics / coordination needed.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t out_off = slice * E * K;
+
+                if (K == 1) {
+                  const scalar_t v = src_data[n];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    out_data[out_off + e] = v;
+                  }
+                } else {
+                  // Cache row value across the inner E loop to avoid repeated
+                  // loads from `src`. Matches upstream `vals[K]` cache pattern.
+                  std::vector<scalar_t> vals(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    vals[k] = src_data[n * K + k];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      out_data[out_off + e * K + k] = vals[k];
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -1,0 +1,450 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 12: dynamic block sizing — replicates the inline `threads()` /
+// `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
+// Each `.cu` file in `pyg_lib/csrc/ops/cuda/` carries its own copy until a
+// shared helper lands.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// Strided-offset helper specialised for `indptr` row pointers.
+//
+// `at::cuda::detail::IndexToOffset` walks all dims of a `TensorInfo` and is
+// suitable for COO `index` (where the last dim's size matches the number of
+// reduced rows). For CSR `indptr` we need the **same arithmetic with the last
+// dim's effective size reduced by 1** — `indptr` has `rows + 1` entries per
+// batch (one trailing sentinel), but we only index `[0, rows)` from the
+// kernel. Port of upstream `pytorch_scatter/csrc/cuda/index_info.cuh:7-19`.
+struct IndexPtrToOffset {
+  static __host__ __device__ __forceinline__ int get(
+      int idx,
+      const at::cuda::detail::TensorInfo<int64_t, int>& info) {
+    int offset = idx % (info.sizes[info.dims - 1] - 1);
+    offset *= info.strides[info.dims - 1];
+    idx /= info.sizes[info.dims - 1] - 1;
+    for (int i = info.dims - 2; i >= 0; --i) {
+      offset += (idx % info.sizes[i]) * info.strides[i];
+      idx /= info.sizes[i];
+    }
+    return offset;
+  }
+};
+
+// ============================================================================
+// `segment_sum_csr` — Commit 10.
+//
+// Two CUDA kernel variants:
+//
+//   1. `segment_sum_csr_cuda_kernel` (K==1, no trailing feature dims). One
+//      thread per row; sequential inner loop summing
+//      `src[indptr[r] : indptr[r+1]]` into `out[r]`. Port of upstream
+//      `pytorch_scatter/csrc/cuda/segment_csr_cuda.cu:15-60` with `TB == 1`
+//      — TB==1 means single thread per row, so the warp-tree shuffle path is
+//      dead code and is omitted entirely. The `SHFL_DOWN_SYNC` reduction only
+//      fires for the min/max ops (commits 12/13) where TB > 1.
+//
+//   2. `segment_sum_csr_broadcast_cuda_kernel` (K>1, trailing feature dims).
+//      One thread per `(row, col)` pair; each thread sequentially walks the
+//      row's source range. Port of upstream `segment_csr_cuda.cu:62-95`.
+//      Per the upstream comment at line 70, shared-memory reuse was tried
+//      and discarded — the syncthreads overhead exceeded the benefit, so we
+//      keep the same "no shared memory" design here.
+//
+// Accumulation is in `at::opmath_type<scalar_t>` registers; the final cast
+// back to `scalar_t` matches upstream behaviour for `Half`/`BFloat16`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we
+// **accumulate** into it (no zero-init). Matches the upstream `segment_csr`
+// contract and is what makes `GatherCSR::backward` efficient (`at::zeros` +
+// `segment_sum_csr(out=grad_in)` deposits the gradient in-place).
+
+// K==1 kernel — one thread per row.
+template <typename scalar_t>
+__global__ void segment_sum_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Compute the strided indptr offset for this row.
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Upstream
+  // computes this via
+  //   `(row_idx / (indptr.size(-1) - 1)) * E`
+  // where `E = src.size(dim)`. Mirrors `segment_csr_cuda.cu:38-43`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(src_data[batch_offset + src_idx]);
+  }
+
+  // Accumulate into `out`. The dispatcher zero-inits a freshly allocated
+  // `out`; when the caller supplies `out=`, we **add** to it (accumulate
+  // contract used by `GatherCSR::backward`). For empty rows
+  // (`row_end == row_start`), `val == 0` so the existing value is preserved.
+  out_data[row_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[row_idx]) + val);
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair.
+template <typename scalar_t>
+__global__ void segment_sum_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` includes the trailing `K` extent.
+  // Mirrors `segment_csr_cuda.cu:85`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx]);
+  }
+
+  // Accumulate-into contract (see K==1 kernel above).
+  out_data[thread_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[thread_idx]) + val);
+}
+
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_sum_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_sum_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_sum_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // CSR convention: `indptr` is `expand`-broadcast up to
+  // `src.shape[:indptr.dim()-1]` so the leading batch dims match. The last
+  // dim of `indptr` is the row pointer itself and stays at its native size.
+  // Mirrors `segment_csr_cuda.cu:108-112`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  // CSR ops fix the reduction axis at the last `indptr` dim.
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Accumulate-into contract: caller owns the buffer, no zero-init.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_sum_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_sum_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Zero-init so the in-kernel `+=` accumulation produces the correct
+    // result for a freshly allocated buffer.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  // `N` is the total number of rows across all leading batch dims (upstream
+  // `segment_csr_cuda.cu:144`). `K` is the product of trailing feature dims
+  // past the reduction axis (upstream line 145). `E` is `src.size(dim)`.
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row, sequential inner sum. No SHFL — TB == 1
+          // means there's only one lane per row.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          segment_sum_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col). Sequential row scan in inner loop.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_sum_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+// ============================================================================
+// `gather_csr` — Commit 10.
+//
+// Symmetric inverse of `segment_sum_csr`: for each row `r`, broadcast
+// `src[r]` to every output position `[indptr[r], indptr[r+1])` along the
+// reduction axis. Two kernel variants:
+//
+//   * K==1: one thread per row writes the row value to all `[row_start,
+//     row_end)` output positions. Port of upstream `segment_csr_cuda.cu:
+//     171-192` with `TB == 1`. (Upstream uses TB=4 to get more parallelism
+//     for long rows; we mirror that ladder via the dynamic block-size
+//     dispatch — see comment below.)
+//   * K>1: one thread per `(row, col)` pair, same write pattern with the
+//     trailing `K` extent. Port of upstream `segment_csr_cuda.cu:194-217`.
+//
+// `out=` contract: **overwrite** (not accumulate) — every output element is
+// written exactly once. Matches upstream `gather_csr`. The output sizing
+// rule allocates the same shape as `src` with the reduction axis replaced
+// by `indptr[..., -1]` (upstream lines 245-253).
+
+template <typename scalar_t>
+__global__ void gather_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = __ldg(src_data + row_idx);
+
+  // Per-batch slice offset into `out` along the reduction axis. Mirrors
+  // upstream `segment_csr_cuda.cu:187`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + out_idx] = val;
+  }
+}
+
+template <typename scalar_t>
+__global__ void gather_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = src_data[thread_idx];
+
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + static_cast<int>(K) * out_idx + col_idx] = val;
+  }
+}
+
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(), "gather_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "gather_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr (CUDA): src and indptr must be on the same device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "gather_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `indptr` leading dims up to `src.shape[:indptr.dim()-1]`.
+  // Mirrors upstream `segment_csr_cuda.cu:229-232`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr (CUDA): src.size(", dim,
+              ") must be 0 or equal to indptr.size(-1) - 1 (got ",
+              src.size(dim), " vs ", indptr_b.size(dim) - 1, ")");
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    // Overwrite contract: every output element is written exactly once.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "gather_csr (CUDA): out.size(", i, ") must match src.size(",
+                    i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // `out.size(dim) = indptr[..., -1]` — the total number of "gathered"
+      // entries. Mirrors upstream `segment_csr_cuda.cu:247-252`. Reading
+      // the last entry of a contiguous flat `indptr` costs one D->H sync
+      // but is one-off (host-side allocation path).
+      out_sizes[dim] = indptr_c.flatten()[-1].cpu().data_ptr<int64_t>()[0];
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // `N` = total number of input rows across all batch dims (upstream
+  // `segment_csr_cuda.cu:261`). `K` = trailing feature-dim extent. `E` =
+  // `out.size(dim)` — the per-batch output length.
+  const auto N = src_c.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = src_c.numel() / N;
+  const auto E = out.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row writes the row value to all output positions
+          // in `[row_start, row_end)`.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          gather_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col); same write pattern with the trailing
+          // `K` extent.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          gather_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -1,0 +1,73 @@
+#include "segment_csr.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor segment_sum_csr(const at::Tensor& src,
+                                   const at::Tensor& indptr,
+                                   const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_sum_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_sum_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_sum_csr", "")
+                       .typed<decltype(segment_sum_csr)>();
+  return op.call(src, indptr, out);
+}
+
+PYG_API at::Tensor gather_csr(const at::Tensor& src,
+                              const at::Tensor& indptr,
+                              const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"gather_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "gather_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::gather_csr", "")
+                       .typed<decltype(gather_csr)>();
+  return op.call(src, indptr, out);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_sum_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the segments specified by the
+// compressed row pointer `indptr` along the implicit axis
+// `dim = indptr.dim() - 1`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row sum into `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) leave the corresponding `out` slot at its
+// zero-initialized value (or unchanged if a caller-supplied `out=` is given).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// `GatherCSR::backward` efficient (the backward allocates
+// `at::zeros(src_shape)` and calls `segment_sum_csr` with it as `out=` to
+// deposit the gradient in-place).
+PYG_API at::Tensor segment_sum_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Gathers values from `src` at the row positions encoded in `indptr`, along
+// the implicit axis `dim = indptr.dim() - 1`. Concretely, for each row `r`,
+// the value `src[..., r, ...]` is broadcast to all output positions
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the gather axis at `indptr.dim() - 1`. The output size along `dim` is
+// determined by the last entry of `indptr` (i.e. `indptr[..., -1]`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated. When `out` *is*
+// provided, the operation **overwrites** the caller's buffer per element
+// (matches upstream `pytorch_scatter`).
+PYG_API at::Tensor gather_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -631,6 +631,56 @@ def gather_coo(
     return torch.ops.pyg.gather_coo(src, index, out)
 
 
+def segment_sum_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``sum`` as the reduction.
+
+    The reduction axis is ``indptr.dim() - 1`` and the output size along that
+    axis is ``indptr.size(-1) - 1`` (no explicit ``dim_size`` arg).
+
+    If :obj:`out` is not given, a new zero-initialized tensor is allocated.
+    If :obj:`out` is given, values are **accumulated** into it.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_sum_csr(src, indptr, out)
+
+
+segment_add_csr = segment_sum_csr
+
+
+def gather_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Gathers values from :obj:`src` to all positions encoded by the CSR
+    :obj:`indptr`: for each row ``r``, broadcasts ``src[r]`` to all output
+    positions in ``[indptr[r], indptr[r+1])``. Symmetric inverse of
+    :func:`segment_sum_csr`.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor (overwritten if given).
+
+    Returns:
+        Broadcast tensor of shape ``src.shape`` with ``indptr.dim()-1`` axis
+        replaced by ``indptr[-1]``.
+    """
+    return torch.ops.pyg.gather_csr(src, indptr, out)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -881,6 +931,9 @@ __all__ = [
     'segment_min_coo',
     'segment_max_coo',
     'gather_coo',
+    'segment_sum_csr',
+    'segment_add_csr',
+    'gather_csr',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1,0 +1,536 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _csr_to_coo(indptr: torch.Tensor) -> torch.Tensor:
+    """Converts a 1-D ``indptr`` to a 1-D COO ``index`` of length
+    ``indptr[-1]`` via ``torch.repeat_interleave``. For example,
+    ``indptr = [0, 2, 2, 5]`` maps to ``[0, 0, 2, 2, 2]``.
+    """
+    num_rows = indptr.numel() - 1
+    arange = torch.arange(num_rows, device=indptr.device)
+    return torch.repeat_interleave(arange, indptr.diff())
+
+
+def _segment_sum_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_sum_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. The reference converts ``indptr`` (any
+    leading-dim broadcast handled by simply taking the last row of strides:
+    indptr is required to be either truly 1-D w.r.t. its trailing rows, or
+    consistent across leading dims) to a COO index and falls back to
+    ``torch.zeros + scatter_add_``.
+    """
+    # CSR reduces along the trailing dim of ``indptr``.
+    dim = indptr.dim() - 1
+    num_rows = indptr.size(-1) - 1
+
+    # Compute the output shape: src shape with src.size(dim) -> num_rows.
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+
+    if out is None:
+        out = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+
+    if indptr.dim() == 1:
+        # 1-D indptr path: convert to a 1-D COO index and scatter_add along
+        # the reduction dim.
+        coo_index = _csr_to_coo(indptr)
+        # Broadcast coo_index to src's shape if needed.
+        if coo_index.dim() < src.dim():
+            view = [1] * src.dim()
+            view[dim] = -1
+            bcast = coo_index.view(view).expand_as(src)
+        else:
+            bcast = coo_index
+        out.scatter_add_(dim, bcast, src)
+    else:
+        # Multi-dim indptr: iterate the leading dims explicitly.
+        # ``indptr`` shares all leading dims with ``src``; the trailing dim
+        # describes per-leading-coord row boundaries.
+        leading_shape = indptr.shape[:-1]
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            out_slice = out[tuple(leading_idx)]
+            coo_index = _csr_to_coo(row_ptr)
+            if coo_index.dim() < src_slice.dim():
+                view = [1] * src_slice.dim()
+                view[0] = -1
+                bcast = coo_index.view(view).expand_as(src_slice)
+            else:
+                bcast = coo_index
+            out_slice.scatter_add_(0, bcast, src_slice)
+    return out
+
+
+def _gather_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`gather_csr`.
+
+    For each output position ``i`` along ``dim = indptr.dim() - 1``,
+    ``out[..., i, ...] = src[..., r, ...]`` where ``r`` is the row containing
+    ``i`` (i.e. the unique ``r`` with ``indptr[r] <= i < indptr[r+1]``).
+
+    Computed by repeat-interleaving ``src`` along ``dim`` by row-lengths
+    ``indptr.diff()``.
+    """
+    dim = indptr.dim() - 1
+    if indptr.dim() == 1:
+        repeats = indptr.diff()
+        result = torch.repeat_interleave(src, repeats, dim=dim)
+    else:
+        # Multi-dim indptr: handle the leading dims explicitly.
+        leading_shape = indptr.shape[:-1]
+        pieces = []
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            pieces.append(
+                torch.repeat_interleave(src_slice, row_ptr.diff(), dim=0),
+            )
+        # Stack back along the leading dim — assumes one leading dim.
+        result = torch.stack(pieces, dim=0).view(
+            *leading_shape,
+            *pieces[0].shape,
+        )
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+
+
+def test_segment_add_csr_is_segment_sum_csr_alias():
+    assert pyg_lib.ops.segment_add_csr is pyg_lib.ops.segment_sum_csr
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_sum_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_1d(device):
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k1_small_trailing(device):
+    """K==1 path: 1-D src, 1-D indptr — exercises the per-row CUDA kernel."""
+    src = torch.randn(10, device=device)
+    indptr = torch.tensor([0, 2, 4, 6, 8, 10], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_matches_segment_coo(device):
+    """The plan's primary parity test: ``segment_sum_csr`` must agree with
+    ``segment_sum_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+    """
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    out_csr = pyg_lib.ops.segment_sum_csr(src, indptr)
+    out_coo = pyg_lib.ops.segment_sum_coo(src, coo_index)
+    torch.testing.assert_close(out_csr, out_coo)
+
+
+@withCUDA
+def test_segment_sum_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty and its output row must be zero.
+    """
+    src = torch.randn(5, 4, device=device)
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_all_rows_empty(device):
+    """All rows empty -> output is all-zero of the expected shape."""
+    src = torch.empty(0, 4, device=device)
+    indptr = torch.tensor([0, 0, 0, 0], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_indptr_broadcast_via_expand(device):
+    """Indptr broadcasting: an expanded (non-contiguous) ``indptr`` should
+    work — the dispatcher must call ``.contiguous()`` at the kernel boundary.
+    """
+    torch.manual_seed(0)
+    # Two "graphs" sharing the same row layout. The natural way to express
+    # this is to expand a 1-D indptr to (B, R+1) and let the kernel reduce
+    # over the trailing dim for each batch entry.
+    src = torch.randn(2, 8, 4, device=device)
+    base_indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    # Sanity: the input is intentionally non-contiguous.
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_stress_short_and_huge_rows(device):
+    """Mix of many short rows and a few huge rows — exercises both fast paths
+    in the CUDA kernel (per-row sequential vs broadcast).
+    """
+    torch.manual_seed(0)
+    # 50 single-element rows, 1 small row, 2 huge rows.
+    row_lengths = [1] * 50 + [3] + [200, 500]
+    indptr_vals = [0]
+    for r in row_lengths:
+        indptr_vals.append(indptr_vals[-1] + r)
+    indptr = torch.tensor(indptr_vals, device=device)
+    total = indptr_vals[-1]
+    src = torch.randn(total, 8, device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (len(row_lengths), 8)
+    # Loose tolerance: huge rows accumulate in different orders on CUDA vs CPU.
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+
+@withCUDA
+def test_segment_sum_csr_with_out_argument(device):
+    """``out=...`` overrides allocation; output should be written in place."""
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    out = torch.zeros(4, 4, device=device)
+
+    result = pyg_lib.ops.segment_sum_csr(src, indptr, out=out)
+    expected = _segment_sum_csr_ref(src, indptr)
+    torch.testing.assert_close(out, expected)
+    # The returned tensor should be the same storage as ``out``.
+    assert result.data_ptr() == out.data_ptr()
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck(device):
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_gather_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(4, 3, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_1d(device):
+    src = torch.tensor([10.0, 20.0, 30.0, 40.0], device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    # Expected: row 0 (val 10) repeated 2x, row 1 (val 20) 3x, row 2 (val 30)
+    # 1x, row 3 (val 40) 2x.
+    expected = torch.tensor(
+        [10.0, 10.0, 20.0, 20.0, 20.0, 30.0, 40.0, 40.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    src = torch.randn(5, 64, device=device)
+    indptr = torch.tensor([0, 2, 3, 7, 10, 12], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (12, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_empty_rows(device):
+    """Empty-row fixture: ``indptr = [0, 2, 2, 5]`` — row 1 contributes
+    nothing to the gathered output.
+    """
+    src = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        device=device,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (5, 2)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_inverse_of_segment_sum_signature(device):
+    """``segment_sum_csr`` output rows have shape ``[N, *trailing]``; passing
+    it through ``gather_csr`` with the same ``indptr`` recovers a tensor of
+    shape ``[E, *trailing]`` (the backward of segment_sum_csr).
+    """
+    src = torch.randn(8, 3, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    summed = pyg_lib.ops.segment_sum_csr(src, indptr)  # [4, 3]
+    scattered = pyg_lib.ops.gather_csr(summed, indptr)  # [8, 3]
+    assert scattered.size() == (8, 3)
+    expected = _gather_csr_ref(summed, indptr)
+    torch.testing.assert_close(scattered, expected)
+
+
+@withCUDA
+def test_gather_csr_indptr_broadcast_via_expand(device):
+    """Expanded (non-contiguous) ``indptr`` — dispatcher must
+    ``.contiguous()`` at the kernel boundary.
+    """
+    src = torch.randn(2, 4, 3, device=device)
+    base_indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck(device):
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries, so its
+    gradient contribution is zero.
+    """
+    src = torch.randn(
+        3,
+        2,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gradgradcheck — symmetric pair (each op's backward calls the other)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck(device):
+    """``SegmentSumCSR.backward`` invokes ``gather_csr``; gradgradcheck
+    exercises ``gather_csr``'s backward (which in turn invokes
+    ``segment_sum_csr``).
+    """
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_gradgradcheck(device):
+    """``GatherCSR.backward`` invokes ``segment_sum_csr``; gradgradcheck
+    exercises ``segment_sum_csr``'s backward (which in turn invokes
+    ``gather_csr``).
+    """
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck_empty_rows(device):
+    """Gradgradcheck on the empty-rows fixture — exercises the symmetric
+    backward pair in the presence of zero-length rows.
+    """
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))


### PR DESCRIPTION
First CSR commit. Bundles the symmetric pair — each is the other's
backward, so shipping one alone would leave a broken autograd graph.
Reduction axis is always `indptr.dim() - 1`; output size along that
axis is fixed by `indptr.size(-1) - 1`, so no `dim`/`dim_size` args.
Includes `segment_add_csr` alias.

CUDA splits on K: K==1 runs one thread per row with a sequential inner
scan; K>1 runs one thread per `(row, col)` with the same inner scan.
Sum needs neither SHFL nor shared memory — that's gated behind `TB>1`
and only fires for min/max in commits 12/13 (per upstream's note that
the syncthreads overhead exceeded the shared-memory benefit). `gather_csr`
runs one thread per row that broadcasts `src[r]` to all positions in
`[indptr[r], indptr[r+1])`.

`GatherCSR::backward` uses the same `out=` accumulate trick as
`GatherCOO`: allocate zeros and let `segment_sum_csr` deposit into it.
