### PR TITLE
Add `segment_min_csr`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -157,6 +157,93 @@ at::Tensor segment_mean_csr_autograd(
   return SegmentMeanCSR::apply(src, indptr, optional_out)[0];
 }
 
+// Autograd Function for `pyg::segment_min_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `SegmentMinCOO` / `ScatterMin`).
+//
+// Backward formula (mirrors `ScatterMin` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions that
+// produced the per-row min and silently drops any contribution from rows
+// whose `arg_out` is still at the sentinel (empty rows).
+class SegmentMinCSR : public torch::autograd::Function<SegmentMinCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = indptr.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_min_csr: indptr must have at least 1 dimension");
+
+    auto result = segment_min_csr(src, indptr, optional_out);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // implicit `dim`, and the original `src.sizes()` (so the +1/narrow trick
+    // reconstructs the right shape). We save `indptr` for parity with other
+    // CSR Functions; it is not used directly by backward.
+    ctx->save_for_backward({indptr, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `indptr`, kept for parity with other CSR Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are dropped
+    // by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  auto result = SegmentMinCSR::apply(src, indptr, optional_out);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
@@ -220,6 +307,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_sum_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
          TORCH_FN(gather_csr_autograd));
 }

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -253,6 +253,157 @@ at::Tensor segment_mean_csr_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_min_csr`.
+//
+// Same (N, E, K) layout as `segment_sum_csr_kernel` with
+// `dim = indptr.dim() - 1`. Per-row sequential pass: maintain a running
+// minimum value and its first-match argindex per row. Two output tensors:
+//   * `out`: the per-row minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty rows
+//     (no contributing source element) are reset to `0` after the
+//     reduction loop (matched against the sentinel in `arg_out`, mirrors
+//     `segment_min_coo_kernel`).
+//   * `arg_out`: the source position that produced each per-row min, init
+//     to the sentinel `src.size(dim)` (one past the last valid index along
+//     `dim`). Has dtype `int64` (matches `indptr.options()`).
+//
+// **Determinism:** the inner E loop is sequential per row and uses strict
+// `<` on the comparison, so on ties the kernel preserves *first-match*
+// semantics. Parallelism is only over the flat row index `N` where rows
+// write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_min_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` and force contiguous
+  // so the kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_min_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_min_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`) and
+  // starts at the sentinel `src.size(dim)`. The sentinel both encodes "empty
+  // row" for the `masked_fill_` post-step and feeds into the backward's
+  // `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, indptr_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did not
+        // supply `optional_out` (otherwise the caller's state is the running
+        // state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` / `arg_out` slot so no atomics are needed. The
+        // inner reduction loop is sequential to preserve first-match
+        // argindex semantics on tied source values within a row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  auto* out_slot = out_data + n;
+                  auto* arg_slot = arg_out_data + n;
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    const scalar_t v = src_data[src_off + e];
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      *arg_slot = e;
+                    }
+                  }
+                } else {
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + n * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[n * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty rows retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the former,
+  // upstream resets the value to `0`; for the latter we leave the caller's
+  // value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
@@ -379,6 +530,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -8,10 +8,40 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 
+#include "shuffle.cuh"
+
 namespace pyg {
 namespace ops {
 
 namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). Already defined in `segment_coo_kernel.cu` /
+// `scatter_kernel.cu` in their own TUs; we redefine guarded here so the TUs
+// stay independent.
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+// Full-warp mask for `__shfl_*_sync` — every lane participates.
+#ifndef FULL_MASK
+#define FULL_MASK 0xffffffff
+#endif
+
+// Strict less-than predicate used by the min reductions below. Half-precision
+// routes through `float` to avoid an ambiguous overload between
+// `c10::Half::operator<` and the built-in `arithmetic <` (nvcc rejects the
+// direct comparison; same reason `device_min` in `segment_coo_kernel.cu`
+// uses a `static_cast<float>` route).
+template <typename scalar_t>
+static inline __device__ bool device_lt(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) < static_cast<float>(b);
+  } else {
+    return a < b;
+  }
+}
 
 // Convention 12: dynamic block sizing — replicates the inline `threads()` /
 // `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
@@ -579,6 +609,329 @@ at::Tensor gather_csr_kernel(const at::Tensor& src,
   return out;
 }
 
+// ============================================================================
+// `segment_min_csr` — Commit 12.
+//
+// First CSR op to use `TB > 1`: each warp lane (one of 32) collaborates on a
+// single row, then a warp-tree `SHFL_DOWN_SYNC` reduction halves the active
+// lane count five times to land the row's `(min_value, argindex)` in lane 0.
+//
+// Why `TB == 1` is wrong for min/max (and was fine for sum/mean):
+// sum/mean's inner loop is `+=` and a single thread per row was already fast
+// enough — adding TB warp lanes would just waste them on the tail of short
+// rows. Min/max, however, has no early-exit and benefits more from
+// parallelism over long rows. Upstream `segment_csr_cuda.cu:157` launches
+// `<<<BLOCKS(32, N), THREADS>>>` for min/max (32 lanes per row), versus
+// `<<<BLOCKS(1, N), THREADS>>>` (TB == 1) for sum.
+//
+// TB choice: we mirror upstream and fix `TB == 32` (one warp per row). Long
+// rows benefit from the parallelism; short rows just leave the trailing
+// lanes holding `(numeric_limits::max(), E_dim)` which contributes nothing.
+// Picking TB == warp size also lets us drive the reduction with the existing
+// `SHFL_DOWN_SYNC` macro without involving shared memory.
+//
+// Pair propagation through `SHFL_DOWN_SYNC`:
+//
+//   Each lane holds a local `(val, arg)`. At reduction step `i` (i = 16, 8,
+//   4, 2, 1):
+//
+//     tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+//     tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+//     if (device_lt(tmp_val, val)) { val = tmp_val; arg = tmp_arg; }
+//
+//   We perform two independent shuffles — one carrying `val`, one carrying
+//   `arg` — and then choose between the **pair members together**, so the
+//   surviving `arg` always matches the surviving `val`. After 5 steps (32
+//   -> 16 -> 8 -> 4 -> 2 -> 1) lane 0 holds the row's min and corresponding
+//   argindex. Mirrors upstream `segment_csr_cuda.cu:46-52`. The comparison
+//   is strict `<` (via `device_lt`): on ties, the **lower-lane** value wins,
+//   which matches the upstream first-match convention for the argindex.
+//
+// No shared memory: upstream comment at `segment_csr_cuda.cu:68-70`
+// explicitly notes that shared memory was tried and rejected — the
+// `__syncthreads` overhead exceeded the benefit. We mirror that decision;
+// the warp shuffle is sufficient because TB == warp size.
+//
+// Argindex semantics: stored as `int64_t` (matches `arg_out` dtype), tracks
+// the absolute `src_idx` along the reduction axis (NOT relative to the
+// row), which makes it directly indexable into the per-batch slice of `src`
+// along `dim`. Upstream stores the same absolute index.
+//
+// Empty-row post-pass: `out.masked_fill_(arg_out == src.size(dim), 0)`.
+// Initial `arg_out` is filled with the sentinel `E_dim = src.size(dim)`;
+// any row that ran zero iterations keeps that sentinel, and we reset the
+// corresponding `out` slot (still at `numeric_limits::max()`) to 0. Matches
+// `segment_min_coo`'s empty-bucket policy and the CPU min kernel contract.
+
+// K==1 kernel — one warp per row, lanes stride through the row by `TB == 32`.
+template <typename scalar_t>
+__global__ void segment_min_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t E) {
+  // `TB == WARP_SIZE` (32): one warp processes one row. `lane_idx` selects
+  // the slot within the row.
+  constexpr int TB = WARP_SIZE;
+
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / TB;
+  const int lane_idx = thread_idx & (TB - 1);
+
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Strided indptr offset for this row.
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Same as the
+  // sum kernel above.
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E);
+
+  // Per-lane sentinel pair. The sentinel argindex `E` (== `src.size(dim)`)
+  // matches the host-side `at::full` init of `arg_out`; the host post-pass
+  // checks `arg_out == E` to identify empty rows. The sentinel value
+  // `numeric_limits<scalar_t>::max()` matches the host-side `out.fill_`.
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  // Lane-strided scan: each lane handles `ceil(row_len / TB)` elements at
+  // stride `TB`. Mirrors upstream `segment_csr_cuda.cu:39-43`.
+  //
+  // On ties (`cand == val`), we keep the **earlier** (lower `src_idx`)
+  // winner via strict `<` — matches the CPU kernel's first-match argindex
+  // convention. Pathological case: if every element in a row equals
+  // `numeric_limits::max()`, `arg` stays at sentinel `E`, and the host
+  // post-pass will `masked_fill_` `out` to 0 (matches upstream's behaviour
+  // for the same edge case).
+  for (int64_t src_idx = row_start + lane_idx; src_idx < row_end;
+       src_idx += TB) {
+    scalar_t cand = src_data[batch_offset + src_idx];
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  // Warp-tree min reduction over `(val, arg)` pairs. Two independent
+  // shuffles transport the pair members across lanes; we then choose
+  // between them as a unit so the surviving `arg` always matches the
+  // surviving `val`. Mirrors upstream `segment_csr_cuda.cu:45-52`.
+#pragma unroll
+  for (int i = TB / 2; i > 0; i /= 2) {
+    scalar_t tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+    int64_t tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+    // Strict `<`: on ties, keep the existing (lower-lane) value/arg, which
+    // matches the first-match convention for the argindex.
+    if (device_lt(tmp_val, val)) {
+      val = tmp_val;
+      arg = tmp_arg;
+    }
+  }
+
+  // Lane 0 writes the row's `(min, argmin)` pair. Other lanes contribute
+  // nothing past this point. No `atomicMin` needed — the warp-tree
+  // reduction has already aggregated all of row `r`'s contributions, and
+  // each warp owns exactly one row.
+  //
+  // For empty rows (`row_start == row_end`), the inner loop ran zero
+  // iterations, `val` is still `numeric_limits::max()`, and `arg` is still
+  // the sentinel `E`. The host post-pass resets such slots to 0.
+  if (lane_idx == 0) {
+    out_data[row_idx] = val;
+    arg_out_data[row_idx] = arg;
+  }
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair. Sequential row scan
+// with running `(val, arg)`; no shuffle (each thread already owns its full
+// reduction). Mirrors upstream `segment_csr_cuda.cu:62-95`.
+template <typename scalar_t>
+__global__ void segment_min_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / static_cast<int>(K);
+  const int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E) * static_cast<int>(K);
+
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    scalar_t cand =
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx];
+    // Same strict-`<` first-match logic as the K==1 kernel above.
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  out_data[thread_idx] = val;
+  arg_out_data[thread_idx] = arg;
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_min_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_min_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_min_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Same broadcast rule as `segment_sum_csr`: leading dims of `indptr`
+  // expand to `src.shape[:indptr.dim()-1]`; last `indptr` dim is the row
+  // pointer itself (kept native).
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  // `E_dim = src.size(dim)` is the sentinel argindex value for `arg_out`
+  // (matches `segment_min_coo` and `scatter_min`).
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no max-init. With `out=` supplied, the kernel
+    // **overwrites** the per-row slot with the computed row min — there is
+    // no atomicMin path here (the warp-tree fully reduces the row before
+    // the single write), so any prior value in `out` is discarded for
+    // non-empty rows. This matches upstream's "out= as scratch buffer"
+    // contract: the caller is expected to pre-initialize if they want a
+    // running min across calls.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_min_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_min_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Allocate uninit then fill with per-dtype `max()`. Same rationale as
+    // `segment_min_coo`: `at::full` with a single host `Scalar` cannot
+    // represent each dtype's max correctly, so we route through
+    // `AT_DISPATCH_*` + `numeric_limits<scalar_t>::max()`.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_min_csr_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always freshly allocated and filled with the sentinel
+  // `E_dim`. The kernel either overwrites it with a real argindex (non-empty
+  // row) or leaves it at the sentinel (empty row); the host post-pass below
+  // uses `arg_out == E_dim` to identify empty rows.
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          indptr_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    // No contributors at all; every row is empty. Reset to 0 (matching the
+    // CPU kernel) when we own `out`. With `out=` supplied, the caller's
+    // values are preserved.
+    if (!out_was_provided) {
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        if (K == 1) {
+          // 32 lanes per row (TB == warp size). Total threads = `32 * N`;
+          // block size from the dynamic `threads()` helper (always a
+          // multiple of 32 for sm_60+).
+          constexpr int TB = WARP_SIZE;
+          const int T = threads();
+          const int B =
+              std::max<int>(1, static_cast<int>((TB * N + T - 1) / T));
+          segment_min_csr_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col) pair; sequential row scan inside the
+          // thread, no shuffle.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_min_csr_broadcast_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-row cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that row, so `out` still holds `numeric_limits::max()`. Reset to `0` to
+  // match the CPU kernel's contract. Skipped when `out=` is supplied — the
+  // caller's pre-existing values in empty rows must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -586,6 +939,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -60,6 +60,34 @@ PYG_API at::Tensor segment_mean_csr(const at::Tensor& src,
   return op.call(src, indptr, out);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_min_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_min_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_min_csr", "")
+                       .typed<decltype(segment_min_csr)>();
+  return op.call(src, indptr, out);
+}
+
 PYG_API at::Tensor gather_csr(const at::Tensor& src,
                               const at::Tensor& indptr,
                               const std::optional<at::Tensor>& out) {
@@ -94,6 +122,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::segment_mean_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_min_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> (Tensor, Tensor)"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -56,6 +57,41 @@ PYG_API at::Tensor segment_sum_csr(
 // caller-supplied buffer — it overwrites the per-row slots. We allocate the
 // `out` buffer zero-initialized so that empty-row slots stay at 0.
 PYG_API at::Tensor segment_mean_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Computes the per-row minimum of `src` along the implicit axis
+// `dim = indptr.dim() - 1`, using the compressed row pointer `indptr`. Returns
+// `(out, arg_out)` where `arg_out[r]` is the source position that produced the
+// minimum value at row `r`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row min to `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) are reset to `0` after the reduction loop; the
+// matching slot in `arg_out` keeps the sentinel value `src.size(dim)` (one
+// past the last valid index along `dim`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized to
+// `numeric_limits<scalar_t>::max()` so that the first contributing element
+// always wins. When `out` *is* provided, the caller's buffer is used as the
+// running state (no max-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `<` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
     const at::Tensor& src,
     const at::Tensor& indptr,
     const std::optional<at::Tensor>& out = std::nullopt);

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -679,6 +679,28 @@ def segment_mean_csr(
     return torch.ops.pyg.segment_mean_csr(src, indptr, out)
 
 
+def segment_min_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. Empty rows yield value ``0`` and
+    argindex ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor for the values.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_min_csr(src, indptr, out)
+
+
 def gather_csr(
     src: Tensor,
     indptr: Tensor,
@@ -954,6 +976,7 @@ __all__ = [
     'segment_sum_csr',
     'segment_add_csr',
     'segment_mean_csr',
+    'segment_min_csr',
     'gather_csr',
     'spline_basis',
     'spline_weighting',

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 # ---------------------------------------------------------------------------
 # Reference implementations
@@ -745,3 +745,280 @@ def test_segment_mean_csr_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_min_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+):
+    """Pure-PyTorch reference for :func:`segment_min_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. Returns ``(value, argindex)``:
+      * ``value[..., r, ...]`` is the minimum of ``src`` entries whose
+        position along ``dim`` lies in ``[indptr[r], indptr[r+1])``.
+      * ``argindex[..., r, ...]`` is the position along ``dim`` of the
+        first-match min entry (CPU upstream contract).
+      * Empty rows (``indptr[r+1] == indptr[r]``) get ``value == 0`` and
+        ``argindex == src.size(dim)`` (upstream sentinel).
+
+    This reference handles the 1-D ``indptr`` case (the variant tested
+    below — matching the plan's spec for commit 12).
+    """
+    assert indptr.dim() == 1, '1-D indptr reference only'
+    dim = indptr.dim() - 1  # == 0
+    num_rows = indptr.size(-1) - 1
+    sentinel = src.size(dim)
+
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    indptr_cpu = indptr.detach().cpu().tolist()
+    for r in range(num_rows):
+        lo, hi = indptr_cpu[r], indptr_cpu[r + 1]
+        if lo == hi:
+            # Empty row -> leave zero value + sentinel arg.
+            continue
+        seg = src.narrow(dim, lo, hi - lo)
+        # min along the reduction dim; ``torch.min`` returns (values, indices)
+        # where indices index *into the narrowed segment*, so offset by ``lo``.
+        seg_val, seg_arg = seg.min(dim=dim)
+        # Assign into the r-th slice of value/argindex along ``dim``.
+        value.select(dim, r).copy_(seg_val)
+        argindex.select(dim, r).copy_(seg_arg + lo)
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_min_csr_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_matches_segment_min_coo(device):
+    """Primary parity test: ``segment_min_csr`` must agree with
+    ``segment_min_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+
+    Uses a unique-value source so argindex tie-breaks are deterministic on
+    both CPU and CUDA.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    val_csr, arg_csr = pyg_lib.ops.segment_min_csr(src, indptr)
+    val_coo, arg_coo = pyg_lib.ops.segment_min_coo(src, coo_index)
+    torch.testing.assert_close(val_csr, val_coo)
+    torch.testing.assert_close(arg_csr, arg_coo)
+
+
+@withCUDA
+def test_segment_min_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty; its output value row is zero and arg row is sentinel.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 is empty -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_min_csr_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Row 0: positions 0, 1, 2 all with value 1.0 (tied min).
+    # Row 1: positions 3, 4 with value 2.0 (tied min).
+    # Row 2: empty.
+    # Row 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    indptr = torch.tensor([0, 3, 5, 5, 6], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    # Value must equal the true per-row min regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Row 0 arg must be in {0, 1, 2}; row 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Row 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Row 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must attain the row's min value.
+    for r in range(value.size(0)):
+        a = int(arg[r].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[r].item(), (
+            f'arg[{r}]={a} points to src value {src[a].item()} but row '
+            f'min is {value[r].item()}'
+        )
+
+
+@withCUDA
+def test_segment_min_csr_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(8, dtype=torch.double, device=device, requires_grad=True)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses a unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(8 * 3, device=device).to(torch.double) - 12)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries; its
+    argindex points at the sentinel and the ``+1``/``narrow`` backward
+    pattern drops that slot.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))


### PR DESCRIPTION
Tuple-returning min reduction over a CSR `indptr`. CPU is deterministic
first-match via a per-row sequential pass with strict `<`. CUDA uses
`TB == 32` (one warp per row) and `SHFL_DOWN_SYNC` to reduce the
`(value, argindex)` pair across the warp — two parallel shuffles
(one per pair member) with a conditional swap, so the surviving
argindex always corresponds to the surviving value. Trailing lanes
beyond the row hold the sentinel `(numeric_limits::max(), src.size(dim))`
and never win comparison. Still no shared memory.

Empty rows reset values to 0 with the sentinel `arg = src.size(dim)`;
backward uses the `+1`/`narrow` pattern from `scatter_min`.
