### PR TITLE
ci: test Linux aarch64 CPU wheels

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   wheel:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: read
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          bash ./.github/workflows/utils/build_linux.sh ${{ matrix.cuda-version }} ${{ matrix.python-version }} ${{ matrix.torch-version }}
+          bash ./.github/workflows/utils/build_linux.sh ${{ matrix.cuda-version }} ${{ matrix.python-version }} ${{ matrix.torch-version }} ${{ matrix.arch }}
 
       - name: Upload wheel (final)
         if: ${{ inputs.release-type == 'final' }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -57,7 +57,7 @@ jobs:
           # Set Linux matrix
           echo ::group::Set Linux matrix
           filename=".github/workflows/utils/${matrix_type}_matrix_linux.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][], "arch": (.["arch"] // ["x86_64"])[] }]' $filename)
           echo "matrix-linux=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-linux=$matrix"
           trigger=${{ contains(github.event.pull_request.labels.*.name, 'os: linux') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           # Set Linux matrix
           echo ::group::Set Linux matrix
           filename=".github/workflows/utils/full_matrix_linux.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][], "arch": (.["arch"] // ["x86_64"])[] }]' $filename)
           echo "matrix-linux=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-linux=$matrix"
           echo ::endgroup::

--- a/.github/workflows/utils/build_linux.sh
+++ b/.github/workflows/utils/build_linux.sh
@@ -4,15 +4,30 @@ set -ex
 CUDA_VERSION="${1:?Specify cuda version, e.g. cpu, cu130}"
 PYTHON_VERSION="${2:?Specify python version, e.g. 3.14}"
 TORCH_VERSION="${3:?Specify torch version, e.g. 2.11.0}"
+ARCH="${4:-x86_64}"
 echo "CUDA_VERSION: ${CUDA_VERSION}"
 echo "PYTHON_VERSION: ${PYTHON_VERSION//./}"
 echo "TORCH_VERSION: ${TORCH_VERSION}"
+echo "ARCH: ${ARCH}"
 
 source ./.github/workflows/cuda/Linux-env.sh ${CUDA_VERSION}
 echo "FORCE_CUDA: ${FORCE_CUDA}"
 echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}"
 
-export CIBW_BUILD="cp${PYTHON_VERSION//./}-manylinux_x86_64"
+case "${ARCH}" in
+  x86_64)
+    CIBW_MANYLINUX_IMAGE_VAR=CIBW_MANYLINUX_X86_64_IMAGE
+    ;;
+  aarch64)
+    CIBW_MANYLINUX_IMAGE_VAR=CIBW_MANYLINUX_AARCH64_IMAGE
+    ;;
+  *)
+    echo "Unsupported Linux architecture: ${ARCH}"
+    exit 1
+    ;;
+esac
+
+export CIBW_BUILD="cp${PYTHON_VERSION//./}-manylinux_${ARCH}"
 # pyg-lib doesn't have torch as a dependency, so we need to explicitly install it when running tests.
 if [[ "${TORCH_VERSION}" == "2.13.0" ]]; then
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${CUDA_VERSION}"
@@ -23,10 +38,14 @@ else
 fi
 
 if [[ "${CUDA_VERSION}" == "cu"* ]]; then
+  if [[ "${ARCH}" != "x86_64" ]]; then
+    echo "CUDA Linux wheels are not configured for ${ARCH} yet"
+    exit 1
+  fi
   # Use CUDA-pre-installed image
   export CIBW_MANYLINUX_X86_64_IMAGE=ghcr.io/pyg-team/pyg-lib/manylinux_2_28_x86_64:${CUDA_VERSION}
 else
-  export CIBW_MANYLINUX_X86_64_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+  export "${CIBW_MANYLINUX_IMAGE_VAR}=quay.io/pypa/manylinux_2_28_${ARCH}"
 fi
 
 rm -rf Testing pyg_lib/libpyg.so build dist outputs  # for local testing

--- a/.github/workflows/utils/full_matrix_linux.json
+++ b/.github/workflows/utils/full_matrix_linux.json
@@ -2,16 +2,37 @@
   {
     "torch-version": "2.12.0",
     "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
+    "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
+    "arch": ["x86_64"]
+  },
+  {
+    "torch-version": "2.12.0",
+    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+    "cuda-version": ["cpu"],
+    "arch": ["aarch64"]
   },
   {
     "torch-version": "2.11.0",
     "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
-    "cuda-version": ["cpu", "cu126", "cu128", "cu130"]
+    "cuda-version": ["cpu", "cu126", "cu128", "cu130"],
+    "arch": ["x86_64"]
+  },
+  {
+    "torch-version": "2.11.0",
+    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+    "cuda-version": ["cpu"],
+    "arch": ["aarch64"]
   },
   {
     "torch-version": "2.10.0",
     "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
-    "cuda-version": ["cpu", "cu126", "cu128", "cu130"]
+    "cuda-version": ["cpu", "cu126", "cu128", "cu130"],
+    "arch": ["x86_64"]
+  },
+  {
+    "torch-version": "2.10.0",
+    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+    "cuda-version": ["cpu"],
+    "arch": ["aarch64"]
   }
 ]

--- a/.github/workflows/utils/minimal_matrix_linux.json
+++ b/.github/workflows/utils/minimal_matrix_linux.json
@@ -2,11 +2,25 @@
   {
     "torch-version": "2.12.0",
     "python-version": ["3.10", "3.14"],
-    "cuda-version": ["cu132"]
+    "cuda-version": ["cu132"],
+    "arch": ["x86_64"]
+  },
+  {
+    "torch-version": "2.12.0",
+    "python-version": ["3.10", "3.14"],
+    "cuda-version": ["cpu"],
+    "arch": ["aarch64"]
   },
   {
     "torch-version": "2.10.0",
     "python-version": ["3.10", "3.14"],
-    "cuda-version": ["cu126"]
+    "cuda-version": ["cu126"],
+    "arch": ["x86_64"]
+  },
+  {
+    "torch-version": "2.10.0",
+    "python-version": ["3.10", "3.14"],
+    "cuda-version": ["cpu"],
+    "arch": ["aarch64"]
   }
 ]


### PR DESCRIPTION
This is an experimental CI change to validate Linux aarch64 CPU wheel builds. It adds an arch entry to the Linux wheel matrix, runs aarch64 jobs on GitHub hosted ARM runners, and leaves the existing x86_64 CUDA matrix unchanged.

CUDA/aarch64 combinations are intentionally out of scope for this PR; those can follow separately once the CPU-only path is validated.