### PR TITLE
Add Python layer: dispatchers + composites

### DIFF
--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -745,6 +745,245 @@ def gather_csr(
     return torch.ops.pyg.gather_csr(src, indptr, out)
 
 
+def _broadcast(src: Tensor, other: Tensor, dim: int) -> Tensor:
+    r"""Broadcasts a 1-D :obj:`src` to the shape of :obj:`other` along
+    :obj:`dim`. Used by the Python composites that need to lift a 1-D
+    per-bucket result back to per-element positions for ``gather`` /
+    arithmetic broadcasting.
+
+    Ports ``torch_scatter/utils.py:broadcast``.
+    """
+    if src.dim() == 1:
+        for _ in range(dim if dim >= 0 else other.dim() + dim):
+            src = src.unsqueeze(0)
+    while src.dim() < other.dim():
+        src = src.unsqueeze(-1)
+    return src.expand_as(other)
+
+
+def scatter(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic scatter dispatcher.
+
+    Routes to the typed scatter op based on :obj:`reduce`:
+    ``"sum"``/``"add"`` -> :func:`scatter_sum`,
+    ``"mul"`` -> :func:`scatter_mul`, ``"mean"`` -> :func:`scatter_mean`,
+    ``"min"`` -> :func:`scatter_min`, ``"max"`` -> :func:`scatter_max`.
+    Min/max return only the values.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return scatter_sum(src, index, dim, out, dim_size)
+    if reduce == 'mul':
+        return scatter_mul(src, index, dim, out, dim_size)
+    if reduce == 'mean':
+        return scatter_mean(src, index, dim, out, dim_size)
+    if reduce == 'min':
+        return scatter_min(src, index, dim, out, dim_size)[0]
+    if reduce == 'max':
+        return scatter_max(src, index, dim, out, dim_size)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def segment_coo(
+    src: Tensor,
+    index: Tensor,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic COO segment dispatcher.
+
+    Routes by :obj:`reduce` to the typed ``segment_*_coo`` op.
+    Min/max return only the value tensor.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return segment_sum_coo(src, index, out, dim_size)
+    if reduce == 'mean':
+        return segment_mean_coo(src, index, out, dim_size)
+    if reduce == 'min':
+        return segment_min_coo(src, index, out, dim_size)[0]
+    if reduce == 'max':
+        return segment_max_coo(src, index, out, dim_size)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def segment_csr(
+    src: Tensor,
+    indptr: Tensor,
+    out: Optional[Tensor] = None,
+    reduce: str = 'sum',
+) -> Tensor:
+    r"""Polymorphic CSR segment dispatcher.
+
+    Routes by :obj:`reduce` to the typed ``segment_*_csr`` op.
+    Min/max return only the value tensor.
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return segment_sum_csr(src, indptr, out)
+    if reduce == 'mean':
+        return segment_mean_csr(src, indptr, out)
+    if reduce == 'min':
+        return segment_min_csr(src, indptr, out)[0]
+    if reduce == 'max':
+        return segment_max_csr(src, indptr, out)[0]
+    raise ValueError(f'Unknown reduce: {reduce!r}')
+
+
+def scatter_softmax(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    dim_size: Optional[int] = None,
+) -> Tensor:
+    r"""Per-bucket softmax composite. Float inputs only."""
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_softmax requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    max_per_idx = scatter_max(src, index, dim, dim_size=dim_size)[0]
+    max_per_src = max_per_idx.gather(dim, _broadcast(index, src, dim))
+    recentered_exp = (src - max_per_src).exp()
+    sum_per_idx = scatter_sum(recentered_exp, index, dim, dim_size=dim_size)
+    sum_per_src = sum_per_idx.gather(dim, _broadcast(index, src, dim))
+    return recentered_exp / sum_per_src
+
+
+def scatter_log_softmax(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    dim_size: Optional[int] = None,
+    eps: float = 1e-12,
+) -> Tensor:
+    r"""Per-bucket log-softmax composite. Float inputs only."""
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_log_softmax requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    max_per_idx = scatter_max(src, index, dim, dim_size=dim_size)[0]
+    max_per_src = max_per_idx.gather(dim, _broadcast(index, src, dim))
+    recentered = src - max_per_src
+    sum_per_idx = scatter_sum(recentered.exp(), index, dim, dim_size=dim_size)
+    sum_per_src = sum_per_idx.gather(dim, _broadcast(index, src, dim))
+    return recentered - torch.log(sum_per_src + eps)
+
+
+def scatter_std(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    unbiased: bool = True,
+) -> Tensor:
+    r"""Per-bucket standard deviation composite. Float inputs only.
+
+    Ports ``torch_scatter.composite.scatter_std``: uses :func:`scatter_sum`
+    for both passes (avoids integer floor-division coupling that would
+    appear if :func:`scatter_mean` were used). Applies Bessel's correction
+    ``N / (N - 1)`` when :obj:`unbiased` is :obj:`True`.
+    """
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_std requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    if out is not None:
+        dim_size = out.size(dim)
+
+    bcast_index = _broadcast(index, src, dim)
+    ones = torch.ones_like(src)
+    count = scatter_sum(ones, bcast_index, dim, dim_size=dim_size)
+    sum_per_idx = scatter_sum(src, bcast_index, dim, dim_size=dim_size)
+    count_safe = count.clamp(min=1)
+    mean = sum_per_idx / count_safe
+
+    var = src - mean.gather(dim, bcast_index)
+    var = var * var
+    result = scatter_sum(var, bcast_index, dim, out, dim_size)
+    if unbiased:
+        denom = (count - 1).clamp(min=1)
+    else:
+        denom = count_safe
+    result = result / denom
+    return result.sqrt()
+
+
+def scatter_logsumexp(
+    src: Tensor,
+    index: Tensor,
+    dim: int = -1,
+    out: Optional[Tensor] = None,
+    dim_size: Optional[int] = None,
+    eps: float = 1e-12,
+) -> Tensor:
+    r"""Per-bucket log-sum-exp composite. Float inputs only.
+
+    Numerically stable: recenter by the per-bucket max before exponentiating.
+    When :obj:`out` is supplied, positions that ended up non-finite (empty
+    buckets that produced ``-inf``) are restored from the caller-supplied
+    ``out`` to preserve any caller-provided initial values.
+    """
+    if not src.is_floating_point():
+        raise ValueError(
+            'scatter_logsumexp requires a floating-point src tensor (got '
+            f'{src.dtype})',
+        )
+    if out is not None:
+        dim_size = out.size(dim)
+
+    # Allocate `max_value_per_index` filled with -inf so empty buckets stay
+    # at -inf and get masked back to 0 below.
+    size = list(src.size())
+    if dim_size is not None:
+        size[dim] = dim_size
+    elif index.numel() == 0:
+        size[dim] = 0
+    else:
+        size[dim] = int(index.max().item()) + 1
+    max_value_per_index = torch.full(
+        size,
+        float('-inf'),
+        dtype=src.dtype,
+        device=src.device,
+    )
+    scatter_max(src, index, dim, max_value_per_index, dim_size)
+
+    # `gather` only reads positions that appear in `index`, so empty-bucket
+    # slots in `max_value_per_index` (still -inf) are never read here.
+    max_per_src = max_value_per_index.gather(dim, _broadcast(index, src, dim))
+    recentered = src - max_per_src
+    # If src had inf or both src and max are -inf, recentered may be NaN.
+    recentered = torch.where(
+        torch.isnan(recentered),
+        torch.full_like(recentered, float('-inf')),
+        recentered,
+    )
+    sum_per_idx = scatter_sum(recentered.exp(), index, dim, dim_size=dim_size)
+
+    result = max_value_per_index + (sum_per_idx + eps).log()
+
+    if out is None:
+        # Empty buckets had max=-inf and sum=0, producing -inf + log(eps) =
+        # -inf. Map any non-finite output to 0 to match the upstream contract.
+        return result.nan_to_num(nan=0.0, posinf=0.0, neginf=0.0)
+
+    # `out=`: restore caller's value at positions that produced non-finite
+    # results (e.g. empty buckets).
+    orig_out = out.clone()
+    mask = ~torch.isfinite(result)
+    out.copy_(torch.where(mask, orig_out, result))
+    return out
+
+
 def spline_basis(
     pseudo: Tensor,
     kernel_size: Tensor,
@@ -1001,6 +1240,13 @@ __all__ = [
     'segment_min_csr',
     'segment_max_csr',
     'gather_csr',
+    'scatter',
+    'segment_coo',
+    'segment_csr',
+    'scatter_softmax',
+    'scatter_log_softmax',
+    'scatter_std',
+    'scatter_logsumexp',
     'spline_basis',
     'spline_weighting',
     'grid_cluster',

--- a/test/ops/test_composite.py
+++ b/test/ops/test_composite.py
@@ -1,0 +1,448 @@
+import math
+
+import pytest
+import torch
+
+import pyg_lib
+from pyg_lib.testing import withCUDA, withSeed
+
+# ---------------------------------------------------------------------------
+# Reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _broadcast_index(
+    index: torch.Tensor,
+    src: torch.Tensor,
+    dim: int,
+) -> torch.Tensor:
+    """Broadcasts a 1-D :obj:`index` to the shape of :obj:`src` along
+    :obj:`dim`. Mirrors the helper used elsewhere in the test suite.
+    """
+    if index.dim() == src.dim():
+        return index
+    if dim < 0:
+        dim = dim + src.dim()
+    size = [1] * src.dim()
+    size[dim] = -1
+    return index.view(size).expand_as(src)
+
+
+def _scatter_softmax_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+) -> torch.Tensor:
+    """Per-bucket softmax reference: max-recenter, exp, divide by per-bucket
+    sum. Reproduces the upstream ``torch_scatter.composite.scatter_softmax``
+    algorithm verbatim using plain PyTorch primitives.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    # Per-bucket max via ``scatter_reduce_(..., amax, include_self=False)``.
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = (src - max_per_src).exp()
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered,
+    )
+    return recentered / sum_per_idx.gather(dim, bcast_index)
+
+
+def _scatter_log_softmax_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    eps: float = 1e-12,
+) -> torch.Tensor:
+    """Per-bucket log-softmax reference: ``(src - max) - log(sum + eps)``."""
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = src - max_per_src
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered.exp(),
+    )
+    return recentered - (sum_per_idx + eps).log().gather(dim, bcast_index)
+
+
+def _scatter_std_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    unbiased: bool = True,
+) -> torch.Tensor:
+    """Per-bucket std reference matching upstream's two-pass scatter_sum
+    algorithm (used to avoid integer/float coupling). Bessel correction
+    ``N / (N - 1)`` applied when ``unbiased=True``.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    ones = torch.ones_like(src)
+    count = src.new_zeros(size).scatter_add_(dim, bcast_index, ones)
+    total = src.new_zeros(size).scatter_add_(dim, bcast_index, src)
+    mean = total / count.clamp(min=1)
+    diff = src - mean.gather(dim, bcast_index)
+    sq_sum = src.new_zeros(size).scatter_add_(dim, bcast_index, diff * diff)
+    denom = count.sub(1).clamp_(min=1) if unbiased else count.clamp(min=1)
+    return (sq_sum / (denom + 1e-6)).sqrt()
+
+
+def _scatter_logsumexp_ref(
+    src: torch.Tensor,
+    index: torch.Tensor,
+    dim: int = -1,
+    dim_size: int = None,
+    eps: float = 1e-12,
+) -> torch.Tensor:
+    """Numerically-stable per-bucket logsumexp reference:
+    ``max + log(sum(exp(src - max)) + eps)``. Empty buckets yield 0.
+    """
+    if dim < 0:
+        dim = dim + src.dim()
+    bcast_index = _broadcast_index(index, src, dim)
+    if dim_size is None:
+        dim_size = int(index.max().item()) + 1 if index.numel() > 0 else 0
+    size = list(src.size())
+    size[dim] = dim_size
+    max_per_idx = src.new_full(size, float('-inf')).scatter_reduce_(
+        dim,
+        bcast_index,
+        src,
+        reduce='amax',
+        include_self=False,
+    )
+    max_per_src = max_per_idx.gather(dim, bcast_index)
+    recentered = src - max_per_src
+    recentered = torch.where(
+        torch.isnan(recentered),
+        torch.full_like(recentered, float('-inf')),
+        recentered,
+    )
+    sum_per_idx = src.new_zeros(size).scatter_add_(
+        dim,
+        bcast_index,
+        recentered.exp(),
+    )
+    out = max_per_idx + (sum_per_idx + eps).log()
+    # Empty buckets: max == -inf -> nan_to_num to 0.
+    return torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_softmax — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_forward(device):
+    """Forward correctness against a pure-PyTorch max-recentered softmax."""
+    # Distinct random values per bucket avoid argmax ties.
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_softmax(src, index, dim=0)
+    expected = _scatter_softmax_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_normalizes_per_bucket(device):
+    """The per-bucket sum of the softmax must be 1 (or 0 for empty buckets)."""
+    src = torch.randn(10, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0, 2, 3], device=device)
+
+    out = pyg_lib.ops.scatter_softmax(src, index, dim=0, dim_size=4)
+    sums = torch.zeros(4, dtype=out.dtype, device=device).scatter_add_(
+        0,
+        index,
+        out,
+    )
+    torch.testing.assert_close(sums, torch.ones(4, device=device))
+
+
+@withCUDA
+@withSeed
+def test_scatter_softmax_backward_gradcheck(device):
+    """Gradcheck with distinct double-precision values so argmax never ties."""
+    # ``torch.randperm`` gives unique integers; scale + cast for double values.
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_softmax(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_softmax_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_softmax(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_log_softmax — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_forward(device):
+    """Forward correctness against a pure-PyTorch log-softmax reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+    expected = _scatter_log_softmax_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_matches_log_of_softmax(device):
+    """``log_softmax`` and ``log(softmax)`` should agree up to numerics."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    log_sm = pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+    sm = pyg_lib.ops.scatter_softmax(src, index, dim=0)
+    torch.testing.assert_close(log_sm, sm.log(), atol=1e-5, rtol=1e-5)
+
+
+@withCUDA
+@withSeed
+def test_scatter_log_softmax_backward_gradcheck(device):
+    """Gradcheck with distinct double-precision values so argmax never ties."""
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_log_softmax(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_log_softmax_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_log_softmax(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_std — forward + grad
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+@pytest.mark.parametrize('unbiased', [True, False])
+def test_scatter_std_forward(unbiased, device):
+    """Forward correctness against a pure-PyTorch per-bucket std reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_std(
+        src,
+        index,
+        dim=0,
+        unbiased=unbiased,
+    )
+    expected = _scatter_std_ref(src, index, dim=0, unbiased=unbiased)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+@pytest.mark.parametrize('unbiased', [True, False])
+def test_scatter_std_backward_gradcheck(unbiased, device):
+    """Gradcheck for the std composite. Uses distinct random values so no
+    degenerate single-element bucket has zero variance gradient ambiguity.
+    """
+    src = (
+        ((torch.randperm(8 * 3, device=device).to(torch.double) - 12) * 0.1)
+        .view(8, 3)
+        .requires_grad_(True)
+    )
+    # Every bucket gets at least two elements to avoid zero-variance cases.
+    index = torch.tensor([0, 1, 0, 1, 2, 2, 0, 1], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_std(s, index, dim=0, unbiased=unbiased)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_std_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_std(src, index, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# scatter_logsumexp — forward + numerical stability + ``out=`` path
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_forward(device):
+    """Forward correctness against a pure-PyTorch logsumexp reference."""
+    src = torch.randn(8, 4, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3, 2, 0], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0)
+    expected = _scatter_logsumexp_ref(src, index, dim=0)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_logsumexp_large_magnitude_stability(device):
+    """Stability test: very large positive values would overflow naive
+    ``log(sum(exp(...)))`` (``exp(1000)`` is ``inf``). The numerically-stable
+    implementation must produce finite, correct results.
+
+    Per-bucket logsumexp is ``max + log(count_exp_shifted)`` so for a bucket
+    with two equal entries at value ``v`` the result is ``v + log(2)``.
+    """
+    # Bucket 0: two entries at 1000.0 -> expect 1000 + log(2).
+    # Bucket 1: two entries at -1000.0 -> expect -1000 + log(2).
+    # Bucket 2: one entry at 5.0       -> expect 5.0 exactly.
+    src = torch.tensor(
+        [1000.0, 1000.0, -1000.0, -1000.0, 5.0],
+        device=device,
+    )
+    index = torch.tensor([0, 0, 1, 1, 2], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0)
+    # All entries must be finite.
+    assert torch.isfinite(out).all(), f'non-finite entries in {out}'
+    expected = torch.tensor(
+        [1000.0 + math.log(2.0), -1000.0 + math.log(2.0), 5.0],
+        device=device,
+    )
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-5)
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_empty_buckets_yield_zero(device):
+    """Empty buckets must produce 0 (upstream's ``nan_to_num_(neginf=0)``)."""
+    src = torch.randn(4, device=device)
+    # Buckets 1 and 3 receive no entries.
+    index = torch.tensor([0, 2, 0, 2], device=device)
+
+    out = pyg_lib.ops.scatter_logsumexp(src, index, dim=0, dim_size=4)
+    assert torch.isfinite(out).all()
+    assert out[1].item() == 0.0
+    assert out[3].item() == 0.0
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_out_restores_non_finite(device):
+    """``out=...`` non-finite restoration: empty buckets in the result must
+    be replaced by the corresponding pre-existing values in ``out``. Upstream
+    ``scatter_logsumexp.py`` keeps ``orig_out`` and copies it into positions
+    where the final result is non-finite.
+    """
+    src = torch.tensor([1.0, 2.0, 3.0], device=device)
+    # Only bucket 0 receives entries; buckets 1, 2 are empty.
+    index = torch.tensor([0, 0, 0], device=device)
+
+    # Pre-fill ``out`` with sentinel values that must be preserved at the
+    # empty-bucket positions.
+    sentinel = torch.tensor([-999.0, 42.0, -7.0], device=device)
+    out = sentinel.clone()
+    result = pyg_lib.ops.scatter_logsumexp(src, index, dim=0, out=out)
+
+    # Bucket 0 is non-empty -> logsumexp result (not sentinel).
+    expected_0 = torch.tensor([1.0, 2.0, 3.0], device=device).logsumexp(0)
+    # Loose tolerance because of the +eps inside the log.
+    assert abs(result[0].item() - expected_0.item()) < 1e-4
+    # Buckets 1 and 2 are empty -> sentinel values restored from original out.
+    assert result[1].item() == 42.0
+    assert result[2].item() == -7.0
+
+
+@withCUDA
+@withSeed
+def test_scatter_logsumexp_backward_gradcheck(device):
+    """Gradcheck on logsumexp. Uses scaled distinct values so the max within
+    each bucket is unambiguous (no tied argmax that would break finite
+    differencing).
+    """
+    src = (
+        ((torch.randperm(6 * 3, device=device).to(torch.double) - 9) * 0.1)
+        .view(6, 3)
+        .requires_grad_(True)
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 2], device=device)
+
+    def fn(s):
+        return pyg_lib.ops.scatter_logsumexp(s, index, dim=0)
+
+    assert torch.autograd.gradcheck(fn, (src,))
+
+
+@withCUDA
+def test_scatter_logsumexp_rejects_integer_input(device):
+    """Integer ``src`` must raise a clear error (upstream behavior)."""
+    src = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+    index = torch.tensor([0, 0, 1, 1], device=device)
+    with pytest.raises((ValueError, TypeError)):
+        pyg_lib.ops.scatter_logsumexp(src, index, dim=0)

--- a/test/ops/test_scatter.py
+++ b/test/ops/test_scatter.py
@@ -1717,3 +1717,64 @@ def test_scatter_max_backward_gradcheck_with_dim_size(device):
         return pyg_lib.ops.scatter_max(s, index, dim=-1, dim_size=6)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# scatter dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mul', 'mean', 'min', 'max'],
+)
+def test_scatter_dispatcher(reduce, device):
+    """``scatter(src, index, dim, out, dim_size, reduce=...)`` must route to
+    the corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Uses a unique-valued ``src`` so argindex tie-breaks are deterministic
+    and ``min``/``max`` value outputs compare exactly across devices.
+    """
+    torch.manual_seed(0)
+    src = (torch.randperm(6 * 3, device=device).to(torch.float64) - 9).view(
+        6,
+        3,
+    )
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter(src, index, dim=0, dim_size=4, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.scatter_sum(src, index, dim=0, dim_size=4)
+    elif reduce == 'mul':
+        expected = pyg_lib.ops.scatter_mul(src, index, dim=0, dim_size=4)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.scatter_mean(src, index, dim=0, dim_size=4)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.scatter_min(src, index, dim=0, dim_size=4)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.scatter_max(src, index, dim=0, dim_size=4)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_scatter_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(6, 3, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.scatter(src, index, dim=0, reduce='unsupported')
+
+
+@withCUDA
+def test_scatter_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(6, 3, device=device)
+    index = torch.tensor([0, 1, 0, 1, 1, 3], device=device)
+
+    out = pyg_lib.ops.scatter(src, index, dim=0)
+    expected = pyg_lib.ops.scatter_sum(src, index, dim=0)
+    torch.testing.assert_close(out, expected)

--- a/test/ops/test_segment_coo.py
+++ b/test/ops/test_segment_coo.py
@@ -1457,3 +1457,63 @@ def test_segment_max_coo_backward_empty_input(device):
     assert src.grad is not None
     assert src.grad.size() == src.size()
     torch.testing.assert_close(src.grad, torch.zeros_like(src))
+
+
+# ---------------------------------------------------------------------------
+# segment_coo dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mean', 'min', 'max'],
+)
+def test_segment_coo_dispatcher(reduce, device):
+    """``segment_coo(src, index, out, dim_size, reduce=...)`` must route to
+    the corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Note: there is no ``segment_mul_coo``, so ``mul`` is not part of the
+    valid reduce set for this dispatcher.
+    """
+    torch.manual_seed(0)
+    # Unique values -> deterministic argindex tie-break across devices.
+    src = (torch.randperm(8 * 3, device=device).to(torch.float64) - 12).view(
+        8,
+        3,
+    )
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_coo(src, index, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.segment_sum_coo(src, index)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.segment_mean_coo(src, index)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.segment_min_coo(src, index)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.segment_max_coo(src, index)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_coo_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(8, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.segment_coo(src, index, reduce='unsupported')
+
+
+@withCUDA
+def test_segment_coo_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(8, 3, device=device)
+    index = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3], device=device)
+
+    out = pyg_lib.ops.segment_coo(src, index)
+    expected = pyg_lib.ops.segment_sum_coo(src, index)
+    torch.testing.assert_close(out, expected)

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1299,3 +1299,63 @@ def test_segment_max_csr_backward_gradcheck_empty_rows(device):
         return pyg_lib.ops.segment_max_csr(s, indptr)[0]
 
     assert torch.autograd.gradcheck(fn, (src,))
+
+
+# ---------------------------------------------------------------------------
+# segment_csr dispatcher (commit 14 — Python layer)
+# ---------------------------------------------------------------------------
+
+
+@withCUDA
+@pytest.mark.parametrize(
+    'reduce',
+    ['sum', 'add', 'mean', 'min', 'max'],
+)
+def test_segment_csr_dispatcher(reduce, device):
+    """``segment_csr(src, indptr, out, reduce=...)`` must route to the
+    corresponding typed op. For ``min``/``max`` the dispatcher returns
+    ``[0]`` (value only), not the ``(value, argindex)`` tuple.
+
+    Note: there is no ``segment_mul_csr``, so ``mul`` is not part of the
+    valid reduce set for this dispatcher.
+    """
+    torch.manual_seed(0)
+    # Unique values -> deterministic argindex tie-break across devices.
+    src = (torch.randperm(8 * 3, device=device).to(torch.float64) - 12).view(
+        8,
+        3,
+    )
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_csr(src, indptr, reduce=reduce)
+    if reduce in ('sum', 'add'):
+        expected = pyg_lib.ops.segment_sum_csr(src, indptr)
+    elif reduce == 'mean':
+        expected = pyg_lib.ops.segment_mean_csr(src, indptr)
+    elif reduce == 'min':
+        expected = pyg_lib.ops.segment_min_csr(src, indptr)[0]
+    elif reduce == 'max':
+        expected = pyg_lib.ops.segment_max_csr(src, indptr)[0]
+    assert isinstance(out, torch.Tensor)
+    torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+def test_segment_csr_dispatcher_unknown_reduce_raises(device):
+    """The dispatcher must reject unknown reduce strings with a clear error."""
+    src = torch.randn(8, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+    with pytest.raises(ValueError):
+        pyg_lib.ops.segment_csr(src, indptr, reduce='unsupported')
+
+
+@withCUDA
+def test_segment_csr_dispatcher_default_reduce_is_sum(device):
+    """Default ``reduce`` is ``"sum"`` (upstream convention)."""
+    torch.manual_seed(0)
+    src = torch.randn(8, 3, device=device)
+    indptr = torch.tensor([0, 3, 5, 6, 8], device=device)
+
+    out = pyg_lib.ops.segment_csr(src, indptr)
+    expected = pyg_lib.ops.segment_sum_csr(src, indptr)
+    torch.testing.assert_close(out, expected)


### PR DESCRIPTION
Final commit of the pytorch_scatter port. Pure-Python public API on top
of the typed C++ ops:

- `_broadcast(src, other, dim)` — unsqueeze + expand helper used by
  composites that need to lift a 1-D per-bucket result back to per-element
  positions for `gather` / arithmetic broadcasting.
- `scatter`, `segment_coo`, `segment_csr` — polymorphic dispatchers that
  route on a `reduce` string. Min/max return only the value tensor (drop
  the argindex), matching upstream's polymorphic API.
- `scatter_softmax`, `scatter_log_softmax` — max-recentered numerically
  stable per-bucket (log-)softmax.
- `scatter_std` — per-bucket standard deviation. Uses `scatter_sum` for
  both passes (avoids integer floor-division coupling) and Bessel's
  correction when `unbiased=True`.
- `scatter_logsumexp` — numerically stable per-bucket log-sum-exp. Empty
  buckets produce -inf inside the algorithm; `nan_to_num` maps them to 0
  when `out=None`, and the caller's `out` values are restored at
  non-finite positions when `out=` is supplied.

All composites reject non-float inputs with a clear ValueError.
