### PR TITLE
Add `segment_mean_csr`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -1,0 +1,143 @@
+#include "../segment_csr.h"
+
+#include <torch/autograd.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+using torch::autograd::variable_list;
+
+// Autograd Function for `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr`; backward is exactly `gather_csr(grad_out, indptr)` — the
+// symmetric-pair inverse of forward (each `grad_out[r]` is broadcast back to
+// every source position `i ∈ [indptr[r], indptr[r+1])`).
+//
+// `out=` contract: the C++ dispatcher accumulates into the caller's buffer
+// when `out=` is supplied. `mark_dirty` lets gradcheck pick up the in-place
+// mutation; the backward gradient itself is computed the same way regardless.
+class SegmentSumCSR : public torch::autograd::Function<SegmentSumCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = segment_sum_csr(src, indptr, optional_out);
+
+    // Save `indptr` for backward's `gather_csr` call. The gather kernel
+    // applies the same broadcast convention, so we save the *original*
+    // (possibly pre-broadcast) `indptr`.
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `grad_src[..., i, ...] = grad_out[..., r, ...]` where `r` is the row
+    // such that `i ∈ [indptr[r], indptr[r+1])` — exactly `gather_csr`.
+    // We allocate a `grad_in` buffer the size of `src` and let `gather_csr`
+    // fill it via the `out=` overwrite contract. Positions in `grad_in` that
+    // are not covered by any `[indptr[r], indptr[r+1])` range (e.g. when
+    // `src` has trailing entries past `indptr[-1]`) remain uninitialized;
+    // upstream `segment_csr.cpp:75-76` uses `torch::empty` here for the same
+    // reason — those positions never received any contribution in forward,
+    // so their gradient is undefined.
+    auto grad_in = at::empty(src_shape, grad_out.options());
+    gather_csr(grad_out, indptr, grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_sum_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  return SegmentSumCSR::apply(src, indptr, optional_out)[0];
+}
+
+// Autograd Function for `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
+// `indptr` and `src.sizes()`; backward allocates `at::zeros(src_shape)` and
+// calls `segment_sum_csr(grad_out, indptr, /*out=*/grad_in)`, which
+// accumulates each `grad_out` entry into its source position via the `out=`
+// accumulate contract. This is the inverse of forward.
+class GatherCSR : public torch::autograd::Function<GatherCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = gather_csr(src, indptr, optional_out);
+
+    // Backward needs `indptr` (to know which `grad_out` entries map to which
+    // source row) and `src.sizes()` (to allocate the right-shaped `grad_in`).
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // Allocate the gradient buffer at `src.shape` and use the `out=`
+    // accumulate contract of `segment_sum_csr` to deposit each `grad_out`
+    // entry at its source row. This is the inverse of forward: each
+    // `grad_in[r]` accumulates `grad_out[i]` for all `i ∈ [indptr[r],
+    // indptr[r+1])`.
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    segment_sum_csr(grad_out, indptr, /*out=*/grad_in);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor gather_csr_autograd(const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+  return GatherCSR::apply(src, indptr, optional_out)[0];
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
+         TORCH_FN(gather_csr_autograd));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -74,6 +74,89 @@ at::Tensor segment_sum_csr_autograd(
   return SegmentSumCSR::apply(src, indptr, optional_out)[0];
 }
 
+// Autograd Function for `pyg::segment_mean_csr`.
+//
+// Forward computes the per-row mean of `src` over `[indptr[r], indptr[r+1])`.
+// Backward routes each `grad_out[r]` back to every source entry in that row,
+// scaled by `1 / row_length[r]`. We use `gather_csr(grad_out, indptr)` to
+// broadcast `grad_out` back to source positions, and `gather_csr(count, ...)`
+// to lift the per-row count to per-source positions; then in-place divide.
+//
+// Row-length recompute: cheap (just `indptr.narrow().diff()`) and avoids
+// saving an extra tensor for backward (the COO mean kernel has to save the
+// count because reconstructing it from `index` would require a second pass).
+//
+// Empty-tensor guard: if `grad_in.numel() == 0` (e.g. `src` was empty), the
+// gather/divide both no-op and we can skip them — matches upstream
+// `segment_csr.cpp:100-109`.
+class SegmentMeanCSR : public torch::autograd::Function<SegmentMeanCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    auto out = segment_mean_csr(src, indptr, optional_out);
+
+    ctx->save_for_backward({indptr});
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto indptr = saved[0];
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    auto grad_in = at::empty(src_shape, grad_out.options());
+
+    // Match upstream `segment_csr.cpp:100-109`: skip gather/divide when the
+    // gradient buffer is empty (e.g. `src` was empty); the empty tensor
+    // itself is the correct gradient.
+    if (grad_in.numel() > 0) {
+      // Lift `grad_out` to per-source positions via the CSR-symmetric
+      // inverse of forward (uses the `out=` overwrite contract of
+      // `gather_csr` to fill `grad_in` in place).
+      gather_csr(grad_out, indptr, grad_in);
+
+      // Per-row count from `indptr`: `count[r] = indptr[r+1] - indptr[r]`.
+      // `indptr` may carry leading dims (when broadcast); narrowing the
+      // last dim produces a `count` with shape `indptr.shape[:-1] + (R,)`
+      // where `R = indptr.size(-1) - 1`. Cast to grad dtype so the divide
+      // is in-place safe.
+      auto indptr1 = indptr.narrow(-1, 0, indptr.size(-1) - 1);
+      auto indptr2 = indptr.narrow(-1, 1, indptr.size(-1) - 1);
+      auto count = (indptr2 - indptr1).to(grad_in.options());
+      // `gather_csr` lifts the per-row count to per-source positions along
+      // the CSR axis. Unsqueeze the result over trailing K dims of
+      // `grad_out` past `indptr.dim()` so the divide broadcasts correctly.
+      count = gather_csr(count, indptr, std::nullopt);
+      for (int64_t i = 0; i < grad_out.dim() - indptr.dim(); ++i)
+        count = count.unsqueeze(-1);
+      grad_in.true_divide_(count);
+    }
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+at::Tensor segment_mean_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  return SegmentMeanCSR::apply(src, indptr, optional_out)[0];
+}
+
 // Autograd Function for `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
@@ -135,6 +218,8 @@ at::Tensor gather_csr_autograd(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
          TORCH_FN(segment_sum_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
+         TORCH_FN(segment_mean_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
          TORCH_FN(gather_csr_autograd));
 }

--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -157,6 +157,93 @@ at::Tensor segment_mean_csr_autograd(
   return SegmentMeanCSR::apply(src, indptr, optional_out)[0];
 }
 
+// Autograd Function for `pyg::segment_min_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `SegmentMinCOO` / `ScatterMin`).
+//
+// Backward formula (mirrors `ScatterMin` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions that
+// produced the per-row min and silently drops any contribution from rows
+// whose `arg_out` is still at the sentinel (empty rows).
+class SegmentMinCSR : public torch::autograd::Function<SegmentMinCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = indptr.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_min_csr: indptr must have at least 1 dimension");
+
+    auto result = segment_min_csr(src, indptr, optional_out);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // implicit `dim`, and the original `src.sizes()` (so the +1/narrow trick
+    // reconstructs the right shape). We save `indptr` for parity with other
+    // CSR Functions; it is not used directly by backward.
+    ctx->save_for_backward({indptr, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `indptr`, kept for parity with other CSR Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are dropped
+    // by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  auto result = SegmentMinCSR::apply(src, indptr, optional_out);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
@@ -220,6 +307,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_sum_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
          TORCH_FN(gather_csr_autograd));
 }

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -139,6 +139,120 @@ at::Tensor segment_sum_csr_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_mean_csr`.
+//
+// Same layout/shape as `segment_sum_csr_kernel` (sequential per-row pass with
+// `at::parallel_for` over rows), with an extra post-loop divide by the row
+// length. Row length is `indptr[r+1] - indptr[r]`; empty rows have length 0
+// so we clamp to 1 before dividing — the corresponding `out` slot is already
+// zero (from the zero-init) and `0 / 1 = 0` is the desired empty-row value.
+//
+// `out=` contract: upstream MEAN does **not** honor an accumulate contract.
+// We allocate `out` as `at::zeros(...)` and overwrite per row (sum into the
+// zero, then divide). If the caller supplies `out=`, we still overwrite —
+// the API surface accepts it for symmetry with sum.
+//
+// `AT_DISPATCH_FLOATING_TYPES_AND2` (not `_ALL_TYPES_AND2`) — mean returns a
+// floating result; integer dispatch would silently truncate the divide.
+at::Tensor segment_mean_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_mean_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_mean_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` (mirrors the sum
+  // kernel) and force contiguous so we can use flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_mean_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_mean_csr: out.size(dim) must equal indptr.size(-1) - 1");
+    // Mean overwrites; clear the buffer so the sum loop accumulates from 0
+    // and empty rows land at 0 after the divide.
+    out.zero_();
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_csr_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t src_off = slice * E * K;
+
+                // Row length: clamp to 1 for empty rows so the divide is a
+                // no-op (the accumulator is still 0).
+                const int64_t row_len = row_end - row_start;
+                const opmath_t denom =
+                    static_cast<opmath_t>(row_len > 0 ? row_len : 1);
+
+                if (K == 1) {
+                  opmath_t acc = static_cast<opmath_t>(0);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                  }
+                  out_data[n] = static_cast<scalar_t>(acc / denom);
+                } else {
+                  std::vector<opmath_t> acc(K, static_cast<opmath_t>(0));
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                  }
+                  for (int64_t k = 0; k < K; ++k)
+                    out_data[n * K + k] = static_cast<scalar_t>(acc[k] / denom);
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
 // CPU implementation of `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
@@ -263,6 +377,8 @@ at::Tensor gather_csr_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
          TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
+         TORCH_FN(segment_mean_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -1,0 +1,270 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// CPU implementation of `pyg::segment_sum_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1` (upstream
+// `segment_csr_cpu.cpp:24`). Each row `r ∈ [0, indptr.size(dim) - 1)`
+// consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]` and writes
+// the per-row sum to `out[..., r, ...]`. Empty rows leave the corresponding
+// `out` slot at its zero-initialized (or caller-supplied) value.
+//
+// Layout (upstream `segment_csr_cpu.cpp:54-56`): we factor the work into
+//   * N = out.size(dim) * (indptr.numel() / indptr.size(-1))
+//         — total number of "rows" across all leading indptr dims,
+//   * E = src.size(dim) — number of source entries along the reduction axis,
+//   * K = out.numel() / N — product of trailing dims of `src` past
+//         `indptr.dim()`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we **accumulate**
+// into it (no zero-init). Matches upstream and is what makes
+// `GatherCSR::backward` efficient.
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_sum_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` along its leading
+  // dims (upstream `segment_csr_cpu.cpp:19-22`). The last indptr dim
+  // (size = num_rows + 1) is preserved as-is. Then force contiguous so the
+  // kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_sum_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_sum_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Zero-init so empty rows (and the accumulate loop) produce the correct
+    // result without any per-row pre-fill.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const int64_t E = src_c.size(dim);
+  // `N` is the total row count across all leading indptr dims (upstream's
+  // factoring: `out.size(dim) * (indptr.numel() / indptr.size(-1))`).
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cpu", [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` slot (`out_data + n * K`) so no atomics are
+        // needed. The inner accumulate loop is sequential per row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                // `n` indexes into the flattened (leading, rows_per_slice)
+                // space; reconstruct the offsets into indptr and src.
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                // indptr layout: leading slices each of length
+                // `indptr.size(-1)`
+                // (= rows_per_slice + 1). Row `row` consumes
+                // `[indptr[row], indptr[row+1])`.
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                // `src` per-slice stride along `dim` is `E * K`; within a
+                // slice each row position is one `K`-block.
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  // Honor the `out=` accumulate contract: seed from the
+                  // current `out` slot.
+                  opmath_t acc = static_cast<opmath_t>(out_data[n]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    acc += static_cast<opmath_t>(src_data[src_off + e]);
+                  }
+                  out_data[n] = static_cast<scalar_t>(acc);
+                } else {
+                  std::vector<opmath_t> acc(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    acc[k] = static_cast<opmath_t>(out_data[n * K + k]);
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      acc[k] +=
+                          static_cast<opmath_t>(src_data[src_off + e * K + k]);
+                  }
+                  for (int64_t k = 0; k < K; ++k)
+                    out_data[n * K + k] = static_cast<scalar_t>(acc[k]);
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+// CPU implementation of `pyg::gather_csr`.
+//
+// CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
+// the value `src[..., r, ...]` is **broadcast** to every output position
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// Strategy: per-row linear pass (upstream `segment_csr_cpu.cpp:146-158`).
+// This avoids the per-output-position binary search the plan mentions: for
+// each row we read one `src` value (per K) and write it to a contiguous
+// stretch of `out`. Parallelism is over the flat row index `N`.
+//
+// Layout:
+//   * N = src.size(dim) * (indptr.numel() / indptr.size(-1)),
+//   * E = out.size(dim) — number of output positions along the gather axis,
+//   * K = src.numel() / N — product of trailing dims past `indptr.dim()`.
+//
+// `out=` contract: **overwrite** the caller's buffer per element. Positions
+// outside any `[indptr[r], indptr[r+1])` range (i.e. before `indptr[0]` or
+// after `indptr[-1]`) are left untouched.
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr: src.dim() must be >= indptr.dim() (got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0, "gather_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` along leading dims to match `src.shape[:dim]`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr: src.size(dim) must equal indptr.size(-1) - 1");
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < src_c.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "gather_csr: out.size(", i,
+                    ") must match src.size(", i, ")");
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // Output size along `dim` is the trailing entry of `indptr`. We read it
+      // from the flattened-last entry of the broadcast indptr (all leading
+      // slices share the same trailing value since the original indptr only
+      // varied along `dim`).
+      out_sizes[dim] = *indptr_b.flatten()[-1].data_ptr<int64_t>();
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // Layout: N = (rows_per_slice) * (leading slices); per src entry we write
+  // a contiguous stretch in `out` of length (row_end - row_start) * K.
+  const int64_t rows_per_slice = src_c.size(dim);
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = rows_per_slice * leading;
+  const int64_t K = src_c.numel() / N;
+  const int64_t E = out.size(dim);
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cpu", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over flat row index. Each row writes a disjoint
+        // stretch of `out` so no atomics / coordination needed.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t out_off = slice * E * K;
+
+                if (K == 1) {
+                  const scalar_t v = src_data[n];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    out_data[out_off + e] = v;
+                  }
+                } else {
+                  // Cache row value across the inner E loop to avoid repeated
+                  // loads from `src`. Matches upstream `vals[K]` cache pattern.
+                  std::vector<scalar_t> vals(K);
+                  for (int64_t k = 0; k < K; ++k)
+                    vals[k] = src_data[n * K + k];
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k)
+                      out_data[out_off + e * K + k] = vals[k];
+                  }
+                }
+              }
+            });
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CPU, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -253,6 +253,157 @@ at::Tensor segment_mean_csr_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_min_csr`.
+//
+// Same (N, E, K) layout as `segment_sum_csr_kernel` with
+// `dim = indptr.dim() - 1`. Per-row sequential pass: maintain a running
+// minimum value and its first-match argindex per row. Two output tensors:
+//   * `out`: the per-row minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty rows
+//     (no contributing source element) are reset to `0` after the
+//     reduction loop (matched against the sentinel in `arg_out`, mirrors
+//     `segment_min_coo_kernel`).
+//   * `arg_out`: the source position that produced each per-row min, init
+//     to the sentinel `src.size(dim)` (one past the last valid index along
+//     `dim`). Has dtype `int64` (matches `indptr.options()`).
+//
+// **Determinism:** the inner E loop is sequential per row and uses strict
+// `<` on the comparison, so on ties the kernel preserves *first-match*
+// semantics. Parallelism is only over the flat row index `N` where rows
+// write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_min_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` and force contiguous
+  // so the kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_min_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_min_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`) and
+  // starts at the sentinel `src.size(dim)`. The sentinel both encodes "empty
+  // row" for the `masked_fill_` post-step and feeds into the backward's
+  // `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, indptr_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did not
+        // supply `optional_out` (otherwise the caller's state is the running
+        // state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` / `arg_out` slot so no atomics are needed. The
+        // inner reduction loop is sequential to preserve first-match
+        // argindex semantics on tied source values within a row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  auto* out_slot = out_data + n;
+                  auto* arg_slot = arg_out_data + n;
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    const scalar_t v = src_data[src_off + e];
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      *arg_slot = e;
+                    }
+                  }
+                } else {
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + n * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[n * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty rows retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the former,
+  // upstream resets the value to `0`; for the latter we leave the caller's
+  // value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
@@ -379,6 +530,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -1,0 +1,450 @@
+#include "../segment_csr.h"
+
+#include <ATen/ATen.h>
+#include <ATen/OpMathType.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+
+namespace pyg {
+namespace ops {
+
+namespace {
+
+// Convention 12: dynamic block sizing — replicates the inline `threads()` /
+// `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
+// Each `.cu` file in `pyg_lib/csrc/ops/cuda/` carries its own copy until a
+// shared helper lands.
+int threads() {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  return std::min(props->maxThreadsPerBlock, 1024);
+}
+
+int blocks(int numel) {
+  const auto props = at::cuda::getCurrentDeviceProperties();
+  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
+  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  const auto max_threads = threads();
+  return std::max(
+      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+}
+
+// Strided-offset helper specialised for `indptr` row pointers.
+//
+// `at::cuda::detail::IndexToOffset` walks all dims of a `TensorInfo` and is
+// suitable for COO `index` (where the last dim's size matches the number of
+// reduced rows). For CSR `indptr` we need the **same arithmetic with the last
+// dim's effective size reduced by 1** — `indptr` has `rows + 1` entries per
+// batch (one trailing sentinel), but we only index `[0, rows)` from the
+// kernel. Port of upstream `pytorch_scatter/csrc/cuda/index_info.cuh:7-19`.
+struct IndexPtrToOffset {
+  static __host__ __device__ __forceinline__ int get(
+      int idx,
+      const at::cuda::detail::TensorInfo<int64_t, int>& info) {
+    int offset = idx % (info.sizes[info.dims - 1] - 1);
+    offset *= info.strides[info.dims - 1];
+    idx /= info.sizes[info.dims - 1] - 1;
+    for (int i = info.dims - 2; i >= 0; --i) {
+      offset += (idx % info.sizes[i]) * info.strides[i];
+      idx /= info.sizes[i];
+    }
+    return offset;
+  }
+};
+
+// ============================================================================
+// `segment_sum_csr` — Commit 10.
+//
+// Two CUDA kernel variants:
+//
+//   1. `segment_sum_csr_cuda_kernel` (K==1, no trailing feature dims). One
+//      thread per row; sequential inner loop summing
+//      `src[indptr[r] : indptr[r+1]]` into `out[r]`. Port of upstream
+//      `pytorch_scatter/csrc/cuda/segment_csr_cuda.cu:15-60` with `TB == 1`
+//      — TB==1 means single thread per row, so the warp-tree shuffle path is
+//      dead code and is omitted entirely. The `SHFL_DOWN_SYNC` reduction only
+//      fires for the min/max ops (commits 12/13) where TB > 1.
+//
+//   2. `segment_sum_csr_broadcast_cuda_kernel` (K>1, trailing feature dims).
+//      One thread per `(row, col)` pair; each thread sequentially walks the
+//      row's source range. Port of upstream `segment_csr_cuda.cu:62-95`.
+//      Per the upstream comment at line 70, shared-memory reuse was tried
+//      and discarded — the syncthreads overhead exceeded the benefit, so we
+//      keep the same "no shared memory" design here.
+//
+// Accumulation is in `at::opmath_type<scalar_t>` registers; the final cast
+// back to `scalar_t` matches upstream behaviour for `Half`/`BFloat16`.
+//
+// `out=` contract: when the caller supplies `optional_out`, we
+// **accumulate** into it (no zero-init). Matches the upstream `segment_csr`
+// contract and is what makes `GatherCSR::backward` efficient (`at::zeros` +
+// `segment_sum_csr(out=grad_in)` deposits the gradient in-place).
+
+// K==1 kernel — one thread per row.
+template <typename scalar_t>
+__global__ void segment_sum_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Compute the strided indptr offset for this row.
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Upstream
+  // computes this via
+  //   `(row_idx / (indptr.size(-1) - 1)) * E`
+  // where `E = src.size(dim)`. Mirrors `segment_csr_cuda.cu:38-43`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(src_data[batch_offset + src_idx]);
+  }
+
+  // Accumulate into `out`. The dispatcher zero-inits a freshly allocated
+  // `out`; when the caller supplies `out=`, we **add** to it (accumulate
+  // contract used by `GatherCSR::backward`). For empty rows
+  // (`row_end == row_start`), `val == 0` so the existing value is preserved.
+  out_data[row_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[row_idx]) + val);
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair.
+template <typename scalar_t>
+__global__ void segment_sum_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  using opmath_t = at::opmath_type<scalar_t>;
+
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + offset);
+  int64_t row_end = __ldg(indptr_info.data + offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` includes the trailing `K` extent.
+  // Mirrors `segment_csr_cuda.cu:85`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+
+  opmath_t val = static_cast<opmath_t>(0);
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    val += static_cast<opmath_t>(
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx]);
+  }
+
+  // Accumulate-into contract (see K==1 kernel above).
+  out_data[thread_idx] =
+      static_cast<scalar_t>(static_cast<opmath_t>(out_data[thread_idx]) + val);
+}
+
+at::Tensor segment_sum_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_sum_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_sum_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_sum_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_sum_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // CSR convention: `indptr` is `expand`-broadcast up to
+  // `src.shape[:indptr.dim()-1]` so the leading batch dims match. The last
+  // dim of `indptr` is the row pointer itself and stays at its native size.
+  // Mirrors `segment_csr_cuda.cu:108-112`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  // CSR ops fix the reduction axis at the last `indptr` dim.
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Accumulate-into contract: caller owns the buffer, no zero-init.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_sum_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_sum_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Zero-init so the in-kernel `+=` accumulation produces the correct
+    // result for a freshly allocated buffer.
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  // `N` is the total number of rows across all leading batch dims (upstream
+  // `segment_csr_cuda.cu:144`). `K` is the product of trailing feature dims
+  // past the reduction axis (upstream line 145). `E` is `src.size(dim)`.
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_sum_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row, sequential inner sum. No SHFL — TB == 1
+          // means there's only one lane per row.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          segment_sum_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col). Sequential row scan in inner loop.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_sum_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+// ============================================================================
+// `gather_csr` — Commit 10.
+//
+// Symmetric inverse of `segment_sum_csr`: for each row `r`, broadcast
+// `src[r]` to every output position `[indptr[r], indptr[r+1])` along the
+// reduction axis. Two kernel variants:
+//
+//   * K==1: one thread per row writes the row value to all `[row_start,
+//     row_end)` output positions. Port of upstream `segment_csr_cuda.cu:
+//     171-192` with `TB == 1`. (Upstream uses TB=4 to get more parallelism
+//     for long rows; we mirror that ladder via the dynamic block-size
+//     dispatch — see comment below.)
+//   * K>1: one thread per `(row, col)` pair, same write pattern with the
+//     trailing `K` extent. Port of upstream `segment_csr_cuda.cu:194-217`.
+//
+// `out=` contract: **overwrite** (not accumulate) — every output element is
+// written exactly once. Matches upstream `gather_csr`. The output sizing
+// rule allocates the same shape as `src` with the reduction axis replaced
+// by `indptr[..., -1]` (upstream lines 245-253).
+
+template <typename scalar_t>
+__global__ void gather_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t E) {
+  int row_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = __ldg(src_data + row_idx);
+
+  // Per-batch slice offset into `out` along the reduction axis. Mirrors
+  // upstream `segment_csr_cuda.cu:187`.
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + out_idx] = val;
+  }
+}
+
+template <typename scalar_t>
+__global__ void gather_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int row_idx = thread_idx / static_cast<int>(K);
+  int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int row_start = static_cast<int>(__ldg(indptr_info.data + offset));
+  int row_end = static_cast<int>(__ldg(
+      indptr_info.data + offset + indptr_info.strides[indptr_info.dims - 1]));
+  scalar_t val = src_data[thread_idx];
+
+  int batch_offset = (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+                     static_cast<int>(E) * static_cast<int>(K);
+  for (int out_idx = row_start; out_idx < row_end; ++out_idx) {
+    out_data[batch_offset + static_cast<int>(K) * out_idx + col_idx] = val;
+  }
+}
+
+at::Tensor gather_csr_kernel(const at::Tensor& src,
+                             const at::Tensor& indptr,
+                             const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(), "gather_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "gather_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr (CUDA): src and indptr must be on the same device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "gather_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "gather_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Broadcast `indptr` leading dims up to `src.shape[:indptr.dim()-1]`.
+  // Mirrors upstream `segment_csr_cuda.cu:229-232`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+  TORCH_CHECK(src.size(dim) == 0 || src.size(dim) == indptr_b.size(dim) - 1,
+              "gather_csr (CUDA): src.size(", dim,
+              ") must be 0 or equal to indptr.size(-1) - 1 (got ",
+              src.size(dim), " vs ", indptr_b.size(dim) - 1, ")");
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    // Overwrite contract: every output element is written exactly once.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "gather_csr (CUDA): out.size(", i, ") must match src.size(",
+                    i, ")");
+      }
+    }
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    if (src_c.numel() > 0) {
+      // `out.size(dim) = indptr[..., -1]` — the total number of "gathered"
+      // entries. Mirrors upstream `segment_csr_cuda.cu:247-252`. Reading
+      // the last entry of a contiguous flat `indptr` costs one D->H sync
+      // but is one-off (host-side allocation path).
+      out_sizes[dim] = indptr_c.flatten()[-1].cpu().data_ptr<int64_t>()[0];
+    } else {
+      out_sizes[dim] = 0;
+    }
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return out;
+  }
+
+  // `N` = total number of input rows across all batch dims (upstream
+  // `segment_csr_cuda.cu:261`). `K` = trailing feature-dim extent. `E` =
+  // `out.size(dim)` — the per-batch output length.
+  const auto N = src_c.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = src_c.numel() / N;
+  const auto E = out.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "gather_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          // One thread per row writes the row value to all output positions
+          // in `[row_start, row_end)`.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          gather_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col); same write pattern with the trailing
+          // `K` extent.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          gather_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  return out;
+}
+
+}  // namespace
+
+TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
+         TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -262,6 +262,147 @@ at::Tensor segment_sum_csr_kernel(
 }
 
 // ============================================================================
+// `segment_mean_csr` — Commit 11.
+//
+// Strategy: reuse the two `segment_sum_csr_*` kernels above for the per-row
+// sum pass, then divide by per-row lengths.
+//
+// Row-length computation — `indptr.diff()` along the last `indptr` dim. This
+// is the same data the kernels already load (`row_end - row_start`), but doing
+// it as a single tensor op on the host keeps the K==1 / K>1 kernels identical
+// to the sum case (no need to thread a `count_data` pointer through). Empty
+// rows have `diff == 0`; we `masked_fill_(diff == 0, 1)` so the subsequent
+// division leaves the zero-init `out[r]` at `0` — matches the upstream
+// reducer's "empty row -> 0" semantic at `segment_csr_cuda.cu:38-43` via
+// `Reducer::initial_value()` for MEAN.
+//
+// Compared to `segment_mean_coo` (which needs an atomic counting kernel
+// because COO `index` can repeat arbitrarily), CSR row lengths are trivially
+// available from `indptr` — no extra kernel launch.
+//
+// `out=` contract: matches upstream — divides into a fresh `at::zeros` buffer,
+// or into the caller-supplied buffer (where the sum kernel's `+=` accumulates
+// before the divide, then we divide the **combined** value by the row length).
+// This is the same combined semantic as `segment_mean_coo`.
+//
+// Dispatch: `AT_DISPATCH_FLOATING_TYPES_AND2` for the floating mean path
+// (true division); integer types take the `floor` path. Same convention as
+// `segment_mean_coo`.
+
+at::Tensor segment_mean_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_mean_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_mean_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_mean_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_mean_csr (CUDA): src.dim() must be >= indptr.dim() "
+              "(got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_mean_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Same broadcast rule as `segment_sum_csr` — `indptr` leading dims expand
+  // up to `src.shape[:indptr.dim()-1]`, last dim of `indptr` stays as-is.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; we accumulate into it during the sum pass and
+    // then divide the combined value (mirrors `segment_mean_coo` semantics).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_mean_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_mean_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Zero-init so the in-kernel `+=` sum accumulation starts from 0, and
+    // empty rows stay at 0 (no division occurs in the kernel; the
+    // post-pass divide reads `0 / 1 == 0`).
+    out = at::zeros(out_sizes, src_c.options());
+  }
+
+  if (src_c.numel() == 0) {
+    return out;
+  }
+
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  // -------- Pass 1: sum into `out`. Reuses the `segment_sum_csr_*` kernels.
+  // Mean uses floating-point div, so dispatch on floating types (+ Half /
+  // BFloat16). Mirrors the `segment_mean_coo` dispatch.
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_mean_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+
+        if (K == 1) {
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N));
+          segment_sum_csr_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_sum_csr_broadcast_cuda_kernel<scalar_t>
+              <<<B, T, 0, stream>>>(src_data, indptr_info, out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // -------- Pass 2: divide by row lengths.
+  //
+  // `indptr.diff()` along the last dim gives the per-row source-element
+  // count, shape `[..., rows]` (matches `out` along dims `[0, dim]`). Empty
+  // rows have count 0; mask them up to 1 so the broadcast divide preserves
+  // the zero-init in those slots. Cast to `out.dtype()` so the broadcast
+  // matches the output's scalar type. Then unsqueeze trailing K dims to
+  // broadcast along the feature axis. Same divide pattern as
+  // `segment_mean_coo`.
+  auto count = indptr_c.diff(/*n=*/1, /*dim=*/-1).to(out.options());
+  count.masked_fill_(count == 0, 1);
+  for (int64_t i = dim + 1; i < out.dim(); ++i) {
+    count = count.unsqueeze(-1);
+  }
+  out.true_divide_(count);
+
+  return out;
+}
+
+// ============================================================================
 // `gather_csr` — Commit 10.
 //
 // Symmetric inverse of `segment_sum_csr`: for each row `r`, broadcast
@@ -443,6 +584,8 @@ at::Tensor gather_csr_kernel(const at::Tensor& src,
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_sum_csr"),
          TORCH_FN(segment_sum_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
+         TORCH_FN(segment_mean_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -8,10 +8,40 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 
+#include "shuffle.cuh"
+
 namespace pyg {
 namespace ops {
 
 namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). Already defined in `segment_coo_kernel.cu` /
+// `scatter_kernel.cu` in their own TUs; we redefine guarded here so the TUs
+// stay independent.
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+// Full-warp mask for `__shfl_*_sync` — every lane participates.
+#ifndef FULL_MASK
+#define FULL_MASK 0xffffffff
+#endif
+
+// Strict less-than predicate used by the min reductions below. Half-precision
+// routes through `float` to avoid an ambiguous overload between
+// `c10::Half::operator<` and the built-in `arithmetic <` (nvcc rejects the
+// direct comparison; same reason `device_min` in `segment_coo_kernel.cu`
+// uses a `static_cast<float>` route).
+template <typename scalar_t>
+static inline __device__ bool device_lt(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) < static_cast<float>(b);
+  } else {
+    return a < b;
+  }
+}
 
 // Convention 12: dynamic block sizing — replicates the inline `threads()` /
 // `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
@@ -579,6 +609,329 @@ at::Tensor gather_csr_kernel(const at::Tensor& src,
   return out;
 }
 
+// ============================================================================
+// `segment_min_csr` — Commit 12.
+//
+// First CSR op to use `TB > 1`: each warp lane (one of 32) collaborates on a
+// single row, then a warp-tree `SHFL_DOWN_SYNC` reduction halves the active
+// lane count five times to land the row's `(min_value, argindex)` in lane 0.
+//
+// Why `TB == 1` is wrong for min/max (and was fine for sum/mean):
+// sum/mean's inner loop is `+=` and a single thread per row was already fast
+// enough — adding TB warp lanes would just waste them on the tail of short
+// rows. Min/max, however, has no early-exit and benefits more from
+// parallelism over long rows. Upstream `segment_csr_cuda.cu:157` launches
+// `<<<BLOCKS(32, N), THREADS>>>` for min/max (32 lanes per row), versus
+// `<<<BLOCKS(1, N), THREADS>>>` (TB == 1) for sum.
+//
+// TB choice: we mirror upstream and fix `TB == 32` (one warp per row). Long
+// rows benefit from the parallelism; short rows just leave the trailing
+// lanes holding `(numeric_limits::max(), E_dim)` which contributes nothing.
+// Picking TB == warp size also lets us drive the reduction with the existing
+// `SHFL_DOWN_SYNC` macro without involving shared memory.
+//
+// Pair propagation through `SHFL_DOWN_SYNC`:
+//
+//   Each lane holds a local `(val, arg)`. At reduction step `i` (i = 16, 8,
+//   4, 2, 1):
+//
+//     tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+//     tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+//     if (device_lt(tmp_val, val)) { val = tmp_val; arg = tmp_arg; }
+//
+//   We perform two independent shuffles — one carrying `val`, one carrying
+//   `arg` — and then choose between the **pair members together**, so the
+//   surviving `arg` always matches the surviving `val`. After 5 steps (32
+//   -> 16 -> 8 -> 4 -> 2 -> 1) lane 0 holds the row's min and corresponding
+//   argindex. Mirrors upstream `segment_csr_cuda.cu:46-52`. The comparison
+//   is strict `<` (via `device_lt`): on ties, the **lower-lane** value wins,
+//   which matches the upstream first-match convention for the argindex.
+//
+// No shared memory: upstream comment at `segment_csr_cuda.cu:68-70`
+// explicitly notes that shared memory was tried and rejected — the
+// `__syncthreads` overhead exceeded the benefit. We mirror that decision;
+// the warp shuffle is sufficient because TB == warp size.
+//
+// Argindex semantics: stored as `int64_t` (matches `arg_out` dtype), tracks
+// the absolute `src_idx` along the reduction axis (NOT relative to the
+// row), which makes it directly indexable into the per-batch slice of `src`
+// along `dim`. Upstream stores the same absolute index.
+//
+// Empty-row post-pass: `out.masked_fill_(arg_out == src.size(dim), 0)`.
+// Initial `arg_out` is filled with the sentinel `E_dim = src.size(dim)`;
+// any row that ran zero iterations keeps that sentinel, and we reset the
+// corresponding `out` slot (still at `numeric_limits::max()`) to 0. Matches
+// `segment_min_coo`'s empty-bucket policy and the CPU min kernel contract.
+
+// K==1 kernel — one warp per row, lanes stride through the row by `TB == 32`.
+template <typename scalar_t>
+__global__ void segment_min_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t E) {
+  // `TB == WARP_SIZE` (32): one warp processes one row. `lane_idx` selects
+  // the slot within the row.
+  constexpr int TB = WARP_SIZE;
+
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / TB;
+  const int lane_idx = thread_idx & (TB - 1);
+
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Strided indptr offset for this row.
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Same as the
+  // sum kernel above.
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E);
+
+  // Per-lane sentinel pair. The sentinel argindex `E` (== `src.size(dim)`)
+  // matches the host-side `at::full` init of `arg_out`; the host post-pass
+  // checks `arg_out == E` to identify empty rows. The sentinel value
+  // `numeric_limits<scalar_t>::max()` matches the host-side `out.fill_`.
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  // Lane-strided scan: each lane handles `ceil(row_len / TB)` elements at
+  // stride `TB`. Mirrors upstream `segment_csr_cuda.cu:39-43`.
+  //
+  // On ties (`cand == val`), we keep the **earlier** (lower `src_idx`)
+  // winner via strict `<` — matches the CPU kernel's first-match argindex
+  // convention. Pathological case: if every element in a row equals
+  // `numeric_limits::max()`, `arg` stays at sentinel `E`, and the host
+  // post-pass will `masked_fill_` `out` to 0 (matches upstream's behaviour
+  // for the same edge case).
+  for (int64_t src_idx = row_start + lane_idx; src_idx < row_end;
+       src_idx += TB) {
+    scalar_t cand = src_data[batch_offset + src_idx];
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  // Warp-tree min reduction over `(val, arg)` pairs. Two independent
+  // shuffles transport the pair members across lanes; we then choose
+  // between them as a unit so the surviving `arg` always matches the
+  // surviving `val`. Mirrors upstream `segment_csr_cuda.cu:45-52`.
+#pragma unroll
+  for (int i = TB / 2; i > 0; i /= 2) {
+    scalar_t tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+    int64_t tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+    // Strict `<`: on ties, keep the existing (lower-lane) value/arg, which
+    // matches the first-match convention for the argindex.
+    if (device_lt(tmp_val, val)) {
+      val = tmp_val;
+      arg = tmp_arg;
+    }
+  }
+
+  // Lane 0 writes the row's `(min, argmin)` pair. Other lanes contribute
+  // nothing past this point. No `atomicMin` needed — the warp-tree
+  // reduction has already aggregated all of row `r`'s contributions, and
+  // each warp owns exactly one row.
+  //
+  // For empty rows (`row_start == row_end`), the inner loop ran zero
+  // iterations, `val` is still `numeric_limits::max()`, and `arg` is still
+  // the sentinel `E`. The host post-pass resets such slots to 0.
+  if (lane_idx == 0) {
+    out_data[row_idx] = val;
+    arg_out_data[row_idx] = arg;
+  }
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair. Sequential row scan
+// with running `(val, arg)`; no shuffle (each thread already owns its full
+// reduction). Mirrors upstream `segment_csr_cuda.cu:62-95`.
+template <typename scalar_t>
+__global__ void segment_min_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / static_cast<int>(K);
+  const int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E) * static_cast<int>(K);
+
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    scalar_t cand =
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx];
+    // Same strict-`<` first-match logic as the K==1 kernel above.
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  out_data[thread_idx] = val;
+  arg_out_data[thread_idx] = arg;
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_min_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_min_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_min_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Same broadcast rule as `segment_sum_csr`: leading dims of `indptr`
+  // expand to `src.shape[:indptr.dim()-1]`; last `indptr` dim is the row
+  // pointer itself (kept native).
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  // `E_dim = src.size(dim)` is the sentinel argindex value for `arg_out`
+  // (matches `segment_min_coo` and `scatter_min`).
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no max-init. With `out=` supplied, the kernel
+    // **overwrites** the per-row slot with the computed row min — there is
+    // no atomicMin path here (the warp-tree fully reduces the row before
+    // the single write), so any prior value in `out` is discarded for
+    // non-empty rows. This matches upstream's "out= as scratch buffer"
+    // contract: the caller is expected to pre-initialize if they want a
+    // running min across calls.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_min_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_min_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Allocate uninit then fill with per-dtype `max()`. Same rationale as
+    // `segment_min_coo`: `at::full` with a single host `Scalar` cannot
+    // represent each dtype's max correctly, so we route through
+    // `AT_DISPATCH_*` + `numeric_limits<scalar_t>::max()`.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_min_csr_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always freshly allocated and filled with the sentinel
+  // `E_dim`. The kernel either overwrites it with a real argindex (non-empty
+  // row) or leaves it at the sentinel (empty row); the host post-pass below
+  // uses `arg_out == E_dim` to identify empty rows.
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          indptr_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    // No contributors at all; every row is empty. Reset to 0 (matching the
+    // CPU kernel) when we own `out`. With `out=` supplied, the caller's
+    // values are preserved.
+    if (!out_was_provided) {
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        if (K == 1) {
+          // 32 lanes per row (TB == warp size). Total threads = `32 * N`;
+          // block size from the dynamic `threads()` helper (always a
+          // multiple of 32 for sm_60+).
+          constexpr int TB = WARP_SIZE;
+          const int T = threads();
+          const int B =
+              std::max<int>(1, static_cast<int>((TB * N + T - 1) / T));
+          segment_min_csr_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col) pair; sequential row scan inside the
+          // thread, no shuffle.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_min_csr_broadcast_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-row cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that row, so `out` still holds `numeric_limits::max()`. Reset to `0` to
+  // match the CPU kernel's contract. Skipped when `out=` is supplied — the
+  // caller's pre-existing values in empty rows must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -586,6 +939,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -1,0 +1,73 @@
+#include "segment_csr.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+
+namespace pyg {
+namespace ops {
+
+PYG_API at::Tensor segment_sum_csr(const at::Tensor& src,
+                                   const at::Tensor& indptr,
+                                   const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_sum_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_sum_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_sum_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_sum_csr", "")
+                       .typed<decltype(segment_sum_csr)>();
+  return op.call(src, indptr, out);
+}
+
+PYG_API at::Tensor gather_csr(const at::Tensor& src,
+                              const at::Tensor& indptr,
+                              const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"gather_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "gather_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "gather_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::gather_csr", "")
+                       .typed<decltype(gather_csr)>();
+  return op.call(src, indptr, out);
+}
+
+TORCH_LIBRARY_FRAGMENT(pyg, m) {
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_sum_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+}
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -33,6 +33,33 @@ PYG_API at::Tensor segment_sum_csr(const at::Tensor& src,
   return op.call(src, indptr, out);
 }
 
+PYG_API at::Tensor segment_mean_csr(const at::Tensor& src,
+                                    const at::Tensor& indptr,
+                                    const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_mean_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_mean_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_mean_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_mean_csr", "")
+                       .typed<decltype(segment_mean_csr)>();
+  return op.call(src, indptr, out);
+}
+
 PYG_API at::Tensor gather_csr(const at::Tensor& src,
                               const at::Tensor& indptr,
                               const std::optional<at::Tensor>& out) {
@@ -63,6 +90,9 @@ PYG_API at::Tensor gather_csr(const at::Tensor& src,
 TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::segment_sum_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_mean_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -60,6 +60,34 @@ PYG_API at::Tensor segment_mean_csr(const at::Tensor& src,
   return op.call(src, indptr, out);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_min_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_min_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_min_csr", "")
+                       .typed<decltype(segment_min_csr)>();
+  return op.call(src, indptr, out);
+}
+
 PYG_API at::Tensor gather_csr(const at::Tensor& src,
                               const at::Tensor& indptr,
                               const std::optional<at::Tensor>& out) {
@@ -94,6 +122,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::segment_mean_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_min_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> (Tensor, Tensor)"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <optional>
+#include "pyg_lib/csrc/macros.h"
+
+namespace pyg {
+namespace ops {
+
+// Sums all values from `src` into `out` at the segments specified by the
+// compressed row pointer `indptr` along the implicit axis
+// `dim = indptr.dim() - 1`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row sum into `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) leave the corresponding `out` slot at its
+// zero-initialized value (or unchanged if a caller-supplied `out=` is given).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh zero-initialized buffer is allocated.
+// When `out` *is* provided, the operation **accumulates** into the caller's
+// buffer (no zero-init); this matches the upstream contract and is what makes
+// `GatherCSR::backward` efficient (the backward allocates
+// `at::zeros(src_shape)` and calls `segment_sum_csr` with it as `out=` to
+// deposit the gradient in-place).
+PYG_API at::Tensor segment_sum_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Gathers values from `src` at the row positions encoded in `indptr`, along
+// the implicit axis `dim = indptr.dim() - 1`. Concretely, for each row `r`,
+// the value `src[..., r, ...]` is broadcast to all output positions
+// `out[..., i, ...]` for `i ∈ [indptr[r], indptr[r+1])`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the gather axis at `indptr.dim() - 1`. The output size along `dim` is
+// determined by the last entry of `indptr` (i.e. `indptr[..., -1]`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated. When `out` *is*
+// provided, the operation **overwrites** the caller's buffer per element
+// (matches upstream `pytorch_scatter`).
+PYG_API at::Tensor gather_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+}  // namespace ops
+}  // namespace pyg

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -56,6 +57,41 @@ PYG_API at::Tensor segment_sum_csr(
 // caller-supplied buffer — it overwrites the per-row slots. We allocate the
 // `out` buffer zero-initialized so that empty-row slots stay at 0.
 PYG_API at::Tensor segment_mean_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Computes the per-row minimum of `src` along the implicit axis
+// `dim = indptr.dim() - 1`, using the compressed row pointer `indptr`. Returns
+// `(out, arg_out)` where `arg_out[r]` is the source position that produced the
+// minimum value at row `r`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row min to `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) are reset to `0` after the reduction loop; the
+// matching slot in `arg_out` keeps the sentinel value `src.size(dim)` (one
+// past the last valid index along `dim`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized to
+// `numeric_limits<scalar_t>::max()` so that the first contributing element
+// always wins. When `out` *is* provided, the caller's buffer is used as the
+// running state (no max-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `<` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
     const at::Tensor& src,
     const at::Tensor& indptr,
     const std::optional<at::Tensor>& out = std::nullopt);

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -35,6 +35,31 @@ PYG_API at::Tensor segment_sum_csr(
     const at::Tensor& indptr,
     const std::optional<at::Tensor>& out = std::nullopt);
 
+// Computes the per-row mean of `src` along the implicit axis
+// `dim = indptr.dim() - 1`, using the compressed row pointer `indptr`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row mean (sum / row-length) into `out[..., r, ...]`.
+// Empty rows (`indptr[r+1] == indptr[r]`) are handled by clamping their
+// row-length to 1 before division; the corresponding `out` slot is left at
+// its zero value (since the sum loop contributes nothing).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// `out=` contract (matches upstream): mean does **not** accumulate into a
+// caller-supplied buffer — it overwrites the per-row slots. We allocate the
+// `out` buffer zero-initialized so that empty-row slots stay at 0.
+PYG_API at::Tensor segment_mean_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
 // Gathers values from `src` at the row positions encoded in `indptr`, along
 // the implicit axis `dim = indptr.dim() - 1`. Concretely, for each row `r`,
 // the value `src[..., r, ...]` is broadcast to all output positions

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -679,6 +679,28 @@ def segment_mean_csr(
     return torch.ops.pyg.segment_mean_csr(src, indptr, out)
 
 
+def segment_min_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. Empty rows yield value ``0`` and
+    argindex ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor for the values.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_min_csr(src, indptr, out)
+
+
 def gather_csr(
     src: Tensor,
     indptr: Tensor,
@@ -954,6 +976,7 @@ __all__ = [
     'segment_sum_csr',
     'segment_add_csr',
     'segment_mean_csr',
+    'segment_min_csr',
     'gather_csr',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -631,6 +631,56 @@ def gather_coo(
     return torch.ops.pyg.gather_coo(src, index, out)
 
 
+def segment_sum_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``sum`` as the reduction.
+
+    The reduction axis is ``indptr.dim() - 1`` and the output size along that
+    axis is ``indptr.size(-1) - 1`` (no explicit ``dim_size`` arg).
+
+    If :obj:`out` is not given, a new zero-initialized tensor is allocated.
+    If :obj:`out` is given, values are **accumulated** into it.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_sum_csr(src, indptr, out)
+
+
+segment_add_csr = segment_sum_csr
+
+
+def gather_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Gathers values from :obj:`src` to all positions encoded by the CSR
+    :obj:`indptr`: for each row ``r``, broadcasts ``src[r]`` to all output
+    positions in ``[indptr[r], indptr[r+1])``. Symmetric inverse of
+    :func:`segment_sum_csr`.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor (overwritten if given).
+
+    Returns:
+        Broadcast tensor of shape ``src.shape`` with ``indptr.dim()-1`` axis
+        replaced by ``indptr[-1]``.
+    """
+    return torch.ops.pyg.gather_csr(src, indptr, out)
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -881,6 +931,9 @@ __all__ = [
     'segment_min_coo',
     'segment_max_coo',
     'gather_coo',
+    'segment_sum_csr',
+    'segment_add_csr',
+    'gather_csr',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -659,6 +659,26 @@ def segment_sum_csr(
 segment_add_csr = segment_sum_csr
 
 
+def segment_mean_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``mean`` as the reduction. Empty rows yield
+    zero.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor.
+
+    Returns:
+        The reduced tensor.
+    """
+    return torch.ops.pyg.segment_mean_csr(src, indptr, out)
+
+
 def gather_csr(
     src: Tensor,
     indptr: Tensor,
@@ -933,6 +953,7 @@ __all__ = [
     'gather_coo',
     'segment_sum_csr',
     'segment_add_csr',
+    'segment_mean_csr',
     'gather_csr',
     'spline_basis',
     'spline_weighting',

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 # ---------------------------------------------------------------------------
 # Reference implementations
@@ -745,3 +745,280 @@ def test_segment_mean_csr_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_min_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+):
+    """Pure-PyTorch reference for :func:`segment_min_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. Returns ``(value, argindex)``:
+      * ``value[..., r, ...]`` is the minimum of ``src`` entries whose
+        position along ``dim`` lies in ``[indptr[r], indptr[r+1])``.
+      * ``argindex[..., r, ...]`` is the position along ``dim`` of the
+        first-match min entry (CPU upstream contract).
+      * Empty rows (``indptr[r+1] == indptr[r]``) get ``value == 0`` and
+        ``argindex == src.size(dim)`` (upstream sentinel).
+
+    This reference handles the 1-D ``indptr`` case (the variant tested
+    below — matching the plan's spec for commit 12).
+    """
+    assert indptr.dim() == 1, '1-D indptr reference only'
+    dim = indptr.dim() - 1  # == 0
+    num_rows = indptr.size(-1) - 1
+    sentinel = src.size(dim)
+
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    indptr_cpu = indptr.detach().cpu().tolist()
+    for r in range(num_rows):
+        lo, hi = indptr_cpu[r], indptr_cpu[r + 1]
+        if lo == hi:
+            # Empty row -> leave zero value + sentinel arg.
+            continue
+        seg = src.narrow(dim, lo, hi - lo)
+        # min along the reduction dim; ``torch.min`` returns (values, indices)
+        # where indices index *into the narrowed segment*, so offset by ``lo``.
+        seg_val, seg_arg = seg.min(dim=dim)
+        # Assign into the r-th slice of value/argindex along ``dim``.
+        value.select(dim, r).copy_(seg_val)
+        argindex.select(dim, r).copy_(seg_arg + lo)
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_min_csr_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_matches_segment_min_coo(device):
+    """Primary parity test: ``segment_min_csr`` must agree with
+    ``segment_min_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+
+    Uses a unique-value source so argindex tie-breaks are deterministic on
+    both CPU and CUDA.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    val_csr, arg_csr = pyg_lib.ops.segment_min_csr(src, indptr)
+    val_coo, arg_coo = pyg_lib.ops.segment_min_coo(src, coo_index)
+    torch.testing.assert_close(val_csr, val_coo)
+    torch.testing.assert_close(arg_csr, arg_coo)
+
+
+@withCUDA
+def test_segment_min_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty; its output value row is zero and arg row is sentinel.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 is empty -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_min_csr_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Row 0: positions 0, 1, 2 all with value 1.0 (tied min).
+    # Row 1: positions 3, 4 with value 2.0 (tied min).
+    # Row 2: empty.
+    # Row 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    indptr = torch.tensor([0, 3, 5, 5, 6], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    # Value must equal the true per-row min regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Row 0 arg must be in {0, 1, 2}; row 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Row 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Row 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must attain the row's min value.
+    for r in range(value.size(0)):
+        a = int(arg[r].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[r].item(), (
+            f'arg[{r}]={a} points to src value {src[a].item()} but row '
+            f'min is {value[r].item()}'
+        )
+
+
+@withCUDA
+def test_segment_min_csr_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(8, dtype=torch.double, device=device, requires_grad=True)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses a unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(8 * 3, device=device).to(torch.double) - 12)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries; its
+    argindex points at the sentinel and the ``+1``/``narrow`` backward
+    pattern drops that slot.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -534,3 +534,214 @@ def test_segment_sum_csr_gradgradcheck_empty_rows(device):
         return pyg_lib.ops.segment_sum_csr(s, indptr)
 
     assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_csr — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_mean_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_mean_csr`.
+
+    Computes the per-row sum via :func:`_segment_sum_csr_ref` and divides by
+    per-row counts (``indptr.diff()``). Counts for empty rows are masked to
+    ``1`` so empty rows yield exactly ``0`` (matching upstream semantics).
+    """
+    dim = indptr.dim() - 1
+    summed = _segment_sum_csr_ref(src, indptr)
+    # Per-row counts: same leading dims as indptr, trailing length R.
+    counts = indptr.diff().to(src.dtype)
+    # Broadcast counts along the reduction dim of ``summed``.
+    shape = [1] * summed.dim()
+    shape[dim] = counts.size(-1)
+    # If indptr has leading dims, expand counts to match.
+    if counts.dim() > 1:
+        # Shape counts to (..., R, 1, 1, ...) — broadcast across trailing dims.
+        view = list(counts.shape) + [1] * (summed.dim() - counts.dim())
+        counts = counts.view(view)
+    else:
+        counts = counts.view(shape)
+    safe_counts = counts.masked_fill(counts == 0, 1)
+    result = summed / safe_counts
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_mean_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    expected = _segment_mean_csr_ref(src, indptr)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_csr_forward_1d(device):
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    expected = _segment_mean_csr_ref(src, indptr)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_csr_forward_k1_small_trailing(device):
+    """K==1 path: 1-D src, 1-D indptr — exercises the per-row CUDA kernel."""
+    src = torch.randn(10, device=device)
+    indptr = torch.tensor([0, 2, 4, 6, 8, 10], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    expected = _segment_mean_csr_ref(src, indptr)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    expected = _segment_mean_csr_ref(src, indptr)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_mean_csr_forward_matches_segment_mean_coo(device):
+    """Primary parity test: ``segment_mean_csr`` must agree with
+    ``segment_mean_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+    """
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    out_csr = pyg_lib.ops.segment_mean_csr(src, indptr)
+    out_coo = pyg_lib.ops.segment_mean_coo(src, coo_index)
+    torch.testing.assert_close(out_csr, out_coo)
+
+
+@withCUDA
+def test_segment_mean_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty and its output row must be zero.
+    """
+    src = torch.randn(5, 4, device=device)
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    expected = _segment_mean_csr_ref(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros (count = 0 -> 0 / 1).
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_mean_csr_all_rows_empty(device):
+    """All rows empty -> output is all-zero of the expected shape."""
+    src = torch.empty(0, 4, device=device)
+    indptr = torch.tensor([0, 0, 0, 0], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_segment_mean_csr_forward_matches_segment_mean_coo_empty_rows(device):
+    """COO parity on the empty-row fixture."""
+    src = torch.randn(5, 4, device=device)
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    out_csr = pyg_lib.ops.segment_mean_csr(src, indptr)
+    out_coo = pyg_lib.ops.segment_mean_coo(src, coo_index, dim_size=3)
+    torch.testing.assert_close(out_csr, out_coo)
+
+
+# ---------------------------------------------------------------------------
+# segment_mean_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_mean_csr_backward_gradcheck(device):
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_mean_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_mean_csr_backward_empty_input(device):
+    """Empty ``src`` and all-zero ``indptr`` — exercises the
+    ``grad_in.numel() > 0`` guard in backward. Forward yields an all-zero
+    output and backward must not crash on the empty grad, returning a
+    correctly-shaped zero gradient.
+    """
+    src = torch.zeros(
+        0,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 0, 0, 0], device=device)
+
+    out = pyg_lib.ops.segment_mean_csr(src, indptr)
+    assert out.size() == (3, 4)
+    # Sum to a scalar and backprop — exercises backward on an empty grad.
+    out.sum().backward()
+    assert src.grad is not None
+    assert src.grad.size() == src.size()
+    torch.testing.assert_close(src.grad, torch.zeros_like(src))

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1,0 +1,536 @@
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _csr_to_coo(indptr: torch.Tensor) -> torch.Tensor:
+    """Converts a 1-D ``indptr`` to a 1-D COO ``index`` of length
+    ``indptr[-1]`` via ``torch.repeat_interleave``. For example,
+    ``indptr = [0, 2, 2, 5]`` maps to ``[0, 0, 2, 2, 2]``.
+    """
+    num_rows = indptr.numel() - 1
+    arange = torch.arange(num_rows, device=indptr.device)
+    return torch.repeat_interleave(arange, indptr.diff())
+
+
+def _segment_sum_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`segment_sum_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. The reference converts ``indptr`` (any
+    leading-dim broadcast handled by simply taking the last row of strides:
+    indptr is required to be either truly 1-D w.r.t. its trailing rows, or
+    consistent across leading dims) to a COO index and falls back to
+    ``torch.zeros + scatter_add_``.
+    """
+    # CSR reduces along the trailing dim of ``indptr``.
+    dim = indptr.dim() - 1
+    num_rows = indptr.size(-1) - 1
+
+    # Compute the output shape: src shape with src.size(dim) -> num_rows.
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+
+    if out is None:
+        out = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+
+    if indptr.dim() == 1:
+        # 1-D indptr path: convert to a 1-D COO index and scatter_add along
+        # the reduction dim.
+        coo_index = _csr_to_coo(indptr)
+        # Broadcast coo_index to src's shape if needed.
+        if coo_index.dim() < src.dim():
+            view = [1] * src.dim()
+            view[dim] = -1
+            bcast = coo_index.view(view).expand_as(src)
+        else:
+            bcast = coo_index
+        out.scatter_add_(dim, bcast, src)
+    else:
+        # Multi-dim indptr: iterate the leading dims explicitly.
+        # ``indptr`` shares all leading dims with ``src``; the trailing dim
+        # describes per-leading-coord row boundaries.
+        leading_shape = indptr.shape[:-1]
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            out_slice = out[tuple(leading_idx)]
+            coo_index = _csr_to_coo(row_ptr)
+            if coo_index.dim() < src_slice.dim():
+                view = [1] * src_slice.dim()
+                view[0] = -1
+                bcast = coo_index.view(view).expand_as(src_slice)
+            else:
+                bcast = coo_index
+            out_slice.scatter_add_(0, bcast, src_slice)
+    return out
+
+
+def _gather_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+    out: torch.Tensor = None,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for :func:`gather_csr`.
+
+    For each output position ``i`` along ``dim = indptr.dim() - 1``,
+    ``out[..., i, ...] = src[..., r, ...]`` where ``r`` is the row containing
+    ``i`` (i.e. the unique ``r`` with ``indptr[r] <= i < indptr[r+1]``).
+
+    Computed by repeat-interleaving ``src`` along ``dim`` by row-lengths
+    ``indptr.diff()``.
+    """
+    dim = indptr.dim() - 1
+    if indptr.dim() == 1:
+        repeats = indptr.diff()
+        result = torch.repeat_interleave(src, repeats, dim=dim)
+    else:
+        # Multi-dim indptr: handle the leading dims explicitly.
+        leading_shape = indptr.shape[:-1]
+        pieces = []
+        for leading_idx in (
+            torch.cartesian_prod(
+                *[torch.arange(s) for s in leading_shape],
+            ).tolist()
+            if len(leading_shape) > 0
+            else [()]
+        ):
+            if isinstance(leading_idx, int):
+                leading_idx = (leading_idx,)
+            row_ptr = indptr[tuple(leading_idx)]
+            src_slice = src[tuple(leading_idx)]
+            pieces.append(
+                torch.repeat_interleave(src_slice, row_ptr.diff(), dim=0),
+            )
+        # Stack back along the leading dim — assumes one leading dim.
+        result = torch.stack(pieces, dim=0).view(
+            *leading_shape,
+            *pieces[0].shape,
+        )
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+
+
+def test_segment_add_csr_is_segment_sum_csr_alias():
+    assert pyg_lib.ops.segment_add_csr is pyg_lib.ops.segment_sum_csr
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_segment_sum_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_1d(device):
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (4,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k1_small_trailing(device):
+    """K==1 path: 1-D src, 1-D indptr — exercises the per-row CUDA kernel."""
+    src = torch.randn(10, device=device)
+    indptr = torch.tensor([0, 2, 4, 6, 8, 10], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5,)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises the broadcast kernel."""
+    src = torch.randn(12, 64, device=device)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (5, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_forward_matches_segment_coo(device):
+    """The plan's primary parity test: ``segment_sum_csr`` must agree with
+    ``segment_sum_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+    """
+    torch.manual_seed(0)
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    out_csr = pyg_lib.ops.segment_sum_csr(src, indptr)
+    out_coo = pyg_lib.ops.segment_sum_coo(src, coo_index)
+    torch.testing.assert_close(out_csr, out_coo)
+
+
+@withCUDA
+def test_segment_sum_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty and its output row must be zero.
+    """
+    src = torch.randn(5, 4, device=device)
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, expected)
+    # Row 1 is empty -> zeros.
+    torch.testing.assert_close(out[1], torch.zeros(4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_all_rows_empty(device):
+    """All rows empty -> output is all-zero of the expected shape."""
+    src = torch.empty(0, 4, device=device)
+    indptr = torch.tensor([0, 0, 0, 0], device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    assert out.size() == (3, 4)
+    torch.testing.assert_close(out, torch.zeros(3, 4, device=device))
+
+
+@withCUDA
+def test_segment_sum_csr_indptr_broadcast_via_expand(device):
+    """Indptr broadcasting: an expanded (non-contiguous) ``indptr`` should
+    work — the dispatcher must call ``.contiguous()`` at the kernel boundary.
+    """
+    torch.manual_seed(0)
+    # Two "graphs" sharing the same row layout. The natural way to express
+    # this is to expand a 1-D indptr to (B, R+1) and let the kernel reduce
+    # over the trailing dim for each batch entry.
+    src = torch.randn(2, 8, 4, device=device)
+    base_indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    # Sanity: the input is intentionally non-contiguous.
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 4, 4)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_sum_csr_stress_short_and_huge_rows(device):
+    """Mix of many short rows and a few huge rows — exercises both fast paths
+    in the CUDA kernel (per-row sequential vs broadcast).
+    """
+    torch.manual_seed(0)
+    # 50 single-element rows, 1 small row, 2 huge rows.
+    row_lengths = [1] * 50 + [3] + [200, 500]
+    indptr_vals = [0]
+    for r in row_lengths:
+        indptr_vals.append(indptr_vals[-1] + r)
+    indptr = torch.tensor(indptr_vals, device=device)
+    total = indptr_vals[-1]
+    src = torch.randn(total, 8, device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = _segment_sum_csr_ref(src, indptr)
+    assert out.size() == (len(row_lengths), 8)
+    # Loose tolerance: huge rows accumulate in different orders on CUDA vs CPU.
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+
+@withCUDA
+def test_segment_sum_csr_with_out_argument(device):
+    """``out=...`` overrides allocation; output should be written in place."""
+    src = torch.randn(8, 4, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    out = torch.zeros(4, 4, device=device)
+
+    result = pyg_lib.ops.segment_sum_csr(src, indptr, out=out)
+    expected = _segment_sum_csr_ref(src, indptr)
+    torch.testing.assert_close(out, expected)
+    # The returned tensor should be the same storage as ``out``.
+    assert result.data_ptr() == out.data_ptr()
+
+
+# ---------------------------------------------------------------------------
+# segment_sum_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck(device):
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries."""
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+def test_gather_csr_forward_dtypes(dtype, device):
+    torch.manual_seed(0)
+    src = torch.randn(4, 3, dtype=dtype, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_1d(device):
+    src = torch.tensor([10.0, 20.0, 30.0, 40.0], device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    # Expected: row 0 (val 10) repeated 2x, row 1 (val 20) 3x, row 2 (val 30)
+    # 1x, row 3 (val 40) 2x.
+    expected = torch.tensor(
+        [10.0, 10.0, 20.0, 20.0, 20.0, 30.0, 40.0, 40.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    src = torch.randn(5, 64, device=device)
+    indptr = torch.tensor([0, 2, 3, 7, 10, 12], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (12, 64)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_empty_rows(device):
+    """Empty-row fixture: ``indptr = [0, 2, 2, 5]`` — row 1 contributes
+    nothing to the gathered output.
+    """
+    src = torch.tensor(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        device=device,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr)
+    assert out.size() == (5, 2)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_gather_csr_inverse_of_segment_sum_signature(device):
+    """``segment_sum_csr`` output rows have shape ``[N, *trailing]``; passing
+    it through ``gather_csr`` with the same ``indptr`` recovers a tensor of
+    shape ``[E, *trailing]`` (the backward of segment_sum_csr).
+    """
+    src = torch.randn(8, 3, device=device)
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    summed = pyg_lib.ops.segment_sum_csr(src, indptr)  # [4, 3]
+    scattered = pyg_lib.ops.gather_csr(summed, indptr)  # [8, 3]
+    assert scattered.size() == (8, 3)
+    expected = _gather_csr_ref(summed, indptr)
+    torch.testing.assert_close(scattered, expected)
+
+
+@withCUDA
+def test_gather_csr_indptr_broadcast_via_expand(device):
+    """Expanded (non-contiguous) ``indptr`` — dispatcher must
+    ``.contiguous()`` at the kernel boundary.
+    """
+    src = torch.randn(2, 4, 3, device=device)
+    base_indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+    indptr = base_indptr.unsqueeze(0).expand(2, -1)
+    assert not indptr.is_contiguous()
+
+    out = pyg_lib.ops.gather_csr(src, indptr)
+    expected = _gather_csr_ref(src, indptr.contiguous())
+    assert out.size() == (2, 8, 3)
+    torch.testing.assert_close(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# gather_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck(device):
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries, so its
+    gradient contribution is zero.
+    """
+    src = torch.randn(
+        3,
+        2,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# gradgradcheck — symmetric pair (each op's backward calls the other)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck(device):
+    """``SegmentSumCSR.backward`` invokes ``gather_csr``; gradgradcheck
+    exercises ``gather_csr``'s backward (which in turn invokes
+    ``segment_sum_csr``).
+    """
+    src = torch.randn(
+        8,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_gather_csr_gradgradcheck(device):
+    """``GatherCSR.backward`` invokes ``segment_sum_csr``; gradgradcheck
+    exercises ``segment_sum_csr``'s backward (which in turn invokes
+    ``gather_csr``).
+    """
+    src = torch.randn(
+        4,
+        3,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.gather_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_sum_csr_gradgradcheck_empty_rows(device):
+    """Gradgradcheck on the empty-rows fixture — exercises the symmetric
+    backward pair in the presence of zero-length rows.
+    """
+    src = torch.randn(
+        5,
+        4,
+        dtype=torch.double,
+        device=device,
+        requires_grad=True,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_sum_csr(s, indptr)
+
+    assert torch.autograd.gradgradcheck(fn, (src,))


### PR DESCRIPTION
Like `segment_sum_csr`, plus division by row lengths (`indptr.diff()`).
Empty rows get clamped denominators so the output is 0 rather than NaN.
Backward wraps in `if (grad_in.numel() > 0)` like `segment_mean_coo` and
returns `gather_csr(grad_out / count, indptr)`.
