### PR TITLE
Migrate type checking to ty

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           uv pip install ty pytest
           uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip install scipy torch-geometric triton
 
       - name: Check type hints
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,6 +31,5 @@ jobs:
           uv pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Check type hints
-        continue-on-error: true
         run: |
           ty check --output-format github

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install ty pytest
+          uv pip install ty pytest scipy torch-geometric
           uv pip install torch --index-url https://download.pytorch.org/whl/cpu
-          uv pip install scipy torch-geometric triton
 
       - name: Check type hints
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Check type hints
         run: |
-          ty check --output-format github
+          ty check --output-format github --error all

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install ty pytest scipy torch-geometric
-          uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip install torch==2.12.0 --torch-backend cpu
 
       - name: Check type hints
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
 
-  mypy:
+  ty:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -26,9 +26,11 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv pip install mypy
+        run: |
+          uv pip install ty pytest
+          uv pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Check type hints
         continue-on-error: true
         run: |
-          mypy --install-types --non-interactive
+          ty check --output-format github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrated Python type checking from `mypy` to `ty` ([#678](https://github.com/pyg-team/pyg-lib/pull/678))
+
 ### Deprecated
 
 ### Removed

--- a/pyg_lib/__init__.py
+++ b/pyg_lib/__init__.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.machinery
 import os
 import os.path as osp
 import warnings

--- a/pyg_lib/_triton.py
+++ b/pyg_lib/_triton.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+triton: Any
+tl: Any
+
 try:
     import triton as _triton
     import triton.language as _tl
@@ -40,8 +43,9 @@ except ImportError:
     class TL:
         constexpr = Any
 
-    _triton = Triton()
-    _tl = TL()
+    triton = Triton()
+    tl = TL()
 
-triton: Any = _triton
-tl: Any = _tl
+else:
+    triton = _triton
+    tl = _tl

--- a/pyg_lib/_triton.py
+++ b/pyg_lib/_triton.py
@@ -1,51 +1,24 @@
 from typing import Any
 
-triton: Any
-tl: Any
+TRITON_ERROR = (
+    "'triton' required. Please install the missing dependency via "
+    '`pip install -U triton`.'
+)
 
-try:
-    import triton as _triton  # ty: ignore[unresolved-import]
-    import triton.language as _tl  # ty: ignore[unresolved-import]
 
-    major_triton_version = int(_triton.__version__.split('.')[0])
-    if major_triton_version < 2:
-        raise ImportError("'triton>=2.0.0' required")
+def load_triton() -> tuple[Any, Any]:
+    try:
+        import triton  # ty: ignore[unresolved-import]
+        import triton.language as tl  # ty: ignore[unresolved-import]
+    except ImportError as e:
+        raise ImportError(TRITON_ERROR) from e
 
-except ImportError:
+    return triton, tl
 
-    class TritonJit:
-        def __init__(self, func_name: str):
-            self.func_name = func_name
 
-        def report_error(self):
-            raise ValueError(
-                f"Could not compile function '{self.func_name}' "
-                f"since 'triton>=2.0.0' dependency was not "
-                f'found. Please install the missing dependency '
-                f'via `pip install -U -pre triton`.',
-            )
-
-        def __call__(self, *args, **kwargs):
-            self.report_error()
-
-        def __getitem__(self, *args, **kwargs):
-            self.report_error()
-
-    class Triton:
-        @staticmethod
-        def jit(func):
-            return TritonJit(func.__name__)
-
-        @staticmethod
-        def cdiv(*args, **kwargs):
-            raise ValueError("'triton>=2.0.0' required")
-
-    class TL:
-        constexpr = Any
-
-    triton = Triton()
-    tl = TL()
-
-else:
-    triton = _triton
-    tl = _tl
+def has_triton() -> bool:
+    try:
+        load_triton()
+    except ImportError:
+        return False
+    return True

--- a/pyg_lib/_triton.py
+++ b/pyg_lib/_triton.py
@@ -4,8 +4,8 @@ triton: Any
 tl: Any
 
 try:
-    import triton as _triton
-    import triton.language as _tl
+    import triton as _triton  # ty: ignore[unresolved-import]
+    import triton.language as _tl  # ty: ignore[unresolved-import]
 
     major_triton_version = int(_triton.__version__.split('.')[0])
     if major_triton_version < 2:

--- a/pyg_lib/_triton.py
+++ b/pyg_lib/_triton.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 try:
-    import triton
-    import triton.language as tl
+    import triton as _triton
+    import triton.language as _tl
 
-    major_triton_version = int(triton.__version__.split('.')[0])
+    major_triton_version = int(_triton.__version__.split('.')[0])
     if major_triton_version < 2:
         raise ImportError("'triton>=2.0.0' required")
 
@@ -28,8 +28,20 @@ except ImportError:
         def __getitem__(self, *args, **kwargs):
             self.report_error()
 
-    triton = type('triton', (object,), {})()
-    triton.jit = lambda func: TritonJit(func.__name__)
+    class Triton:
+        @staticmethod
+        def jit(func):
+            return TritonJit(func.__name__)
 
-    tl = type('tl', (object,), {})()
-    tl.constexpr = Any
+        @staticmethod
+        def cdiv(*args, **kwargs):
+            raise ValueError("'triton>=2.0.0' required")
+
+    class TL:
+        constexpr = Any
+
+    _triton = Triton()
+    _tl = TL()
+
+triton: Any = _triton
+tl: Any = _tl

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -1,8 +1,15 @@
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 import torch.utils._pytree as pytree
 from torch import Tensor
+
+if TYPE_CHECKING:
+    from typing_extensions import override
+else:
+
+    def override(func):
+        return func
 
 
 def _pytreeify(cls):
@@ -62,6 +69,7 @@ def _pytreeify(cls):
 @_pytreeify
 class GroupedMatmul(torch.autograd.Function):
     @staticmethod
+    @override
     def forward(ctx, args: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]:
         ctx.save_for_backward(*args)
 
@@ -77,6 +85,7 @@ class GroupedMatmul(torch.autograd.Function):
         return tuple(outs)
 
     @staticmethod
+    @override
     def backward(ctx, *outs_grad: Tensor) -> Tuple[Optional[Tensor], ...]:
         args = ctx.saved_tensors
         inputs: List[Tensor] = [x for x in args[: int(len(outs_grad))]]

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -29,7 +29,7 @@ def _pytreeify(cls):
         return pytree.tree_unflatten(flat_out, out_struct_holder[0])
 
     def new_forward(ctx, struct, out_struct_holder, *flat_inputs):
-        inputs = pytree.tree_unflatten(flat_inputs, struct)
+        inputs = pytree.tree_unflatten(list(flat_inputs), struct)
 
         out = orig_fw(ctx, *inputs)
 
@@ -40,7 +40,10 @@ def _pytreeify(cls):
         return tuple(flat_out)
 
     def new_backward(ctx, *flat_grad_outputs):
-        outs_grad = pytree.tree_unflatten(flat_grad_outputs, ctx._out_struct)
+        outs_grad = pytree.tree_unflatten(
+            list(flat_grad_outputs),
+            ctx._out_struct,
+        )
         if not isinstance(outs_grad, tuple):
             outs_grad = (outs_grad,)
 
@@ -316,7 +319,7 @@ def index_sort(
         A tuple containing sorted values and indices of the elements in the
         original :obj:`input` tensor.
     """
-    if not inputs.is_cpu:
+    if inputs.device.type != 'cpu':
         return torch.sort(inputs)
     return torch.ops.pyg.index_sort(inputs, max_value)
 

--- a/pyg_lib/ops/__init__.py
+++ b/pyg_lib/ops/__init__.py
@@ -59,7 +59,7 @@ def _pytreeify(cls):
 @_pytreeify
 class GroupedMatmul(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, args: Tuple[Tensor]) -> Tuple[Tensor]:
+    def forward(ctx, args: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]:
         ctx.save_for_backward(*args)
 
         inputs: List[Tensor] = [x for x in args[: int(len(args) / 2)]]
@@ -74,24 +74,24 @@ class GroupedMatmul(torch.autograd.Function):
         return tuple(outs)
 
     @staticmethod
-    def backward(ctx, *outs_grad: Tuple[Tensor]) -> Tuple[Tensor]:
+    def backward(ctx, *outs_grad: Tensor) -> Tuple[Optional[Tensor], ...]:
         args = ctx.saved_tensors
         inputs: List[Tensor] = [x for x in args[: int(len(outs_grad))]]
         others: List[Tensor] = [other for other in args[int(len(outs_grad)) :]]
 
-        inputs_grad = []
+        inputs_grad: List[Optional[Tensor]] = []
         if any([x.requires_grad for x in inputs]):
             others = [other.t() for other in others]
-            inputs_grad = torch.ops.pyg.grouped_matmul(outs_grad, others)
+            inputs_grad = list(torch.ops.pyg.grouped_matmul(outs_grad, others))
         else:
-            inputs_grad = [None for i in range(len(outs_grad))]
+            inputs_grad = [None for _ in range(len(outs_grad))]
 
-        others_grad = []
+        others_grad: List[Optional[Tensor]] = []
         if any([other.requires_grad for other in others]):
             inputs = [x.t() for x in inputs]
-            others_grad = torch.ops.pyg.grouped_matmul(inputs, outs_grad)
+            others_grad = list(torch.ops.pyg.grouped_matmul(inputs, outs_grad))
         else:
-            others_grad = [None for i in range(len(outs_grad))]
+            others_grad = [None for _ in range(len(outs_grad))]
 
         return tuple(inputs_grad + others_grad)
 

--- a/pyg_lib/ops/_scatter_reduce_triton.py
+++ b/pyg_lib/ops/_scatter_reduce_triton.py
@@ -1,0 +1,114 @@
+from typing import Tuple
+
+from torch import Tensor
+
+from pyg_lib._triton import load_triton
+
+triton, tl = load_triton()
+
+
+@triton.jit
+def _fused_scatter_reduce_forward_kernel(
+    inputs_ptr,
+    index_ptr,
+    out_ptr,
+    num_feats,
+    num_reductions,
+    numel,
+    REDUCE0,
+    REDUCE1,
+    REDUCE2,
+    REDUCE3,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    inputs = tl.load(inputs_ptr + offsets, mask=mask)
+
+    index_offsets = offsets // num_feats
+    index = tl.load(index_ptr + index_offsets, mask=mask)
+
+    # NOTE Triton does not support for-loops. As such, we cap the maximum
+    # number of fused operations to `4` and unroll the loop.
+    # TODO (matthias) Try to clean this up.
+
+    if REDUCE0 > 0:
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (offsets % num_feats)
+        if REDUCE0 == 1:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE0 == 2:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE0 == 3:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE0 == 4:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+
+    if REDUCE1 > 0:
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + num_feats
+        out_offsets = out_offsets + (offsets % num_feats)
+        if REDUCE1 == 1:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE1 == 2:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE1 == 3:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE1 == 4:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+
+    if REDUCE2 > 0:
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (2 * num_feats)
+        out_offsets = out_offsets + (offsets % num_feats)
+        if REDUCE2 == 1:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE2 == 2:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE2 == 3:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE2 == 4:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+
+    if REDUCE3 > 0:
+        out_offsets = (num_feats * num_reductions) * index
+        out_offsets = out_offsets + (3 * num_feats)
+        out_offsets = out_offsets + (offsets % num_feats)
+        if REDUCE3 == 1:  # sum
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE3 == 2:  # mean
+            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE3 == 3:  # min
+            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
+        elif REDUCE3 == 4:  # max
+            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
+
+
+def fused_scatter_reduce_forward(
+    inputs: Tensor,
+    index: Tensor,
+    out: Tensor,
+    num_feats: int,
+    num_reductions: int,
+    reduce_ids: Tuple[int, int, int, int],
+) -> None:
+    grid = lambda meta: (  # noqa: E731
+        triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']),
+    )
+
+    _fused_scatter_reduce_forward_kernel[grid](
+        inputs,
+        index,
+        out,
+        num_feats,
+        num_reductions,
+        inputs.numel(),
+        reduce_ids[0],
+        reduce_ids[1],
+        reduce_ids[2],
+        reduce_ids[3],
+        BLOCK_SIZE=256,
+    )

--- a/pyg_lib/ops/scatter_reduce.py
+++ b/pyg_lib/ops/scatter_reduce.py
@@ -3,93 +3,11 @@ from typing import List
 
 from torch import Tensor
 
-from pyg_lib._triton import tl, triton
-
 REDUCTIONS = ['sum', 'mean', 'min', 'max']
 NUM_REDUCTIONS = len(REDUCTIONS)
 NONE = 'none'
 
 OPT_REDUCTIONS = [NONE] + REDUCTIONS
-
-
-@triton.jit
-def _fused_scatter_reduce_forward_kernel(
-    inputs_ptr,
-    index_ptr,
-    out_ptr,
-    num_feats,
-    num_reductions,
-    numel,
-    REDUCE0,
-    REDUCE1,
-    REDUCE2,
-    REDUCE3,
-    BLOCK_SIZE: tl.constexpr,
-):
-    pid = tl.program_id(axis=0)
-    block_start = pid * BLOCK_SIZE
-
-    offsets = block_start + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < numel
-    inputs = tl.load(inputs_ptr + offsets, mask=mask)
-
-    index_offsets = offsets // num_feats
-    index = tl.load(index_ptr + index_offsets, mask=mask)
-
-    # NOTE Triton does not support for-loops. As such, we cap the maximum
-    # number of fused operations to `4` and unroll the loop.
-    # TODO (matthias) Try to clean this up.
-
-    if REDUCE0 > 0:
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (offsets % num_feats)
-        if REDUCE0 == 1:  # sum
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE0 == 2:  # mean
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE0 == 3:  # min
-            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE0 == 4:  # max
-            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
-
-    if REDUCE1 > 0:
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + num_feats
-        out_offsets = out_offsets + (offsets % num_feats)
-        if REDUCE1 == 1:  # sum
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE1 == 2:  # mean
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE2 == 3:  # min
-            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE3 == 4:  # max
-            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
-
-    if REDUCE2 > 0:
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (2 * num_feats)
-        out_offsets = out_offsets + (offsets % num_feats)
-        if REDUCE2 == 1:  # sum
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE2 == 2:  # mean
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE2 == 3:  # min
-            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE2 == 4:  # max
-            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
-
-    if REDUCE3 > 0:
-        out_offsets = (num_feats * num_reductions) * index
-        out_offsets = out_offsets + (3 * num_feats)
-        out_offsets = out_offsets + (offsets % num_feats)
-        if REDUCE3 == 1:  # sum
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE3 == 2:  # mean
-            tl.atomic_add(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE3 == 3:  # min
-            tl.atomic_min(out_ptr + out_offsets, inputs, mask=mask)
-        elif REDUCE3 == 4:  # max
-            tl.atomic_max(out_ptr + out_offsets, inputs, mask=mask)
 
 
 def fused_scatter_reduce(
@@ -146,22 +64,20 @@ def fused_scatter_reduce(
 
     # TODO (matthias) Do not compute "sum" and "mean" reductions twice.
 
-    grid = lambda meta: (  # noqa: E731
-        triton.cdiv(inputs.numel(), meta['BLOCK_SIZE']),
-    )
+    from pyg_lib.ops._scatter_reduce_triton import fused_scatter_reduce_forward
 
-    _fused_scatter_reduce_forward_kernel[grid](
+    fused_scatter_reduce_forward(
         inputs,
         index,
         out,
         num_feats,
         num_reductions,
-        inputs.numel(),
-        OPT_REDUCTIONS.index(reduce_list[0]),
-        OPT_REDUCTIONS.index(reduce_list[1]),
-        OPT_REDUCTIONS.index(reduce_list[2]),
-        OPT_REDUCTIONS.index(reduce_list[3]),
-        BLOCK_SIZE=256,
+        (
+            OPT_REDUCTIONS.index(reduce_list[0]),
+            OPT_REDUCTIONS.index(reduce_list[1]),
+            OPT_REDUCTIONS.index(reduce_list[2]),
+            OPT_REDUCTIONS.index(reduce_list[3]),
+        ),
     )
 
     # Post-processing:

--- a/pyg_lib/sampler/__init__.py
+++ b/pyg_lib/sampler/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, cast
 
 import torch
 from torch import Tensor
@@ -140,54 +140,75 @@ def hetero_neighbor_sample(
     TO_REL_TYPE = {key: '__'.join(key) for key in edge_types}
     TO_EDGE_TYPE = {'__'.join(key): key for key in edge_types}
 
-    rowptr_dict = {TO_REL_TYPE[k]: v for k, v in rowptr_dict.items()}
-    col_dict = {TO_REL_TYPE[k]: v for k, v in col_dict.items()}
-    num_neighbors_dict = {
+    rel_rowptr_dict = {TO_REL_TYPE[k]: v for k, v in rowptr_dict.items()}
+    rel_col_dict = {TO_REL_TYPE[k]: v for k, v in col_dict.items()}
+    rel_num_neighbors_dict = {
         TO_REL_TYPE[k]: v for k, v in num_neighbors_dict.items()
     }
+    rel_edge_time_dict = None
     if edge_time_dict is not None:
-        edge_time_dict = {TO_REL_TYPE[k]: v for k, v in edge_time_dict.items()}
+        rel_edge_time_dict = {
+            TO_REL_TYPE[k]: v for k, v in edge_time_dict.items()
+        }
+    rel_edge_weight_dict = None
     if edge_weight_dict is not None:
-        edge_weight_dict = {
+        rel_edge_weight_dict = {
             TO_REL_TYPE[k]: v for k, v in edge_weight_dict.items()
         }
 
-    out = torch.ops.pyg.hetero_neighbor_sample(
-        node_types,
-        edge_types,
-        rowptr_dict,
-        col_dict,
-        seed_dict,
-        num_neighbors_dict,
-        node_time_dict,
-        edge_time_dict,
-        seed_time_dict,
-        edge_weight_dict,
-        csc,
-        replace,
-        directed,
-        disjoint,
-        temporal_strategy,
-        return_edge_id,
+    out = cast(
+        Tuple[
+            Dict[RelType, Tensor],
+            Dict[RelType, Tensor],
+            Dict[NodeType, Tensor],
+            Optional[Dict[RelType, Tensor]],
+            Dict[NodeType, List[int]],
+            Dict[RelType, List[int]],
+        ],
+        torch.ops.pyg.hetero_neighbor_sample(
+            node_types,
+            edge_types,
+            rel_rowptr_dict,
+            rel_col_dict,
+            seed_dict,
+            rel_num_neighbors_dict,
+            node_time_dict,
+            rel_edge_time_dict,
+            seed_time_dict,
+            rel_edge_weight_dict,
+            csc,
+            replace,
+            directed,
+            disjoint,
+            temporal_strategy,
+            return_edge_id,
+        ),
     )
 
     (
-        row_dict,
-        col_dict,
+        rel_row_dict,
+        rel_col_dict,
         node_id_dict,
-        edge_id_dict,
+        rel_edge_id_dict,
         num_nodes_per_hop_dict,
-        num_edges_per_hop_dict,
+        rel_num_edges_per_hop_dict,
     ) = out
 
-    row_dict = {TO_EDGE_TYPE[k]: v for k, v in row_dict.items()}
-    col_dict = {TO_EDGE_TYPE[k]: v for k, v in col_dict.items()}
+    row_dict: Dict[EdgeType, Tensor] = {
+        TO_EDGE_TYPE[k]: v for k, v in rel_row_dict.items()
+    }
+    col_dict: Dict[EdgeType, Tensor] = {
+        TO_EDGE_TYPE[k]: v for k, v in rel_col_dict.items()
+    }
 
-    if edge_id_dict is not None:
-        edge_id_dict = {TO_EDGE_TYPE[k]: v for k, v in edge_id_dict.items()}
+    edge_id_dict = None
+    if rel_edge_id_dict is not None:
+        edge_id_dict = {
+            TO_EDGE_TYPE[k]: v for k, v in rel_edge_id_dict.items()
+        }
 
-    num_edges_per_hop_dict = {
-        TO_EDGE_TYPE[k]: v for k, v in num_edges_per_hop_dict.items()
+    num_edges_per_hop_dict: Dict[EdgeType, List[int]] = {
+        TO_EDGE_TYPE[k]: v for k, v in rel_num_edges_per_hop_dict.items()
     }
 
     return (

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -1,7 +1,6 @@
 import functools
 import os
 import os.path as osp
-from importlib.util import find_spec
 from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 import torch
@@ -35,8 +34,10 @@ def onlyCUDA(func: Callable) -> Callable:
 def onlyTriton(func: Callable) -> Callable:
     import pytest
 
+    from pyg_lib._triton import has_triton
+
     return pytest.mark.skipif(
-        find_spec('triton') is None,
+        not has_triton(),
         reason="'triton' not installed",
     )(func)
 

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -136,10 +136,8 @@ def get_ogb_mag_hetero_sparse_matrix(
 
     Returns:
         (Dict[Tuple[str, str, str], torch.Tensor],
-        Dict[Tuple[str, str, str], torch.Tensor], int, List,
-        List[Tuple[str, str, str]]): Compressed source node indices and target
-        node indices of the hetero sparse matrix, number of paper nodes,
-        all node types and all edge types.
+        Dict[Tuple[str, str, str], torch.Tensor]): Compressed source node
+        indices and target node indices of the hetero sparse matrix.
     """
     import torch_geometric.transforms as T
     from torch_geometric.datasets import OGB_MAG

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -2,7 +2,7 @@ import functools
 import os
 import os.path as osp
 from importlib.util import find_spec
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 import torch
 from torch import Tensor
@@ -140,11 +140,12 @@ def get_ogb_mag_hetero_sparse_matrix(
         indices and target node indices of the hetero sparse matrix.
     """
     import torch_geometric.transforms as T
+    from torch_geometric.data import HeteroData
     from torch_geometric.datasets import OGB_MAG
 
     path = osp.join(get_home_dir(), 'ogb-mag')
     transform = T.Compose([T.ToUndirected(), T.ToSparseTensor()])
-    data = OGB_MAG(path, pre_transform=transform)[0]
+    data = cast(HeteroData, OGB_MAG(path, pre_transform=transform)[0])
 
     colptr_dict: Dict[EdgeType, Tensor] = {}
     row_dict: Dict[EdgeType, Tensor] = {}

--- a/pyg_lib/testing.py
+++ b/pyg_lib/testing.py
@@ -9,6 +9,8 @@ from torch import Tensor
 
 from pyg_lib import get_home_dir
 
+EdgeType = Tuple[str, str, str]
+
 # Decorators ##################################################################
 
 
@@ -100,7 +102,7 @@ def get_sparse_matrix(
     if not osp.exists(path):
         os.makedirs(get_home_dir(), exist_ok=True)
 
-        import urllib
+        import urllib.request
 
         url = f'https://sparse.tamu.edu/mat/{group}/{name}.mat'
         print(f'Downloading {url}...', end='')
@@ -122,7 +124,7 @@ def get_sparse_matrix(
 def get_ogb_mag_hetero_sparse_matrix(
     dtype: torch.dtype = torch.long,
     device: Optional[torch.device] = None,
-) -> Tuple[Tensor, Tensor]:
+) -> Tuple[Dict[EdgeType, Tensor], Dict[EdgeType, Tensor]]:
     r"""Returns a heterogeneous graph :obj:`(colptr_dict, row_dict)`
     from the `OGB <https://ogb.stanford.edu/>`_ benchmark suite.
 
@@ -146,7 +148,8 @@ def get_ogb_mag_hetero_sparse_matrix(
     transform = T.Compose([T.ToUndirected(), T.ToSparseTensor()])
     data = OGB_MAG(path, pre_transform=transform)[0]
 
-    colptr_dict, row_dict = {}, {}
+    colptr_dict: Dict[EdgeType, Tensor] = {}
+    row_dict: Dict[EdgeType, Tensor] = {}
     for edge_type in data.edge_types:
         colptr, row, _ = data[edge_type].adj_t.csr()
         colptr_dict[edge_type] = colptr.to(device, dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,13 +84,6 @@ delocate-wheel \
 exclude-newer = "7 days"
 exclude-newer-package = { torch = "2099-01-01" }
 
-[tool.ty.analysis]
-allowed-unresolved-imports = [
-    "scipy.**",
-    "torch_geometric.**",
-    "triton.**",
-]
-
 [tool.ty.src]
 include = ["pyg_lib"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude-newer = "7 days"
 exclude-newer-package = { torch = "2099-01-01" }
 
 [tool.ty.analysis]
-replace-imports-with-any = [
+allowed-unresolved-imports = [
     "scipy.**",
     "torch_geometric.**",
     "triton.**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ test = [
 ]
 dev = [
     "pre-commit",
+    "pytest",
+    "ty",
 ]
 
 [tool.cibuildwheel]
@@ -81,6 +83,16 @@ delocate-wheel \
 [tool.uv]
 exclude-newer = "7 days"
 exclude-newer-package = { torch = "2099-01-01" }
+
+[tool.ty.analysis]
+replace-imports-with-any = [
+    "scipy.**",
+    "torch_geometric.**",
+    "triton.**",
+]
+
+[tool.ty.src]
+include = ["pyg_lib"]
 
 [tool.pytest.ini_options]
 addopts=[

--- a/test/test_triton.py
+++ b/test/test_triton.py
@@ -1,8 +1,11 @@
+import pytest
 import torch
 from torch import Tensor
 
-from pyg_lib._triton import tl, triton
-from pyg_lib.testing import onlyCUDA, onlyTriton
+from pyg_lib.testing import onlyCUDA
+
+triton = pytest.importorskip('triton')
+tl = pytest.importorskip('triton.language')
 
 
 @triton.jit
@@ -32,7 +35,6 @@ def add(x: Tensor, y: Tensor) -> Tensor:
 
 
 @onlyCUDA
-@onlyTriton
 def test_triton():
     x = torch.rand(100, device='cuda')
     y = torch.rand(100, device='cuda')


### PR DESCRIPTION
## Summary
- replace the soft mypy linting workflow with ty
- add ty project configuration scoped to pyg_lib
- fix package type diagnostics reported by ty

## Testing
- ty check --output-format github
- python -m ruff check pyg_lib/__init__.py pyg_lib/_triton.py pyg_lib/ops/__init__.py pyg_lib/sampler/__init__.py pyg_lib/testing.py
- python -m ruff format --check pyg_lib/__init__.py pyg_lib/_triton.py pyg_lib/ops/__init__.py pyg_lib/sampler/__init__.py pyg_lib/testing.py
- python -m flake8 --extend-ignore=E203 pyg_lib/__init__.py pyg_lib/_triton.py pyg_lib/ops/__init__.py pyg_lib/sampler/__init__.py pyg_lib/testing.py
- python -m py_compile pyg_lib/__init__.py pyg_lib/_triton.py pyg_lib/ops/__init__.py pyg_lib/sampler/__init__.py pyg_lib/testing.py