### PR TITLE
Add `segment_max_csr`

### DIFF
--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -157,6 +157,93 @@ at::Tensor segment_mean_csr_autograd(
   return SegmentMeanCSR::apply(src, indptr, optional_out)[0];
 }
 
+// Autograd Function for `pyg::segment_min_csr`.
+//
+// CSR ops fix the reduction axis at `dim = indptr.dim() - 1`. Forward returns
+// `(out, arg_out)`. Only `out` is differentiable; `arg_out` is marked
+// non-differentiable so PyTorch will not error when callers try to take
+// gradients through it (mirrors `SegmentMinCOO` / `ScatterMin`).
+//
+// Backward formula (mirrors `ScatterMin` from commit 4):
+//
+//   src_shape_plus = src_shape; src_shape_plus[dim] += 1
+//   grad_in = zeros(src_shape_plus)
+//   grad_in.scatter_(dim, arg_out, grad_out)   // sentinel lands in +1 slot
+//   grad_in = grad_in.narrow(dim, 0, src_shape[dim])  // drop sentinel
+//
+// The `+1`/`narrow` trick routes gradient only to the source positions that
+// produced the per-row min and silently drops any contribution from rows
+// whose `arg_out` is still at the sentinel (empty rows).
+class SegmentMinCSR : public torch::autograd::Function<SegmentMinCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = indptr.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_min_csr: indptr must have at least 1 dimension");
+
+    auto result = segment_min_csr(src, indptr, optional_out);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    // Backward needs `arg_out` (where to deposit each `grad_out`), the
+    // implicit `dim`, and the original `src.sizes()` (so the +1/narrow trick
+    // reconstructs the right shape). We save `indptr` for parity with other
+    // CSR Functions; it is not used directly by backward.
+    ctx->save_for_backward({indptr, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    // `arg_out` is integer / non-differentiable; mark it so PyTorch will
+    // not attempt to propagate gradients through it.
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    // `grad_outs[0]` is the gradient w.r.t. `out`; `grad_outs[1]` is the
+    // gradient w.r.t. `arg_out` and is ignored (non-differentiable).
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    // saved[0] is `indptr`, kept for parity with other CSR Functions; not
+    // used directly by backward (the +1/narrow trick references `arg_out`).
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    // `+1`/`narrow` trick: extend `src_shape` along `dim` by one extra
+    // sentinel slot, scatter `grad_out` into the extended buffer using
+    // `arg_out` (sentinel entries land in the trailing slot and are dropped
+    // by the subsequent `narrow`).
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    // 3 input slots: (src, indptr, out). Only `src` is a real differentiable
+    // tensor; the rest get undefined-Tensor grads.
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  auto result = SegmentMinCSR::apply(src, indptr, optional_out);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
@@ -220,6 +307,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_sum_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
          TORCH_FN(gather_csr_autograd));
 }

--- a/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/autograd/segment_csr_kernel.cpp
@@ -244,6 +244,66 @@ std::tuple<at::Tensor, at::Tensor> segment_min_csr_autograd(
   return std::make_tuple(result[0], result[1]);
 }
 
+// Autograd Function for `pyg::segment_max_csr`.
+//
+// Symmetric to `SegmentMinCSR`: forward returns `(out, arg_out)`, only `out`
+// is differentiable. Backward uses the same `+1`/`narrow` trick to route
+// gradient only to the source positions that produced the per-row max and
+// silently drop sentinel slots (empty rows).
+class SegmentMaxCSR : public torch::autograd::Function<SegmentMaxCSR> {
+ public:
+  static variable_list forward(torch::autograd::AutogradContext* ctx,
+                               const at::Tensor& src,
+                               const at::Tensor& indptr,
+                               const std::optional<at::Tensor>& optional_out) {
+    at::AutoDispatchBelowADInplaceOrView g;
+
+    const int64_t dim = indptr.dim() - 1;
+    TORCH_CHECK(dim >= 0,
+                "segment_max_csr: indptr must have at least 1 dimension");
+
+    auto result = segment_max_csr(src, indptr, optional_out);
+    auto out = std::get<0>(result);
+    auto arg_out = std::get<1>(result);
+
+    ctx->save_for_backward({indptr, arg_out});
+    ctx->saved_data["dim"] = dim;
+    ctx->saved_data["src_shape"] = src.sizes();
+
+    ctx->mark_non_differentiable({arg_out});
+
+    if (optional_out.has_value()) {
+      ctx->mark_dirty({optional_out.value()});
+    }
+
+    return {out, arg_out};
+  }
+
+  static variable_list backward(torch::autograd::AutogradContext* ctx,
+                                variable_list grad_outs) {
+    const auto grad_out = grad_outs[0];
+    const auto saved = ctx->get_saved_variables();
+    const auto arg_out = saved[1];
+    const auto dim = ctx->saved_data["dim"].toInt();
+    auto src_shape = ctx->saved_data["src_shape"].toIntList().vec();
+
+    src_shape[dim] += 1;
+    auto grad_in = at::zeros(src_shape, grad_out.options());
+    grad_in.scatter_(dim, arg_out, grad_out);
+    grad_in = grad_in.narrow(dim, 0, src_shape[dim] - 1);
+
+    return {grad_in, at::Tensor(), at::Tensor()};
+  }
+};
+
+std::tuple<at::Tensor, at::Tensor> segment_max_csr_autograd(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  auto result = SegmentMaxCSR::apply(src, indptr, optional_out);
+  return std::make_tuple(result[0], result[1]);
+}
+
 // Autograd Function for `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. Forward saves
@@ -309,6 +369,8 @@ TORCH_LIBRARY_IMPL(pyg, Autograd, m) {
          TORCH_FN(segment_mean_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
          TORCH_FN(segment_min_csr_autograd));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_csr"),
+         TORCH_FN(segment_max_csr_autograd));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"),
          TORCH_FN(gather_csr_autograd));
 }

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -404,6 +404,130 @@ std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
   return std::make_tuple(out, arg_out);
 }
 
+// CPU implementation of `pyg::segment_max_csr`.
+//
+// Symmetric to `segment_min_csr_kernel`: same (N, E, K) layout with
+// `dim = indptr.dim() - 1`, per-row sequential pass maintaining a running
+// maximum value and its first-match argindex per row. Two output tensors:
+//   * `out`: the per-row maximum value, init to `numeric_limits::lowest()`
+//     when `out=None` so the first contributing element wins. Empty rows
+//     (no contributing source element) are reset to `0` after the
+//     reduction loop (matched against the sentinel in `arg_out`).
+//   * `arg_out`: the source position that produced each per-row max, init
+//     to the sentinel `src.size(dim)`.
+//
+// Determinism: strict `>` comparison preserves first-match argindex on ties.
+//
+// `out=` contract mirrors `segment_min_csr_kernel`: when supplied, the
+// caller's buffer is the running state (no lowest-init).
+std::tuple<at::Tensor, at::Tensor> segment_max_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_max_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_max_csr: indptr must have at least 1 dimension");
+
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_max_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_max_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, indptr_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_max_csr_cpu", [&] {
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::lowest());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  auto* out_slot = out_data + n;
+                  auto* arg_slot = arg_out_data + n;
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    const scalar_t v = src_data[src_off + e];
+                    if (v > *out_slot) {
+                      *out_slot = v;
+                      *arg_slot = e;
+                    }
+                  }
+                } else {
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + n * K + k;
+                      if (v > *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[n * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
@@ -532,6 +656,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_mean_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
          TORCH_FN(segment_min_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_csr"),
+         TORCH_FN(segment_max_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
+++ b/pyg_lib/csrc/ops/cpu/segment_csr_kernel.cpp
@@ -253,6 +253,157 @@ at::Tensor segment_mean_csr_kernel(
   return out;
 }
 
+// CPU implementation of `pyg::segment_min_csr`.
+//
+// Same (N, E, K) layout as `segment_sum_csr_kernel` with
+// `dim = indptr.dim() - 1`. Per-row sequential pass: maintain a running
+// minimum value and its first-match argindex per row. Two output tensors:
+//   * `out`: the per-row minimum value, init to `numeric_limits::max()`
+//     when `out=None` so the first contributing element wins. Empty rows
+//     (no contributing source element) are reset to `0` after the
+//     reduction loop (matched against the sentinel in `arg_out`, mirrors
+//     `segment_min_coo_kernel`).
+//   * `arg_out`: the source position that produced each per-row min, init
+//     to the sentinel `src.size(dim)` (one past the last valid index along
+//     `dim`). Has dtype `int64` (matches `indptr.options()`).
+//
+// **Determinism:** the inner E loop is sequential per row and uses strict
+// `<` on the comparison, so on ties the kernel preserves *first-match*
+// semantics. Parallelism is only over the flat row index `N` where rows
+// write to disjoint sub-regions of `out` / `arg_out`.
+//
+// `out=` contract: when the caller supplies `optional_out`, the running
+// state begins from the caller's buffer (no max-init), and the kernel
+// **continues** the reduction over that state. The caller is responsible
+// for any non-default starting value. This matches upstream.
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr: src.dim() must be >= indptr.dim() "
+              "(got src.dim()=",
+              src.dim(), ", indptr.dim()=", indptr.dim(), ")");
+
+  const int64_t dim = indptr.dim() - 1;
+  TORCH_CHECK(dim >= 0,
+              "segment_min_csr: indptr must have at least 1 dimension");
+
+  // Broadcast `indptr` up to `src.shape[:indptr.dim()-1]` and force contiguous
+  // so the kernel can do flat pointer arithmetic.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i)
+    sizes[i] = src.size(i);
+  auto indptr_b = indptr.expand(sizes).contiguous();
+
+  auto src_c = src.contiguous();
+
+  at::Tensor out;
+  if (optional_out.has_value()) {
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim)
+        TORCH_CHECK(src_c.size(i) == out.size(i), "segment_min_csr: out.size(",
+                    i, ") must match src.size(", i, ")");
+    }
+    TORCH_CHECK(
+        src_c.numel() == 0 || out.size(dim) == indptr_b.size(dim) - 1,
+        "segment_min_csr: out.size(dim) must equal indptr.size(-1) - 1");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_b.size(dim) - 1, 0);
+    // Allocate uninitialized; the dispatch below fills with
+    // `numeric_limits<scalar_t>::max()` before the reduction loop.
+    out = at::empty(out_sizes, src_c.options());
+  }
+
+  // `arg_out` is always freshly allocated (independent of `optional_out`) and
+  // starts at the sentinel `src.size(dim)`. The sentinel both encodes "empty
+  // row" for the `masked_fill_` post-step and feeds into the backward's
+  // `+1`/`narrow` trick.
+  const int64_t sentinel = src_c.size(dim);
+  auto arg_out = at::full(out.sizes(), sentinel, indptr_b.options());
+
+  if (src_c.numel() == 0) {
+    if (!optional_out.has_value()) {
+      out.fill_(0);
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const int64_t E = src_c.size(dim);
+  const int64_t rows_per_slice = indptr_b.size(dim) - 1;
+  const int64_t leading = indptr_b.numel() / indptr_b.size(-1);
+  const int64_t N = out.size(dim) * leading;
+  const int64_t K = out.numel() / N;
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cpu", [&] {
+        // Init `out` to `numeric_limits::max()` only when the caller did not
+        // supply `optional_out` (otherwise the caller's state is the running
+        // state, per the `out=` contract).
+        if (!optional_out.has_value()) {
+          out.fill_(std::numeric_limits<scalar_t>::max());
+        }
+
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+        const auto* indptr_data = indptr_b.data_ptr<int64_t>();
+
+        // Parallelize over the flat row index `n ∈ [0, N)`. Each row writes
+        // to a disjoint `out` / `arg_out` slot so no atomics are needed. The
+        // inner reduction loop is sequential to preserve first-match
+        // argindex semantics on tied source values within a row.
+        at::parallel_for(
+            0, N, at::internal::GRAIN_SIZE, [&](int64_t n_beg, int64_t n_end) {
+              for (int64_t n = n_beg; n < n_end; ++n) {
+                const int64_t slice = n / rows_per_slice;
+                const int64_t row = n % rows_per_slice;
+                const int64_t indptr_off = slice * indptr_b.size(-1) + row;
+                const int64_t row_start = indptr_data[indptr_off];
+                const int64_t row_end = indptr_data[indptr_off + 1];
+                const int64_t src_off = slice * E * K;
+
+                if (K == 1) {
+                  auto* out_slot = out_data + n;
+                  auto* arg_slot = arg_out_data + n;
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    const scalar_t v = src_data[src_off + e];
+                    if (v < *out_slot) {
+                      *out_slot = v;
+                      *arg_slot = e;
+                    }
+                  }
+                } else {
+                  for (int64_t e = row_start; e < row_end; ++e) {
+                    for (int64_t k = 0; k < K; ++k) {
+                      const scalar_t v = src_data[src_off + e * K + k];
+                      auto* out_slot = out_data + n * K + k;
+                      if (v < *out_slot) {
+                        *out_slot = v;
+                        arg_out_data[n * K + k] = e;
+                      }
+                    }
+                  }
+                }
+              }
+            });
+      });
+
+  // Empty rows retain the sentinel in `arg_out` and either keep the
+  // `numeric_limits::max()` placeholder (when `optional_out` was not
+  // supplied) or the caller's initial value (when it was). For the former,
+  // upstream resets the value to `0`; for the latter we leave the caller's
+  // value alone so the `out=` contract is honored.
+  if (!optional_out.has_value()) {
+    out.masked_fill_(arg_out == sentinel, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 // CPU implementation of `pyg::gather_csr`.
 //
 // CSR ops fix the gather axis at `dim = indptr.dim() - 1`. For each row `r`,
@@ -379,6 +530,8 @@ TORCH_LIBRARY_IMPL(pyg, CPU, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -43,6 +43,18 @@ static inline __device__ bool device_lt(scalar_t a, scalar_t b) {
   }
 }
 
+// Strict greater-than predicate used by the max reductions below. Same
+// half-precision routing as `device_lt`.
+template <typename scalar_t>
+static inline __device__ bool device_gt(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) > static_cast<float>(b);
+  } else {
+    return a > b;
+  }
+}
+
 // Convention 12: dynamic block sizing — replicates the inline `threads()` /
 // `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
 // Each `.cu` file in `pyg_lib/csrc/ops/cuda/` carries its own copy until a
@@ -932,6 +944,259 @@ std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
   return std::make_tuple(out, arg_out);
 }
 
+// ============================================================================
+// `segment_max_csr` — Commit 13.
+//
+// Symmetric mirror of `segment_min_csr`: same TB == 32 warp-per-row layout,
+// same `SHFL_DOWN_SYNC` pair propagation across two independent shuffles
+// (one for `val`, one for `arg`), same K>1 broadcast variant with a
+// sequential per-thread row scan. The only differences vs the min kernel:
+//
+//   * Sentinel value is `numeric_limits<scalar_t>::lowest()` (not `max()`),
+//     so the first contributing element always wins.
+//   * Per-element comparison uses strict `>` (via `device_gt`) — on ties the
+//     **earlier** (lower `src_idx`) winner is kept, matching the CPU max
+//     kernel's first-match argindex convention.
+//   * Warp-tree reduction also uses `device_gt`: when the partner lane's
+//     `val` is *greater*, swap both pair members; otherwise keep the
+//     current pair.
+//
+// Empty-row post-pass: identical to min — `out.masked_fill_(arg_out == E_dim,
+// 0)` resets the sentinel `lowest()` to 0 for rows with zero contributors.
+//
+// No new atomics: like min, the warp-tree fully reduces the row before the
+// single lane-0 write; no `atomicMax` is involved.
+
+// K==1 kernel — one warp per row, lanes stride through the row by `TB == 32`.
+template <typename scalar_t>
+__global__ void segment_max_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t E) {
+  constexpr int TB = WARP_SIZE;
+
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / TB;
+  const int lane_idx = thread_idx & (TB - 1);
+
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E);
+
+  // Sentinel pair. `lowest()` for the value (so the first contributor wins
+  // against any real value), `E` for the argindex (host-side `at::full` init
+  // matches this; host post-pass detects empty rows via `arg_out == E`).
+  scalar_t val = std::numeric_limits<scalar_t>::lowest();
+  int64_t arg = static_cast<int64_t>(E);
+
+  // Lane-strided scan. Strict `>` keeps the earlier winner on ties,
+  // mirroring the CPU max kernel's first-match argindex.
+  for (int64_t src_idx = row_start + lane_idx; src_idx < row_end;
+       src_idx += TB) {
+    scalar_t cand = src_data[batch_offset + src_idx];
+    if (device_gt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  // Warp-tree max reduction over `(val, arg)` pairs. Two independent
+  // shuffles transport the pair members across lanes; we swap as a unit so
+  // the surviving `arg` always matches the surviving `val`. When the
+  // partner's `val` is *greater* than ours we adopt the partner's pair.
+#pragma unroll
+  for (int i = TB / 2; i > 0; i /= 2) {
+    scalar_t tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+    int64_t tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+    if (device_gt(tmp_val, val)) {
+      val = tmp_val;
+      arg = tmp_arg;
+    }
+  }
+
+  // Lane 0 writes the row's `(max, argmax)` pair. For empty rows
+  // (`row_start == row_end`), `val` is still `lowest()` and `arg` is still
+  // the sentinel `E`; the host post-pass resets those `out` slots to 0.
+  if (lane_idx == 0) {
+    out_data[row_idx] = val;
+    arg_out_data[row_idx] = arg;
+  }
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair. Sequential row scan
+// with running `(val, arg)`; no shuffle (each thread already owns its full
+// reduction).
+template <typename scalar_t>
+__global__ void segment_max_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / static_cast<int>(K);
+  const int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E) * static_cast<int>(K);
+
+  scalar_t val = std::numeric_limits<scalar_t>::lowest();
+  int64_t arg = static_cast<int64_t>(E);
+
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    scalar_t cand =
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx];
+    // Same strict-`>` first-match logic as the K==1 kernel above.
+    if (device_gt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  out_data[thread_idx] = val;
+  arg_out_data[thread_idx] = arg;
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_max_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_max_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_max_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_max_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_max_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_max_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Same broadcast rule as `segment_sum_csr` / `segment_min_csr`.
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no lowest-init. With `out=` supplied, the
+    // kernel **overwrites** the per-row slot with the computed row max —
+    // same contract as `segment_min_csr` (the warp-tree fully reduces the
+    // row before the single write, so any prior value in `out` is
+    // discarded for non-empty rows).
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_max_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_max_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Allocate uninit then fill with per-dtype `lowest()`. Same rationale
+    // as `segment_min_csr`: `at::full` with a single host `Scalar` cannot
+    // represent each dtype's lowest correctly, so we route through
+    // `AT_DISPATCH_*` + `numeric_limits<scalar_t>::lowest()`.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_max_csr_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::lowest()); });
+  }
+
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          indptr_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    if (!out_was_provided) {
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_max_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        if (K == 1) {
+          constexpr int TB = WARP_SIZE;
+          const int T = threads();
+          const int B =
+              std::max<int>(1, static_cast<int>((TB * N + T - 1) / T));
+          segment_max_csr_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_max_csr_broadcast_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-row cleanup: where `arg_out == E_dim`, no contributor wrote, so
+  // `out` still holds `lowest()`. Reset to `0` to match the CPU kernel's
+  // contract. Skipped when `out=` was caller-provided.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -941,6 +1206,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_mean_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
          TORCH_FN(segment_min_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_max_csr"),
+         TORCH_FN(segment_max_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -8,10 +8,40 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/detail/TensorInfo.cuh>
 
+#include "shuffle.cuh"
+
 namespace pyg {
 namespace ops {
 
 namespace {
+
+// Convention 13: WARP_SIZE is fixed at 32 on every NVIDIA architecture pyg-lib
+// targets (sm_60+). Already defined in `segment_coo_kernel.cu` /
+// `scatter_kernel.cu` in their own TUs; we redefine guarded here so the TUs
+// stay independent.
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+// Full-warp mask for `__shfl_*_sync` — every lane participates.
+#ifndef FULL_MASK
+#define FULL_MASK 0xffffffff
+#endif
+
+// Strict less-than predicate used by the min reductions below. Half-precision
+// routes through `float` to avoid an ambiguous overload between
+// `c10::Half::operator<` and the built-in `arithmetic <` (nvcc rejects the
+// direct comparison; same reason `device_min` in `segment_coo_kernel.cu`
+// uses a `static_cast<float>` route).
+template <typename scalar_t>
+static inline __device__ bool device_lt(scalar_t a, scalar_t b) {
+  if constexpr (std::is_same_v<scalar_t, at::Half> ||
+                std::is_same_v<scalar_t, at::BFloat16>) {
+    return static_cast<float>(a) < static_cast<float>(b);
+  } else {
+    return a < b;
+  }
+}
 
 // Convention 12: dynamic block sizing — replicates the inline `threads()` /
 // `blocks()` pattern used in `segment_coo_kernel.cu` / `scatter_kernel.cu`.
@@ -579,6 +609,329 @@ at::Tensor gather_csr_kernel(const at::Tensor& src,
   return out;
 }
 
+// ============================================================================
+// `segment_min_csr` — Commit 12.
+//
+// First CSR op to use `TB > 1`: each warp lane (one of 32) collaborates on a
+// single row, then a warp-tree `SHFL_DOWN_SYNC` reduction halves the active
+// lane count five times to land the row's `(min_value, argindex)` in lane 0.
+//
+// Why `TB == 1` is wrong for min/max (and was fine for sum/mean):
+// sum/mean's inner loop is `+=` and a single thread per row was already fast
+// enough — adding TB warp lanes would just waste them on the tail of short
+// rows. Min/max, however, has no early-exit and benefits more from
+// parallelism over long rows. Upstream `segment_csr_cuda.cu:157` launches
+// `<<<BLOCKS(32, N), THREADS>>>` for min/max (32 lanes per row), versus
+// `<<<BLOCKS(1, N), THREADS>>>` (TB == 1) for sum.
+//
+// TB choice: we mirror upstream and fix `TB == 32` (one warp per row). Long
+// rows benefit from the parallelism; short rows just leave the trailing
+// lanes holding `(numeric_limits::max(), E_dim)` which contributes nothing.
+// Picking TB == warp size also lets us drive the reduction with the existing
+// `SHFL_DOWN_SYNC` macro without involving shared memory.
+//
+// Pair propagation through `SHFL_DOWN_SYNC`:
+//
+//   Each lane holds a local `(val, arg)`. At reduction step `i` (i = 16, 8,
+//   4, 2, 1):
+//
+//     tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+//     tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+//     if (device_lt(tmp_val, val)) { val = tmp_val; arg = tmp_arg; }
+//
+//   We perform two independent shuffles — one carrying `val`, one carrying
+//   `arg` — and then choose between the **pair members together**, so the
+//   surviving `arg` always matches the surviving `val`. After 5 steps (32
+//   -> 16 -> 8 -> 4 -> 2 -> 1) lane 0 holds the row's min and corresponding
+//   argindex. Mirrors upstream `segment_csr_cuda.cu:46-52`. The comparison
+//   is strict `<` (via `device_lt`): on ties, the **lower-lane** value wins,
+//   which matches the upstream first-match convention for the argindex.
+//
+// No shared memory: upstream comment at `segment_csr_cuda.cu:68-70`
+// explicitly notes that shared memory was tried and rejected — the
+// `__syncthreads` overhead exceeded the benefit. We mirror that decision;
+// the warp shuffle is sufficient because TB == warp size.
+//
+// Argindex semantics: stored as `int64_t` (matches `arg_out` dtype), tracks
+// the absolute `src_idx` along the reduction axis (NOT relative to the
+// row), which makes it directly indexable into the per-batch slice of `src`
+// along `dim`. Upstream stores the same absolute index.
+//
+// Empty-row post-pass: `out.masked_fill_(arg_out == src.size(dim), 0)`.
+// Initial `arg_out` is filled with the sentinel `E_dim = src.size(dim)`;
+// any row that ran zero iterations keeps that sentinel, and we reset the
+// corresponding `out` slot (still at `numeric_limits::max()`) to 0. Matches
+// `segment_min_coo`'s empty-bucket policy and the CPU min kernel contract.
+
+// K==1 kernel — one warp per row, lanes stride through the row by `TB == 32`.
+template <typename scalar_t>
+__global__ void segment_min_csr_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t E) {
+  // `TB == WARP_SIZE` (32): one warp processes one row. `lane_idx` selects
+  // the slot within the row.
+  constexpr int TB = WARP_SIZE;
+
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / TB;
+  const int lane_idx = thread_idx & (TB - 1);
+
+  if (row_idx >= static_cast<int>(N))
+    return;
+
+  // Strided indptr offset for this row.
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  // Per-batch slice offset into `src` along the reduction axis. Same as the
+  // sum kernel above.
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E);
+
+  // Per-lane sentinel pair. The sentinel argindex `E` (== `src.size(dim)`)
+  // matches the host-side `at::full` init of `arg_out`; the host post-pass
+  // checks `arg_out == E` to identify empty rows. The sentinel value
+  // `numeric_limits<scalar_t>::max()` matches the host-side `out.fill_`.
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  // Lane-strided scan: each lane handles `ceil(row_len / TB)` elements at
+  // stride `TB`. Mirrors upstream `segment_csr_cuda.cu:39-43`.
+  //
+  // On ties (`cand == val`), we keep the **earlier** (lower `src_idx`)
+  // winner via strict `<` — matches the CPU kernel's first-match argindex
+  // convention. Pathological case: if every element in a row equals
+  // `numeric_limits::max()`, `arg` stays at sentinel `E`, and the host
+  // post-pass will `masked_fill_` `out` to 0 (matches upstream's behaviour
+  // for the same edge case).
+  for (int64_t src_idx = row_start + lane_idx; src_idx < row_end;
+       src_idx += TB) {
+    scalar_t cand = src_data[batch_offset + src_idx];
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  // Warp-tree min reduction over `(val, arg)` pairs. Two independent
+  // shuffles transport the pair members across lanes; we then choose
+  // between them as a unit so the surviving `arg` always matches the
+  // surviving `val`. Mirrors upstream `segment_csr_cuda.cu:45-52`.
+#pragma unroll
+  for (int i = TB / 2; i > 0; i /= 2) {
+    scalar_t tmp_val = SHFL_DOWN_SYNC(FULL_MASK, val, i);
+    int64_t tmp_arg = SHFL_DOWN_SYNC(FULL_MASK, arg, i);
+    // Strict `<`: on ties, keep the existing (lower-lane) value/arg, which
+    // matches the first-match convention for the argindex.
+    if (device_lt(tmp_val, val)) {
+      val = tmp_val;
+      arg = tmp_arg;
+    }
+  }
+
+  // Lane 0 writes the row's `(min, argmin)` pair. Other lanes contribute
+  // nothing past this point. No `atomicMin` needed — the warp-tree
+  // reduction has already aggregated all of row `r`'s contributions, and
+  // each warp owns exactly one row.
+  //
+  // For empty rows (`row_start == row_end`), the inner loop ran zero
+  // iterations, `val` is still `numeric_limits::max()`, and `arg` is still
+  // the sentinel `E`. The host post-pass resets such slots to 0.
+  if (lane_idx == 0) {
+    out_data[row_idx] = val;
+    arg_out_data[row_idx] = arg;
+  }
+}
+
+// K>1 broadcast kernel — one thread per (row, col) pair. Sequential row scan
+// with running `(val, arg)`; no shuffle (each thread already owns its full
+// reduction). Mirrors upstream `segment_csr_cuda.cu:62-95`.
+template <typename scalar_t>
+__global__ void segment_min_csr_broadcast_cuda_kernel(
+    const scalar_t* __restrict__ src_data,
+    const at::cuda::detail::TensorInfo<int64_t, int> indptr_info,
+    scalar_t* __restrict__ out_data,
+    int64_t* __restrict__ arg_out_data,
+    size_t N,
+    size_t K,
+    size_t E) {
+  const int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row_idx = thread_idx / static_cast<int>(K);
+  const int col_idx = thread_idx % static_cast<int>(K);
+
+  if (thread_idx >= static_cast<int>(N * K))
+    return;
+
+  int ip_offset = IndexPtrToOffset::get(row_idx, indptr_info);
+  int64_t row_start = __ldg(indptr_info.data + ip_offset);
+  int64_t row_end = __ldg(indptr_info.data + ip_offset +
+                          indptr_info.strides[indptr_info.dims - 1]);
+
+  const int batch_offset =
+      (row_idx / (indptr_info.sizes[indptr_info.dims - 1] - 1)) *
+      static_cast<int>(E) * static_cast<int>(K);
+
+  scalar_t val = std::numeric_limits<scalar_t>::max();
+  int64_t arg = static_cast<int64_t>(E);
+
+  for (int64_t src_idx = row_start; src_idx < row_end; ++src_idx) {
+    scalar_t cand =
+        src_data[batch_offset + static_cast<int>(K) * src_idx + col_idx];
+    // Same strict-`<` first-match logic as the K==1 kernel above.
+    if (device_lt(cand, val)) {
+      val = cand;
+      arg = src_idx;
+    }
+  }
+
+  out_data[thread_idx] = val;
+  arg_out_data[thread_idx] = arg;
+}
+
+std::tuple<at::Tensor, at::Tensor> segment_min_csr_kernel(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& optional_out) {
+  TORCH_CHECK(src.is_cuda(),
+              "segment_min_csr (CUDA): src must be a CUDA tensor");
+  TORCH_CHECK(indptr.is_cuda(),
+              "segment_min_csr (CUDA): indptr must be a CUDA tensor");
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr (CUDA): src and indptr must be on the same "
+              "device");
+  TORCH_CHECK(src.dim() >= indptr.dim(),
+              "segment_min_csr (CUDA): src.dim() must be >= indptr.dim() (got ",
+              src.dim(), " vs ", indptr.dim(), ")");
+  TORCH_CHECK(indptr.dim() >= 1,
+              "segment_min_csr (CUDA): indptr must have at least 1 dimension");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(src));
+
+  // Same broadcast rule as `segment_sum_csr`: leading dims of `indptr`
+  // expand to `src.shape[:indptr.dim()-1]`; last `indptr` dim is the row
+  // pointer itself (kept native).
+  auto sizes = indptr.sizes().vec();
+  for (int64_t i = 0; i < indptr.dim() - 1; ++i) {
+    sizes[i] = src.size(i);
+  }
+  auto indptr_b = indptr.expand(sizes);
+
+  const auto dim = indptr_b.dim() - 1;
+
+  auto src_c = src.contiguous();
+  auto indptr_c = indptr_b.contiguous();
+
+  // `E_dim = src.size(dim)` is the sentinel argindex value for `arg_out`
+  // (matches `segment_min_coo` and `scatter_min`).
+  const int64_t E_dim = src_c.size(dim);
+
+  at::Tensor out;
+  const bool out_was_provided = optional_out.has_value();
+  if (out_was_provided) {
+    // Caller owns the buffer; no max-init. With `out=` supplied, the kernel
+    // **overwrites** the per-row slot with the computed row min — there is
+    // no atomicMin path here (the warp-tree fully reduces the row before
+    // the single write), so any prior value in `out` is discarded for
+    // non-empty rows. This matches upstream's "out= as scratch buffer"
+    // contract: the caller is expected to pre-initialize if they want a
+    // running min across calls.
+    out = optional_out.value().contiguous();
+    for (int64_t i = 0; i < out.dim(); ++i) {
+      if (i != dim) {
+        TORCH_CHECK(src_c.size(i) == out.size(i),
+                    "segment_min_csr (CUDA): out.size(", i,
+                    ") must match src.size(", i, ")");
+      }
+    }
+    TORCH_CHECK(src_c.numel() == 0 || out.size(dim) == indptr_c.size(dim) - 1,
+                "segment_min_csr (CUDA): out.size(", dim,
+                ") must equal indptr.size(-1) - 1 (got ", out.size(dim), " vs ",
+                indptr_c.size(dim) - 1, ")");
+  } else {
+    auto out_sizes = src_c.sizes().vec();
+    out_sizes[dim] = std::max<int64_t>(indptr_c.size(dim) - 1, 0);
+    // Allocate uninit then fill with per-dtype `max()`. Same rationale as
+    // `segment_min_coo`: `at::full` with a single host `Scalar` cannot
+    // represent each dtype's max correctly, so we route through
+    // `AT_DISPATCH_*` + `numeric_limits<scalar_t>::max()`.
+    out = at::empty(out_sizes, src_c.options());
+    AT_DISPATCH_ALL_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+        "segment_min_csr_cuda_init_out",
+        [&] { out.fill_(std::numeric_limits<scalar_t>::max()); });
+  }
+
+  // `arg_out` is always freshly allocated and filled with the sentinel
+  // `E_dim`. The kernel either overwrites it with a real argindex (non-empty
+  // row) or leaves it at the sentinel (empty row); the host post-pass below
+  // uses `arg_out == E_dim` to identify empty rows.
+  auto arg_out = at::full(out.sizes(), E_dim,
+                          indptr_c.options().dtype(at::ScalarType::Long));
+
+  if (src_c.numel() == 0) {
+    // No contributors at all; every row is empty. Reset to 0 (matching the
+    // CPU kernel) when we own `out`. With `out=` supplied, the caller's
+    // values are preserved.
+    if (!out_was_provided) {
+      out.zero_();
+    }
+    return std::make_tuple(out, arg_out);
+  }
+
+  const auto N = out.size(dim) * (indptr_c.numel() / indptr_c.size(-1));
+  const auto K = out.numel() / N;
+  const auto E = src_c.size(dim);
+
+  auto indptr_info = at::cuda::detail::getTensorInfo<int64_t, int>(indptr_c);
+  const auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, src_c.scalar_type(),
+      "segment_min_csr_cuda", [&] {
+        const auto* src_data = src_c.data_ptr<scalar_t>();
+        auto* out_data = out.data_ptr<scalar_t>();
+        auto* arg_out_data = arg_out.data_ptr<int64_t>();
+
+        if (K == 1) {
+          // 32 lanes per row (TB == warp size). Total threads = `32 * N`;
+          // block size from the dynamic `threads()` helper (always a
+          // multiple of 32 for sm_60+).
+          constexpr int TB = WARP_SIZE;
+          const int T = threads();
+          const int B =
+              std::max<int>(1, static_cast<int>((TB * N + T - 1) / T));
+          segment_min_csr_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          // One thread per (row, col) pair; sequential row scan inside the
+          // thread, no shuffle.
+          const int T = threads();
+          const int B = blocks(static_cast<int>(N * K));
+          segment_min_csr_broadcast_cuda_kernel<scalar_t><<<B, T, 0, stream>>>(
+              src_data, indptr_info, out_data, arg_out_data, N, K, E);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+
+  // Empty-row cleanup: where `arg_out == E_dim`, no contributor wrote to
+  // that row, so `out` still holds `numeric_limits::max()`. Reset to `0` to
+  // match the CPU kernel's contract. Skipped when `out=` is supplied — the
+  // caller's pre-existing values in empty rows must be preserved.
+  if (!out_was_provided) {
+    out.masked_fill_(arg_out == E_dim, 0);
+  }
+
+  return std::make_tuple(out, arg_out);
+}
+
 }  // namespace
 
 TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
@@ -586,6 +939,8 @@ TORCH_LIBRARY_IMPL(pyg, CUDA, m) {
          TORCH_FN(segment_sum_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::segment_mean_csr"),
          TORCH_FN(segment_mean_csr_kernel));
+  m.impl(TORCH_SELECTIVE_NAME("pyg::segment_min_csr"),
+         TORCH_FN(segment_min_csr_kernel));
   m.impl(TORCH_SELECTIVE_NAME("pyg::gather_csr"), TORCH_FN(gather_csr_kernel));
 }
 

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -88,6 +88,34 @@ PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
   return op.call(src, indptr, out);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_max_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_max_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_max_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_max_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_max_csr", "")
+                       .typed<decltype(segment_max_csr)>();
+  return op.call(src, indptr, out);
+}
+
 PYG_API at::Tensor gather_csr(const at::Tensor& src,
                               const at::Tensor& indptr,
                               const std::optional<at::Tensor>& out) {
@@ -124,6 +152,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
                              "Tensor? out=None) -> Tensor"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::segment_min_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> (Tensor, Tensor)"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_max_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> (Tensor, Tensor)"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "

--- a/pyg_lib/csrc/ops/segment_csr.cpp
+++ b/pyg_lib/csrc/ops/segment_csr.cpp
@@ -60,6 +60,34 @@ PYG_API at::Tensor segment_mean_csr(const at::Tensor& src,
   return op.call(src, indptr, out);
 }
 
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out) {
+  at::TensorArg src_arg{src, "src", 0};
+  at::TensorArg indptr_arg{indptr, "indptr", 1};
+  at::CheckedFrom c{"segment_min_csr"};
+
+  at::checkAllDefined(c, {src_arg, indptr_arg});
+  TORCH_CHECK(src.device() == indptr.device(),
+              "segment_min_csr: src and indptr must be on the same device "
+              "(got src=",
+              src.device(), ", indptr=", indptr.device(), ")");
+  if (out.has_value()) {
+    at::TensorArg out_arg{out.value(), "out", 2};
+    at::checkAllDefined(c, {out_arg});
+    TORCH_CHECK(src.device() == out.value().device(),
+                "segment_min_csr: src and out must be on the same device "
+                "(got src=",
+                src.device(), ", out=", out.value().device(), ")");
+  }
+
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("pyg::segment_min_csr", "")
+                       .typed<decltype(segment_min_csr)>();
+  return op.call(src, indptr, out);
+}
+
 PYG_API at::Tensor gather_csr(const at::Tensor& src,
                               const at::Tensor& indptr,
                               const std::optional<at::Tensor>& out) {
@@ -94,6 +122,9 @@ TORCH_LIBRARY_FRAGMENT(pyg, m) {
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::segment_mean_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));
+  m.def(
+      TORCH_SELECTIVE_SCHEMA("pyg::segment_min_csr(Tensor src, Tensor indptr, "
+                             "Tensor? out=None) -> (Tensor, Tensor)"));
   m.def(
       TORCH_SELECTIVE_SCHEMA("pyg::gather_csr(Tensor src, Tensor indptr, "
                              "Tensor? out=None) -> Tensor"));

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <optional>
+#include <tuple>
 #include "pyg_lib/csrc/macros.h"
 
 namespace pyg {
@@ -56,6 +57,41 @@ PYG_API at::Tensor segment_sum_csr(
 // caller-supplied buffer — it overwrites the per-row slots. We allocate the
 // `out` buffer zero-initialized so that empty-row slots stay at 0.
 PYG_API at::Tensor segment_mean_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
+// Computes the per-row minimum of `src` along the implicit axis
+// `dim = indptr.dim() - 1`, using the compressed row pointer `indptr`. Returns
+// `(out, arg_out)` where `arg_out[r]` is the source position that produced the
+// minimum value at row `r`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row min to `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) are reset to `0` after the reduction loop; the
+// matching slot in `arg_out` keeps the sentinel value `src.size(dim)` (one
+// past the last valid index along `dim`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized to
+// `numeric_limits<scalar_t>::max()` so that the first contributing element
+// always wins. When `out` *is* provided, the caller's buffer is used as the
+// running state (no max-init); the caller is responsible for any non-default
+// starting value. This matches the upstream `pytorch_scatter` contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `<` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmin is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
     const at::Tensor& src,
     const at::Tensor& indptr,
     const std::optional<at::Tensor>& out = std::nullopt);

--- a/pyg_lib/csrc/ops/segment_csr.h
+++ b/pyg_lib/csrc/ops/segment_csr.h
@@ -96,6 +96,42 @@ PYG_API std::tuple<at::Tensor, at::Tensor> segment_min_csr(
     const at::Tensor& indptr,
     const std::optional<at::Tensor>& out = std::nullopt);
 
+// Computes the per-row maximum of `src` along the implicit axis
+// `dim = indptr.dim() - 1`, using the compressed row pointer `indptr`. Returns
+// `(out, arg_out)` where `arg_out[r]` is the source position that produced the
+// maximum value at row `r`.
+//
+// CSR ops do **not** take a `dim` argument: upstream `pytorch_scatter` fixes
+// the reduction axis at `indptr.dim() - 1` (the last indptr dim). They also
+// do **not** take a `dim_size`: the output size along `dim` is determined by
+// `indptr.size(-1) - 1` (one entry per row, plus a trailing sentinel).
+//
+// Each row `r` consumes the source slice `src[..., indptr[r]:indptr[r+1], ...]`
+// and writes the per-row max to `out[..., r, ...]`. Empty rows
+// (`indptr[r+1] == indptr[r]`) are reset to `0` after the reduction loop; the
+// matching slot in `arg_out` keeps the sentinel value `src.size(dim)` (one
+// past the last valid index along `dim`).
+//
+// `indptr` is `expand`-broadcast to match `src.shape[:indptr.dim()-1]` along
+// the leading dims; we force `.contiguous()` at the kernel boundary.
+//
+// When `out` is not provided, a fresh buffer is allocated and initialized to
+// `numeric_limits<scalar_t>::lowest()` so that the first contributing element
+// always wins. When `out` *is* provided, the caller's buffer is used as the
+// running state (no lowest-init); the caller is responsible for any
+// non-default starting value. This matches the upstream `pytorch_scatter`
+// contract.
+//
+// **CPU determinism:** the CPU kernel produces a *first-match* `arg_out`
+// on ties (strict `>` comparison). The CUDA kernel is not guaranteed to
+// match on ties (any valid argmax is acceptable).
+//
+// `arg_out` is non-differentiable; only `out` participates in autograd.
+PYG_API std::tuple<at::Tensor, at::Tensor> segment_max_csr(
+    const at::Tensor& src,
+    const at::Tensor& indptr,
+    const std::optional<at::Tensor>& out = std::nullopt);
+
 // Gathers values from `src` at the row positions encoded in `indptr`, along
 // the implicit axis `dim = indptr.dim() - 1`. Concretely, for each row `r`,
 // the value `src[..., r, ...]` is broadcast to all output positions

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -679,6 +679,28 @@ def segment_mean_csr(
     return torch.ops.pyg.segment_mean_csr(src, indptr, out)
 
 
+def segment_min_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``min`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. Empty rows yield value ``0`` and
+    argindex ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor for the values.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_min_csr(src, indptr, out)
+
+
 def gather_csr(
     src: Tensor,
     indptr: Tensor,
@@ -954,6 +976,7 @@ __all__ = [
     'segment_sum_csr',
     'segment_add_csr',
     'segment_mean_csr',
+    'segment_min_csr',
     'gather_csr',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -701,6 +701,28 @@ def segment_min_csr(
     return torch.ops.pyg.segment_min_csr(src, indptr, out)
 
 
+def segment_max_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    r"""Reduces all values from the :obj:`src` tensor into :obj:`out` according
+    to a CSR :obj:`indptr`, using ``max`` as the reduction.
+
+    Returns a tuple ``(values, argindex)``. Empty rows yield value ``0`` and
+    argindex ``src.size(dim)`` (sentinel). Only ``values`` is differentiable.
+
+    Args:
+        src: The source tensor.
+        indptr: The CSR row pointer of shape :obj:`[..., R+1]`.
+        out: The destination tensor for the values.
+
+    Returns:
+        Tuple ``(values, argindex)``.
+    """
+    return torch.ops.pyg.segment_max_csr(src, indptr, out)
+
+
 def gather_csr(
     src: Tensor,
     indptr: Tensor,
@@ -977,6 +999,7 @@ __all__ = [
     'segment_add_csr',
     'segment_mean_csr',
     'segment_min_csr',
+    'segment_max_csr',
     'gather_csr',
     'spline_basis',
     'spline_weighting',

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -745,6 +745,245 @@ def gather_csr(
     return torch.ops.pyg.gather_csr(src, indptr, out)
 
 
+def _broadcast(src: Tensor, other: Tensor, dim: int) -> Tensor:
+    r"""Broadcasts a 1-D :obj:`src` to the shape of :obj:`other` along
+    :obj:`dim`. Used by the Python composites that need to lift a 1-D
+    per-bucket result back to per-element positions for ``gather`` /
+    arithmetic broadcasting.
+
+    Ports ``torch_scatter/utils.py:broadcast``.
+    """
+    if src.dim() == 1:
+        for _ in range(dim if dim >= 0 else other.dim() + dim):
+            src = src.unsqueeze(0)
+    while src.dim() < other.dim():
+        src = src.unsqueeze(-1)
+    return src.expand_as(other)
+
+
+def scatter(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic scatter dispatcher.
+
+    Routes to the typed scatter op based on :obj:`reduce`:
+    ``"sum"``/``"add"`` -> :func:`scatter_sum`,
+    ``"mul"`` -> :func:`scatter_mul`, ``"mean"`` -> :func:`scatter_mean`,
+    ``"min"`` -> :func:`scatter_min`, ``"max"`` -> :func:`scatter_max`.
+    Min/max return only the values.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return scatter_sum(src, index, dim, out, dim_size)
+    if reduce == 'mul':
+        return scatter_mul(src, index, dim, out, dim_size)
+    if reduce == 'mean':
+        return scatter_mean(src, index, dim, out, dim_size)
+    if reduce == 'min':
+        return scatter_min(src, index, dim, out, dim_size)[0]
+    if reduce == 'max':
+        return scatter_max(src, index, dim, out, dim_size)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def segment_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic COO segment dispatcher.
+
+    Routes by :obj:`reduce` to the typed ``segment_*_coo`` op.
+    Min/max return only the value tensor.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return segment_sum_coo(src, index, out, dim_size)
+    if reduce == 'mean':
+        return segment_mean_coo(src, index, out, dim_size)
+    if reduce == 'min':
+        return segment_min_coo(src, index, out, dim_size)[0]
+    if reduce == 'max':
+        return segment_max_coo(src, index, out, dim_size)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def segment_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic CSR segment dispatcher.
+
+    Routes by :obj:`reduce` to the typed ``segment_*_csr`` op.
+    Min/max return only the value tensor.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return segment_sum_csr(src, indptr, out)
+    if reduce == 'mean':
+        return segment_mean_csr(src, indptr, out)
+    if reduce == 'min':
+        return segment_min_csr(src, indptr, out)[0]
+    if reduce == 'max':
+        return segment_max_csr(src, indptr, out)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def scatter_softmax(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Per-bucket softmax composite. Float inputs only."""
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_softmax requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    max_per_idx = scatter_max(src, index, dim, dim_size=dim_size)[0]
+    max_per_src = max_per_idx.gather(dim, _broadcast(index, src, dim))
+    recentered_exp = (src - max_per_src).exp()
+    sum_per_idx = scatter_sum(recentered_exp, index, dim, dim_size=dim_size)
+    sum_per_src = sum_per_idx.gather(dim, _broadcast(index, src, dim))
+    return recentered_exp / sum_per_src
+
+
+def scatter_log_softmax(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    dim_size: Optional[int] = None,
+    eps: float = 1e-12,
+) -> Tensor:
+    r"""Per-bucket log-softmax composite. Float inputs only."""
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_log_softmax requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    max_per_idx = scatter_max(src, index, dim, dim_size=dim_size)[0]
+    max_per_src = max_per_idx.gather(dim, _broadcast(index, src, dim))
+    recentered = src - max_per_src
+    sum_per_idx = scatter_sum(recentered.exp(), index, dim, dim_size=dim_size)
+    sum_per_src = sum_per_idx.gather(dim, _broadcast(index, src, dim))
+    return recentered - torch.log(sum_per_src + eps)
+
+
+def scatter_std(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    unbiased: bool = True,
+) -> Tensor:
+    r"""Per-bucket standard deviation composite. Float inputs only.
+
+    Ports ``torch_scatter.composite.scatter_std``: uses :func:`scatter_sum`
+    for both passes (avoids integer floor-division coupling that would
+    appear if :func:`scatter_mean` were used). Applies Bessel's correction
+    ``N / (N - 1)`` when :obj:`unbiased` is :obj:`True`.
+    """
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_std requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    if out is not None:
+        dim_size = out.size(dim)
+
+    bcast_index = _broadcast(index, src, dim)
+    ones = torch.ones_like(src)
+    count = scatter_sum(ones, bcast_index, dim, dim_size=dim_size)
+    sum_per_idx = scatter_sum(src, bcast_index, dim, dim_size=dim_size)
+    count_safe = count.clamp(min=1)
+    mean = sum_per_idx / count_safe
+
+    var = src - mean.gather(dim, bcast_index)
+    var = var * var
+    result = scatter_sum(var, bcast_index, dim, out, dim_size)
+    if unbiased:
+        denom = (count - 1).clamp(min=1)
+    else:
+        denom = count_safe
+    result = result / denom
+    return result.sqrt()
+
+
+def scatter_logsumexp(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    eps: float = 1e-12,
+) -> Tensor:
+    r"""Per-bucket log-sum-exp composite. Float inputs only.
+
+    Numerically stable: recenter by the per-bucket max before exponentiating.
+    When :obj:`out` is supplied, positions that ended up non-finite (empty
+    buckets that produced ``-inf``) are restored from the caller-supplied
+    ``out`` to preserve any caller-provided initial values.
+    """
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_logsumexp requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    if out is not None:
+        dim_size = out.size(dim)
+
+    # Allocate `max_value_per_index` filled with -inf so empty buckets stay
+    # at -inf and get masked back to 0 below.
+    size = list(src.size())
+    if dim_size is not None:
+        size[dim] = dim_size
+    elif index.numel() == 0:
+        size[dim] = 0
+    else:
+        size[dim] = int(index.max().item()) + 1
+    max_value_per_index = torch.full(
+        size,
+        float('-inf'),
+        dtype=src.dtype,
+        device=src.device,
+    )
+    scatter_max(src, index, dim, max_value_per_index, dim_size)
+
+    # `gather` only reads positions that appear in `index`, so empty-bucket
+    # slots in `max_value_per_index` (still -inf) are never read here.
+    max_per_src = max_value_per_index.gather(dim, _broadcast(index, src, dim))
+    recentered = src - max_per_src
+    # If src had inf or both src and max are -inf, recentered may be NaN.
+    recentered = torch.where(
+        torch.isnan(recentered),
+        torch.full_like(recentered, float('-inf')),
+        recentered,
+    )
+    sum_per_idx = scatter_sum(recentered.exp(), index, dim, dim_size=dim_size)
+
+    result = max_value_per_index + (sum_per_idx + eps).log()
+
+    if out is None:
+        # Empty buckets had max=-inf and sum=0, producing -inf + log(eps) =
+        # -inf. Map any non-finite output to 0 to match the upstream contract.
+        return result.nan_to_num(nan=0.0, posinf=0.0, neginf=0.0)
+
+    # `out=`: restore caller's value at positions that produced non-finite
+    # results (e.g. empty buckets).
+    orig_out = out.clone()
+    mask = ~torch.isfinite(result)
+    out.copy_(torch.where(mask, orig_out, result))
+    return out
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -1001,6 +1240,13 @@ __all__ = [
     'segment_min_csr',
     'segment_max_csr',
     'gather_csr',
+    'scatter',
+    'segment_coo',
+    'segment_csr',
+    'scatter_softmax',
+    'scatter_log_softmax',
+    'scatter_std',
+    'scatter_logsumexp',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/test/ops/test_composite.py
+++ b/test/ops/test_composite.py
@@ -1,0 +1,448 @@
+import math
+
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA, withSeed
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _broadcast_index(
+    index: torch.Tensor,
+    src: torch.Tensor,
+    dim: int,
+) -> torch.Tensor:
+    """Broadcasts a 1-D :obj:`index` to the shape of :obj:`src` along
+    :obj:`dim`. Mirrors the helper used elsewhere in the test suite.
+    """
+    if index.dim() == src.dim():
+        return index
+    if dim < 0:
+        dim = dim + src.dim()
+    size = [1] * src.dim()
+    size[dim] = -1
+    return index.view(size).expand_as(src)
+
+
+def _scatter_softmax_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Per-bucket softmax reference: max-recenter, exp, divide by per-bucket
+    sum. Reproduces the upstream ``torch_scatter.composite.scatter_softmax``
+    algorithm verbatim using plain PyTorch primitives.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    # Per-bucket max via ``scatter_reduce_(..., amax, include_self=False)``.
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = (src - max_per_src).exp()
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered,
+    )
+    return recentered / sum_per_idx.gather(dim, bcast_index)
+
+
+def _scatter_log_softmax_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    eps: float = 1e-12,
+) -> torch.Tensor:
+    """Per-bucket log-softmax reference: ``(src - max) - log(sum + eps)``."""
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = src - max_per_src
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered.exp(),
+    )
+    return recentered - (sum_per_idx + eps).log().gather(dim, bcast_index)
+
+
+def _scatter_std_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    unbiased: bool = True,
+) -> torch.Tensor:
+    """Per-bucket std reference matching upstream's two-pass scatter_sum
+    algorithm (used to avoid integer/float coupling). Bessel correction
+    ``N / (N - 1)`` applied when ``unbiased=True``.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    ones = torch.ones_like(src)
+    count = src.new_zeros(size).scatter_add_(dim, bcast_index, ones)
+    total = src.new_zeros(size).scatter_add_(dim, bcast_index, src)
+    mean = total / count.clamp(min=1)
+    diff = src - mean.gather(dim, bcast_index)
+    sq_sum = src.new_zeros(size).scatter_add_(dim, bcast_index, diff * diff)
+    denom = count.sub(1).clamp_(min=1) if unbiased else count.clamp(min=1)
+    return (sq_sum / (denom + 1e-6)).sqrt()
+
+
+def _scatter_logsumexp_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    eps: float = 1e-12,
+) -> torch.Tensor:
+    """Numerically-stable per-bucket logsumexp reference:
+    ``max + log(sum(exp(src - max)) + eps)``. Empty buckets yield 0.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = src - max_per_src
+    recentered = torch.where(
+        torch.isnan(recentered),
+        torch.full_like(recentered, float('-inf')),
+        recentered,
+    )
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered.exp(),
+    )
+    out = max_per_idx + (sum_per_idx + eps).log()
+    # Empty buckets: max == -inf -> nan_to_num to 0.
+    return torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_softmax — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_forward(device):
+    """Forward correctness against a pure-PyTorch max-recentered softmax."""
+    # Distinct random values per bucket avoid argmax ties.
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_softmax(src, index, dim=0)
+    expected = _scatter_softmax_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_normalizes_per_bucket(device):
+    """The per-bucket sum of the softmax must be 1 (or 0 for empty buckets)."""
+    src = torch.randn(10, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0, 2, 3], device=device)
+
+    out = pyg_lib.ops.scatter_softmax(src, index, dim=0, dim_size=4)
+    sums = torch.zeros(4, dtype=out.dtype, device=device).scatter_add_(
+        0,
+        index,
+        out,
+    )
+    torch.testing.assert_close(sums, torch.ones(4, device=device))
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_backward_gradcheck(device):
+    """Gradcheck with distinct double-precision values so argmax never ties."""
+    # ``torch.randperm`` gives unique integers; scale + cast for double values.
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_softmax(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_softmax_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_softmax(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_log_softmax — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_forward(device):
+    """Forward correctness against a pure-PyTorch log-softmax reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+    expected = _scatter_log_softmax_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_matches_log_of_softmax(device):
+    """``log_softmax`` and ``log(softmax)`` should agree up to numerics."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    log_sm = pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+    sm = pyg_lib.ops.scatter_softmax(src, index, dim=0)
+    torch.testing.assert_close(log_sm, sm.log(), atol=1e-5, rtol=1e-5)
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_backward_gradcheck(device):
+    """Gradcheck with distinct double-precision values so argmax never ties."""
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_log_softmax(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_log_softmax_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_std — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+@pytest.mark.parametrize('unbiased', [True, False])
+def test_scatter_std_forward(unbiased, device):
+    """Forward correctness against a pure-PyTorch per-bucket std reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_std(
+        src,
+        index,
+        dim=0,
+        unbiased=unbiased,
+    )
+    expected = _scatter_std_ref(src, index, dim=0, unbiased=unbiased)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+@pytest.mark.parametrize('unbiased', [True, False])
+def test_scatter_std_backward_gradcheck(unbiased, device):
+    """Gradcheck for the std composite. Uses distinct random values so no
+    degenerate single-element bucket has zero variance gradient ambiguity.
+    """
+    src = (
+        ((torch.randperm(8 * 3, device=device).to(torch.double) - 12) * 0.1)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    # Every bucket gets at least two elements to avoid zero-variance cases.
+    index = torch.tensor([0, 1, 0, 1, 2, 2, 0, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_std(s, index, dim=0, unbiased=unbiased)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_std_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_std(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_logsumexp — forward + numerical stability + ``out=`` path
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_forward(device):
+    """Forward correctness against a pure-PyTorch logsumexp reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0)
+    expected = _scatter_logsumexp_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_logsumexp_large_magnitude_stability(device):
+    """Stability test: very large positive values would overflow naive
+    ``log(sum(exp(...)))`` (``exp(1000)`` is ``inf``). The numerically-stable
+    implementation must produce finite, correct results.
+
+    Per-bucket logsumexp is ``max + log(count_exp_shifted)`` so for a bucket
+    with two equal entries at value ``v`` the result is ``v + log(2)``.
+    """
+    # Bucket 0: two entries at 1000.0 -> expect 1000 + log(2).
+    # Bucket 1: two entries at -1000.0 -> expect -1000 + log(2).
+    # Bucket 2: one entry at 5.0       -> expect 5.0 exactly.
+    src = torch.tensor(
+        [1000.0, 1000.0, -1000.0, -1000.0, 5.0],
+        device=device,
+    )
+    index = torch.tensor([0, 0, 1, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0)
+    # All entries must be finite.
+    assert torch.isfinite(out).all(), f'non-finite entries in {out}'
+    expected = torch.tensor(
+        [1000.0 + math.log(2.0), -1000.0 + math.log(2.0), 5.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-5)
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_empty_buckets_yield_zero(device):
+    """Empty buckets must produce 0 (upstream's ``nan_to_num_(neginf=0)``)."""
+    src = torch.randn(4, device=device)
+    # Buckets 1 and 3 receive no entries.
+    index = torch.tensor([0, 2, 0, 2], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0, dim_size=4)
+    assert torch.isfinite(out).all()
+    assert out[1].item() == 0.0
+    assert out[3].item() == 0.0
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_out_restores_non_finite(device):
+    """``out=...`` non-finite restoration: empty buckets in the result must
+    be replaced by the corresponding pre-existing values in ``out``. Upstream
+    ``scatter_logsumexp.py`` keeps ``orig_out`` and copies it into positions
+    where the final result is non-finite.
+    """
+    src = torch.tensor([1.0, 2.0, 3.0], device=device)
+    # Only bucket 0 receives entries; buckets 1, 2 are empty.
+    index = torch.tensor([0, 0, 0], device=device)
+
+    # Pre-fill ``out`` with sentinel values that must be preserved at the
+    # empty-bucket positions.
+    sentinel = torch.tensor([-999.0, 42.0, -7.0], device=device)
+    out = sentinel.clone()
+    result = pyg_lib.ops.scatter_logsumexp(src, index, dim=0, out=out)
+
+    # Bucket 0 is non-empty -> logsumexp result (not sentinel).
+    expected_0 = torch.tensor([1.0, 2.0, 3.0], device=device).logsumexp(0)
+    # Loose tolerance because of the +eps inside the log.
+    assert abs(result[0].item() - expected_0.item()) < 1e-4
+    # Buckets 1 and 2 are empty -> sentinel values restored from original out.
+    assert result[1].item() == 42.0
+    assert result[2].item() == -7.0
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_backward_gradcheck(device):
+    """Gradcheck on logsumexp. Uses scaled distinct values so the max within
+    each bucket is unambiguous (no tied argmax that would break finite
+    differencing).
+    """
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_logsumexp(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_logsumexp_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_logsumexp(src, index, dim=0)

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -1717,3 +1717,64 @@ def test_scatter_max_backward_gradcheck_with_dim_size(device):
         return pyg_lib.ops.scatter_max(s, index, dim=-1, dim_size=6)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mul', 'mean', 'min', 'max'],
+)
+def test_scatter_dispatcher(reduce, device):
+    """``scatter(src, index, dim, out, dim_size, reduce=...)`` must route to
+    the corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Uses a unique-valued ``src`` so argindex tie-breaks are deterministic
+    and ``min``/``max`` value outputs compare exactly across devices.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 3, device=device).to(torch.float64) - 9).view(
+        6,
+        3,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter(src, index, dim=0, dim_size=4, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.scatter_sum(src, index, dim=0, dim_size=4)
+    elif reduce == 'mul':
+        expected = pyg_lib.ops.scatter_mul(src, index, dim=0, dim_size=4)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.scatter_mean(src, index, dim=0, dim_size=4)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=4)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.scatter_max(src, index, dim=0, dim_size=4)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(6, 3, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.scatter(src, index, dim=0, reduce='unsupported')
+
+
+@withCUDA
+def test_scatter_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(6, 3, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter(src, index, dim=0)
+    expected = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    torch.testing.assert_close(out, expected)

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -1457,3 +1457,63 @@ def test_segment_max_coo_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_coo dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mean', 'min', 'max'],
+)
+def test_segment_coo_dispatcher(reduce, device):
+    """``segment_coo(src, index, out, dim_size, reduce=...)`` must route to
+    the corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Note: there is no ``segment_mul_coo``, so ``mul`` is not part of the
+    valid reduce set for this dispatcher.
+    """
+    torch.manual_seed(0)
+    # Unique values -> deterministic argindex tie-break across devices.
+    src = (torch.randperm(8 * 3, device=device).to(torch.float64) - 12).view(
+        8,
+        3,
+    )
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_coo(src, index, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.segment_sum_coo(src, index)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.segment_mean_coo(src, index)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.segment_min_coo(src, index)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.segment_max_coo(src, index)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_coo_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(8, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.segment_coo(src, index, reduce='unsupported')
+
+
+@withCUDA
+def test_segment_coo_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(8, 3, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_coo(src, index)
+    expected = pyg_lib.ops.segment_sum_coo(src, index)
+    torch.testing.assert_close(out, expected)

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1022,3 +1022,280 @@ def test_segment_min_csr_backward_gradcheck_empty_rows(device):
         return pyg_lib.ops.segment_min_csr(s, indptr)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_max_csr — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_max_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+):
+    """Pure-PyTorch reference for :func:`segment_max_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. Returns ``(value, argindex)``:
+      * ``value[..., r, ...]`` is the maximum of ``src`` entries whose
+        position along ``dim`` lies in ``[indptr[r], indptr[r+1])``.
+      * ``argindex[..., r, ...]`` is the position along ``dim`` of the
+        first-match max entry (CPU upstream contract).
+      * Empty rows (``indptr[r+1] == indptr[r]``) get ``value == 0`` and
+        ``argindex == src.size(dim)`` (upstream sentinel).
+
+    This reference handles the 1-D ``indptr`` case (the variant tested
+    below — matching the plan's spec for commit 13).
+    """
+    assert indptr.dim() == 1, '1-D indptr reference only'
+    dim = indptr.dim() - 1  # == 0
+    num_rows = indptr.size(-1) - 1
+    sentinel = src.size(dim)
+
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    indptr_cpu = indptr.detach().cpu().tolist()
+    for r in range(num_rows):
+        lo, hi = indptr_cpu[r], indptr_cpu[r + 1]
+        if lo == hi:
+            # Empty row -> leave zero value + sentinel arg.
+            continue
+        seg = src.narrow(dim, lo, hi - lo)
+        # max along the reduction dim; ``torch.max`` returns (values, indices)
+        # where indices index *into the narrowed segment*, so offset by ``lo``.
+        seg_val, seg_arg = seg.max(dim=dim)
+        # Assign into the r-th slice of value/argindex along ``dim``.
+        value.select(dim, r).copy_(seg_val)
+        argindex.select(dim, r).copy_(seg_arg + lo)
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_max_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_max_csr_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    ref_value, ref_arg = _segment_max_csr_ref(src, indptr)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_csr_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    ref_value, ref_arg = _segment_max_csr_ref(src, indptr)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    ref_value, ref_arg = _segment_max_csr_ref(src, indptr)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_max_csr_forward_matches_segment_max_coo(device):
+    """Primary parity test: ``segment_max_csr`` must agree with
+    ``segment_max_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+
+    Uses a unique-value source so argindex tie-breaks are deterministic on
+    both CPU and CUDA.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    val_csr, arg_csr = pyg_lib.ops.segment_max_csr(src, indptr)
+    val_coo, arg_coo = pyg_lib.ops.segment_max_coo(src, coo_index)
+    torch.testing.assert_close(val_csr, val_coo)
+    torch.testing.assert_close(arg_csr, arg_coo)
+
+
+@withCUDA
+def test_segment_max_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty; its output value row is zero and arg row is sentinel.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    ref_value, ref_arg = _segment_max_csr_ref(src, indptr)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 is empty -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_max_csr_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Row 0: positions 0, 1, 2 all with value 1.0 (tied max).
+    # Row 1: positions 3, 4 with value 2.0 (tied max).
+    # Row 2: empty.
+    # Row 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    indptr = torch.tensor([0, 3, 5, 5, 6], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    # Value must equal the true per-row max regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Row 0 arg must be in {0, 1, 2}; row 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Row 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Row 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must attain the row's max value.
+    for r in range(value.size(0)):
+        a = int(arg[r].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[r].item(), (
+            f'arg[{r}]={a} points to src value {src[a].item()} but row '
+            f'max is {value[r].item()}'
+        )
+
+
+@withCUDA
+def test_segment_max_csr_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(8, dtype=torch.double, device=device, requires_grad=True)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_max_csr(src, indptr)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_max_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_max_csr_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses a unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(8 * 3, device=device).to(torch.double) - 12)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_max_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_max_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries; its
+    argindex points at the sentinel and the ``+1``/``narrow`` backward
+    pattern drops that slot.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_max_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import pyg_lib
-from pyg_lib.testing import withCUDA
+from pyg_lib.testing import withCUDA, withSeed
 
 # ---------------------------------------------------------------------------
 # Reference implementations
@@ -745,3 +745,280 @@ def test_segment_mean_csr_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — reference
+# ---------------------------------------------------------------------------
+
+
+def _segment_min_csr_ref(
+    src: torch.Tensor,
+    indptr: torch.Tensor,
+):
+    """Pure-PyTorch reference for :func:`segment_min_csr`.
+
+    Reduces along ``dim = indptr.dim() - 1`` with output size along ``dim``
+    equal to ``indptr.size(-1) - 1``. Returns ``(value, argindex)``:
+      * ``value[..., r, ...]`` is the minimum of ``src`` entries whose
+        position along ``dim`` lies in ``[indptr[r], indptr[r+1])``.
+      * ``argindex[..., r, ...]`` is the position along ``dim`` of the
+        first-match min entry (CPU upstream contract).
+      * Empty rows (``indptr[r+1] == indptr[r]``) get ``value == 0`` and
+        ``argindex == src.size(dim)`` (upstream sentinel).
+
+    This reference handles the 1-D ``indptr`` case (the variant tested
+    below — matching the plan's spec for commit 12).
+    """
+    assert indptr.dim() == 1, '1-D indptr reference only'
+    dim = indptr.dim() - 1  # == 0
+    num_rows = indptr.size(-1) - 1
+    sentinel = src.size(dim)
+
+    out_size = list(src.size())
+    out_size[dim] = num_rows
+    value = torch.zeros(out_size, dtype=src.dtype, device=src.device)
+    argindex = torch.full(
+        out_size,
+        sentinel,
+        dtype=torch.long,
+        device=src.device,
+    )
+
+    indptr_cpu = indptr.detach().cpu().tolist()
+    for r in range(num_rows):
+        lo, hi = indptr_cpu[r], indptr_cpu[r + 1]
+        if lo == hi:
+            # Empty row -> leave zero value + sentinel arg.
+            continue
+        seg = src.narrow(dim, lo, hi - lo)
+        # min along the reduction dim; ``torch.min`` returns (values, indices)
+        # where indices index *into the narrowed segment*, so offset by ``lo``.
+        seg_val, seg_arg = seg.min(dim=dim)
+        # Assign into the r-th slice of value/argindex along ``dim``.
+        value.select(dim, r).copy_(seg_val)
+        argindex.select(dim, r).copy_(seg_arg + lo)
+
+    return value, argindex
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — forward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'dtype',
+    [torch.int32, torch.int64, torch.float32, torch.float64],
+)
+def test_segment_min_csr_forward_dtypes(dtype, device):
+    """Forward correctness on a unique-value fixture across dtypes.
+
+    Unique values mean argindex is unambiguous on both CPU and CUDA.
+    """
+    if dtype in (torch.int32, torch.int64):
+        src = torch.tensor(
+            [[9, 1, 8, 2],
+             [3, 7, 0, 5],
+             [4, 6, -1, 11],
+             [-3, 10, 12, -2],
+             [13, -4, 14, 15],
+             [16, 17, 18, 19],
+             [20, 21, 22, 23],
+             [24, 25, 26, 27]],
+            dtype=dtype,
+            device=device,
+        )  # yapf: disable
+    else:
+        torch.manual_seed(0)
+        flat = (torch.randperm(32, device=device) - 16).to(dtype)
+        src = flat.view(8, 4)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4, 4)
+    assert arg.size() == (4, 4)
+    torch.testing.assert_close(value, ref_value)
+    # Unique values -> exact argindex equivalence on both CPU and CUDA.
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_1d(device):
+    """Unique-value 1-D fixture exercising K==1 path."""
+    torch.manual_seed(0)
+    src = torch.randperm(8, device=device).to(torch.float32) - 4
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (4,)
+    assert arg.size() == (4,)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_k_large_broadcast(device):
+    """K>1 path: large trailing feature dim exercises broadcast kernel."""
+    torch.manual_seed(0)
+    src = (
+        torch.randperm(12 * 64, device=device).to(torch.float32) - 384
+    ).view(12, 64)
+    indptr = torch.tensor([0, 2, 5, 7, 9, 12], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (5, 64)
+    assert arg.size() == (5, 64)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+
+
+@withCUDA
+def test_segment_min_csr_forward_matches_segment_min_coo(device):
+    """Primary parity test: ``segment_min_csr`` must agree with
+    ``segment_min_coo`` invoked on the COO-equivalent index built by
+    ``repeat_interleave(arange(num_rows), indptr.diff())``.
+
+    Uses a unique-value source so argindex tie-breaks are deterministic on
+    both CPU and CUDA.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(8 * 4, device=device).to(torch.float32) - 16).view(
+        8,
+        4,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    coo_index = _csr_to_coo(indptr)
+
+    val_csr, arg_csr = pyg_lib.ops.segment_min_csr(src, indptr)
+    val_coo, arg_coo = pyg_lib.ops.segment_min_coo(src, coo_index)
+    torch.testing.assert_close(val_csr, val_coo)
+    torch.testing.assert_close(arg_csr, arg_coo)
+
+
+@withCUDA
+def test_segment_min_csr_empty_rows_in_middle(device):
+    """Plan-mandated empty-rows fixture: ``indptr = [0, 2, 2, 5]`` —
+    row 1 is empty; its output value row is zero and arg row is sentinel.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(5 * 4, device=device).to(torch.float32) - 10).view(
+        5,
+        4,
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+    sentinel = src.size(0)  # 5
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    ref_value, ref_arg = _segment_min_csr_ref(src, indptr)
+    assert value.size() == (3, 4)
+    assert arg.size() == (3, 4)
+    torch.testing.assert_close(value, ref_value)
+    torch.testing.assert_close(arg, ref_arg)
+    # Row 1 is empty -> zero value row + sentinel arg row.
+    torch.testing.assert_close(value[1], torch.zeros(4, device=device))
+    torch.testing.assert_close(
+        arg[1],
+        torch.full((4,), sentinel, dtype=torch.long, device=device),
+    )
+
+
+@withCUDA
+@withSeed
+def test_segment_min_csr_argindex_ties_returns_valid(device):
+    """Tied values: validity-only assertion (CUDA atomic ordering is
+    non-deterministic).
+    """
+    # Row 0: positions 0, 1, 2 all with value 1.0 (tied min).
+    # Row 1: positions 3, 4 with value 2.0 (tied min).
+    # Row 2: empty.
+    # Row 3: position 5 with unique value 7.0.
+    src = torch.tensor(
+        [1.0, 1.0, 1.0, 2.0, 2.0, 7.0],
+        device=device,
+    )
+    indptr = torch.tensor([0, 3, 5, 5, 6], device=device)
+    sentinel = src.size(0)  # 6
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    # Value must equal the true per-row min regardless of tie-break.
+    expected_value = torch.tensor([1.0, 2.0, 0.0, 7.0], device=device)
+    torch.testing.assert_close(value, expected_value)
+    # Row 0 arg must be in {0, 1, 2}; row 1 in {3, 4}.
+    assert int(arg[0].item()) in (0, 1, 2)
+    assert int(arg[1].item()) in (3, 4)
+    # Row 2 is empty -> sentinel.
+    assert int(arg[2].item()) == sentinel
+    # Row 3 has unique value -> position 5.
+    assert int(arg[3].item()) == 5
+    # Every non-sentinel arg must attain the row's min value.
+    for r in range(value.size(0)):
+        a = int(arg[r].item())
+        if a == sentinel:
+            continue
+        assert src[a].item() == value[r].item(), (
+            f'arg[{r}]={a} points to src value {src[a].item()} but row '
+            f'min is {value[r].item()}'
+        )
+
+
+@withCUDA
+def test_segment_min_csr_arg_non_differentiable(device):
+    """``arg`` must have ``requires_grad=False`` even when ``value`` does."""
+    src = torch.randn(8, dtype=torch.double, device=device, requires_grad=True)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    value, arg = pyg_lib.ops.segment_min_csr(src, indptr)
+    assert value.requires_grad
+    assert not arg.requires_grad
+    assert arg.dtype in (torch.long, torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# segment_min_csr — backward
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck(device):
+    """Gradcheck on the value output. Argindex is excluded via ``[0]``.
+
+    Uses a unique-valued src so the active argindex is deterministic and the
+    finite-difference numerical Jacobian aligns with the analytical one.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(8 * 3, device=device).to(torch.double) - 12)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_segment_min_csr_backward_gradcheck_empty_rows(device):
+    """Empty-row fixture under gradcheck — row 1 has no entries; its
+    argindex points at the sentinel and the ``+1``/``narrow`` backward
+    pattern drops that slot.
+    """
+    torch.manual_seed(0)
+    src = (
+        (torch.randperm(5 * 4, device=device).to(torch.double) - 10)
+        .view(5, 4)
+        .requires_grad_(True)
+    )
+    indptr = torch.tensor([0, 2, 2, 5], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.segment_min_csr(s, indptr)[0]
+
+    assert torch.autograd.gradcheck(fn, (src,))

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1299,3 +1299,63 @@ def test_segment_max_csr_backward_gradcheck_empty_rows(device):
         return pyg_lib.ops.segment_max_csr(s, indptr)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_csr dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mean', 'min', 'max'],
+)
+def test_segment_csr_dispatcher(reduce, device):
+    """``segment_csr(src, indptr, out, reduce=...)`` must route to the
+    corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Note: there is no ``segment_mul_csr``, so ``mul`` is not part of the
+    valid reduce set for this dispatcher.
+    """
+    torch.manual_seed(0)
+    # Unique values -> deterministic argindex tie-break across devices.
+    src = (torch.randperm(8 * 3, device=device).to(torch.float64) - 12).view(
+        8,
+        3,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_csr(src, indptr, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.segment_sum_csr(src, indptr)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.segment_mean_csr(src, indptr)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.segment_min_csr(src, indptr)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.segment_max_csr(src, indptr)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_csr_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.segment_csr(src, indptr, reduce='unsupported')
+
+
+@withCUDA
+def test_segment_csr_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(8, 3, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_csr(src, indptr)
+    expected = pyg_lib.ops.segment_sum_csr(src, indptr)
+    torch.testing.assert_close(out, expected)


### PR DESCRIPTION
Symmetric to `segment_min_csr`: `>` comparison with
`numeric_limits::lowest()` init. CUDA uses the same TB=32 one-warp-per-row
shuffle reduction, conditional-swapping `(value, argindex)` pairs when
the partner's value is greater. Same `+1`/`narrow` backward pattern.
