### PR TITLE
Fix Windows `cu130` build for PyTorch 2.10/2.11 (`small` macro collision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the Windows + CUDA 13.0 (`cu130`) build for PyTorch 2.10/2.11 by defining `WIN32_LEAN_AND_MEAN`, which prevents the Windows `#define small char` macro from colliding with PyTorch's `CUDACachingAllocator.h` ([#672](https://github.com/pyg-team/pyg-lib/pull/672))
 - Fixed build with `clang++` by upgrading `cuCollections` and `cccl` submodules ([#645](https://github.com/pyg-team/pyg-lib/pull/645))
 
 ### Security

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.18)
 project(pyg)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(WIN32)
+  # The Windows SDK's <rpcndr.h> (pulled in by <windows.h>) does
+  # `#define small char`, which collides with the parameter named `small` in
+  # PyTorch 2.10/2.11's c10/cuda/CUDACachingAllocator.h::StreamSegmentSize ctor
+  # (renamed to `small_` in 2.12). CUDA 13's headers newly drag <windows.h> into
+  # our .cu translation units, so nvcc 13 sees `bool char` and fails to parse the
+  # header. WIN32_LEAN_AND_MEAN stops <windows.h> from pulling in the RPC headers
+  # that define `small`, fixing the cu130 build for PyTorch 2.10/2.11.
+  add_compile_definitions(WIN32_LEAN_AND_MEAN)
+endif()
+
 set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
 set(PYG_VERSION 0.7.0)
 set(NO_METIS 0)


### PR DESCRIPTION
## Problem

Windows `cu130` wheel builds fail for PyTorch **2.10/2.11** (nightly red since 2026-05-19):

```
CUDACachingAllocator.h: error: invalid combination of type specifiers
    StreamSegmentSize(cudaStream_t s, bool char , size_t sz)
                                           ^
```

The source says `bool small`, but the Windows SDK's `<rpcndr.h>` (via `<windows.h>`) does `#define small char`. CUDA 13's headers newly pull `<windows.h>` into our `.cu` TUs, so nvcc sees `bool char`. PyTorch fixed this upstream in 2.12 by renaming the param `small` → `small_`; 2.9/2.12 and `cu126`/`cu128` are unaffected, which matches the exact failure set.

## Fix

Define `WIN32_LEAN_AND_MEAN`, so `<windows.h>` skips the RPC headers that define `small`.

## Verification

CI build + install + tests pass for torch **2.10.0 / 2.11.0 / 2.12.0** + `cu130` on Windows: https://github.com/pyg-team/pyg-lib/actions/runs/26854853032