### PR TITLE
Make all our wheels agnostic to Python versions

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install cibuildwheel auditwheel
+          uv pip install 'cibuildwheel>=4.0' auditwheel
 
       - name: Set version (final)
         if: ${{ inputs.release-type == 'final' }}

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          bash ./.github/workflows/utils/build_linux.sh ${{ matrix.cuda-version }} ${{ matrix.python-version }} ${{ matrix.torch-version }} ${{ matrix.arch }}
+          bash ./.github/workflows/utils/build_linux.sh ${{ matrix.cuda-version }} ${{ matrix.torch-version }} ${{ matrix.arch }}
 
       - name: Upload wheel (final)
         if: ${{ inputs.release-type == 'final' }}

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install cibuildwheel delocate
+          uv pip install 'cibuildwheel>=4.0' delocate
 
       - name: Set version (final)
         if: ${{ inputs.release-type == 'final' }}

--- a/.github/workflows/_build_macos.yml
+++ b/.github/workflows/_build_macos.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          bash ./.github/workflows/utils/build_macos.sh ${{ matrix.python-version }} ${{ matrix.torch-version }}
+          bash ./.github/workflows/utils/build_macos.sh ${{ matrix.torch-version }}
 
       - name: Upload wheel (final)
         if: ${{ inputs.release-type == 'final' }}
@@ -90,5 +90,5 @@ jobs:
         if: ${{ inputs.release-type == '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: wheel-macos-${{ matrix.python-version }}-${{ matrix.torch-version }}
+          name: wheel-macos-${{ matrix.torch-version }}
           path: dist/*.whl

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
         with:
-          python-version: ${{ matrix.python-version }}
+          # NOTE: This is used to run cibuildwheel, not to build the wheel.
+          python-version: '3.14'
           torch-version: ${{ matrix.torch-version }}
           cuda-version: ${{ matrix.cuda-version }}
 
@@ -60,26 +61,8 @@ jobs:
 
       - name: Build wheel
         run: |
-          source ./.github/workflows/cuda/Windows-env.sh ${{ matrix.cuda-version }}
-          echo $TORCH_CUDA_ARCH_LIST
-          uv pip install build
-          python -m build --wheel --no-isolation --outdir dist
-
-      - name: Install wheel
-        run: |
-          cd dist
-          ls -lah
-          uv pip install *.whl
-          python -c "import pyg_lib; print('pyg-lib:', pyg_lib.__version__)"
-          python -c "import pyg_lib; print('CUDA:', pyg_lib.cuda_version())"
-          python -c "import pyg_lib.ops"
-          python -c "import pyg_lib.sampler"
-          cd ..
-
-      - name: Test wheel
-        run: |
-          uv pip install pytest pytest-cov
-          pytest --cov --cov-report=xml
+          uv pip install cibuildwheel
+          bash ./.github/workflows/utils/build_windows.sh ${{ matrix.cuda-version }} ${{ matrix.torch-version }}
 
       - name: Upload wheel (final)
         if: ${{ inputs.release-type == 'final' }}

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          uv pip install cibuildwheel
+          uv pip install 'cibuildwheel>=4.0'
           bash ./.github/workflows/utils/build_windows.sh ${{ matrix.cuda-version }} ${{ matrix.torch-version }}
 
       - name: Upload wheel (final)

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -50,14 +50,16 @@ jobs:
             else
               matrix_type="minimal"
             fi
-          else
+          elif [ ${{ inputs.full-matrix }} == 'true' ]; then
             matrix_type="full"
+          else
+            matrix_type="minimal"
           fi
 
           # Set Linux matrix
           echo ::group::Set Linux matrix
           filename=".github/workflows/utils/${matrix_type}_matrix_linux.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][], "arch": .["arch"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][], "arch": .["arch"][] }]' $filename)
           echo "matrix-linux=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-linux=$matrix"
           trigger=${{ contains(github.event.pull_request.labels.*.name, 'os: linux') }}
@@ -68,7 +70,7 @@ jobs:
           # Set macOS matrix
           echo ::group::Set macOS matrix
           filename=".github/workflows/utils/${matrix_type}_matrix_macos.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][] }]' $filename)
           echo "matrix-macos=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-macos=$matrix"
           trigger=${{ contains(github.event.pull_request.labels.*.name, 'os: macos') }}
@@ -79,7 +81,7 @@ jobs:
           # Set Windows matrix
           echo ::group::Set Windows matrix
           filename=".github/workflows/utils/${matrix_type}_matrix_windows.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][] }]' $filename)
           echo "matrix-windows=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-windows=$matrix"
           trigger=${{ contains(github.event.pull_request.labels.*.name, 'os: windows') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           # Set Linux matrix
           echo ::group::Set Linux matrix
           filename=".github/workflows/utils/full_matrix_linux.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][], "arch": .["arch"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][], "arch": .["arch"][] }]' $filename)
           echo "matrix-linux=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-linux=$matrix"
           echo ::endgroup::
@@ -39,7 +39,7 @@ jobs:
           # Set macOS matrix
           echo ::group::Set macOS matrix
           filename=".github/workflows/utils/full_matrix_macos.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][] }]' $filename)
           echo "matrix-macos=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-macos=$matrix"
           echo ::endgroup::
@@ -47,7 +47,7 @@ jobs:
           # Set Windows matrix
           echo ::group::Set Windows matrix
           filename=".github/workflows/utils/full_matrix_windows.json"
-          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "python-version": .["python-version"][], "cuda-version": .["cuda-version"][] }]' $filename)
+          matrix=$(jq -c '[.[] | { "torch-version": .["torch-version"], "cuda-version": .["cuda-version"][] }]' $filename)
           echo "matrix-windows=$matrix" >> $GITHUB_OUTPUT
           echo "matrix-windows=$matrix"
           echo ::endgroup::

--- a/.github/workflows/utils/build_linux.sh
+++ b/.github/workflows/utils/build_linux.sh
@@ -2,9 +2,8 @@
 set -ex
 
 CUDA_VERSION="${1:?Specify cuda version, e.g. cpu, cu130}"
-PYTHON_VERSION="${2:?Specify python version, e.g. 3.14}"
-TORCH_VERSION="${3:?Specify torch version, e.g. 2.13.0}"
-ARCH="${4:-x86_64}"
+TORCH_VERSION="${2:?Specify torch version, e.g. 2.13.0}"
+ARCH="${3:-x86_64}"
 case "${ARCH}" in
   x86_64 | aarch64)
     ;;
@@ -18,15 +17,13 @@ case "${ARCH}" in
 esac
 
 echo "CUDA_VERSION: ${CUDA_VERSION}"
-echo "PYTHON_VERSION: ${PYTHON_VERSION//./}"
 echo "TORCH_VERSION: ${TORCH_VERSION}"
 echo "ARCH: ${ARCH}"
 
-source ./.github/workflows/cuda/Linux-env.sh ${CUDA_VERSION}
+source ./.github/workflows/cuda/Linux-env.sh "${CUDA_VERSION}"
 echo "FORCE_CUDA: ${FORCE_CUDA}"
 echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}"
 
-export CIBW_BUILD="cp${PYTHON_VERSION//./}-manylinux_${ARCH}"
 export CIBW_ARCHS_LINUX="${ARCH}"
 # pyg-lib doesn't have torch as a dependency, so we need to explicitly install it when running tests.
 if [[ "${TORCH_VERSION}" == "2.14.0" ]]; then
@@ -44,9 +41,14 @@ else
   export "CIBW_MANYLINUX_${ARCH^^}_IMAGE=quay.io/pypa/manylinux_2_28_${ARCH}"
 fi
 
-rm -rf Testing pyg_lib/libpyg.so build dist outputs  # for local testing
+rm -rf Testing pyg_lib/libpyg.so build debug dist outputs  # for local testing
 python -m cibuildwheel --output-dir dist
 ls -ahl dist/
+WHEELS=(dist/*.whl)
+if [[ ${#WHEELS[@]} -ne 1 || ${WHEELS[0]} != *-cp310-abi3-* ]]; then
+  echo "Expected exactly one cp310-abi3 wheel, found: ${WHEELS[*]}"
+  exit 1
+fi
 python -m auditwheel show dist/*.whl
 
 unzip dist/*.whl -d debug/

--- a/.github/workflows/utils/build_macos.sh
+++ b/.github/workflows/utils/build_macos.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -ex
 
-PYTHON_VERSION="${1:?Specify python version, e.g. 3.14}"
-TORCH_VERSION="${2:?Specify torch version, e.g. 2.13.0}"
-echo "PYTHON_VERSION: ${PYTHON_VERSION//./}"
+TORCH_VERSION="${1:?Specify torch version, e.g. 2.13.0}"
 echo "TORCH_VERSION: ${TORCH_VERSION}"
 
-export CIBW_BUILD="cp${PYTHON_VERSION//./}-macosx_arm64"
 # pyg-lib doesn't have torch as a dependency, so we need to explicitly install it when running tests.
 if [[ "${TORCH_VERSION}" == "2.14.0" ]]; then
   export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu"
@@ -16,9 +13,14 @@ else
   export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/cpu"
 fi
 
-rm -rf Testing pyg_lib/libpyg.so build dist outputs  # for local testing
+rm -rf Testing pyg_lib/libpyg.so build debug dist outputs  # for local testing
 python -m cibuildwheel --output-dir dist
 ls -ahl dist/
+WHEELS=(dist/*.whl)
+if [[ ${#WHEELS[@]} -ne 1 || ${WHEELS[0]} != *-cp310-abi3-* ]]; then
+  echo "Expected exactly one cp310-abi3 wheel, found: ${WHEELS[*]}"
+  exit 1
+fi
 delocate-listdeps -vv --all dist/*.whl
 
 unzip dist/*.whl -d debug/

--- a/.github/workflows/utils/build_windows.sh
+++ b/.github/workflows/utils/build_windows.sh
@@ -7,6 +7,8 @@ TORCH_VERSION="${2:?Specify torch version, e.g. 2.13.0}"
 echo "CUDA_VERSION: ${CUDA_VERSION}"
 echo "TORCH_VERSION: ${TORCH_VERSION}"
 
+export CIBW_ARCHS_WINDOWS=AMD64
+
 source ./.github/workflows/cuda/Windows-env.sh "${CUDA_VERSION}"
 echo "FORCE_CUDA: ${FORCE_CUDA:-0}"
 echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST:-}"

--- a/.github/workflows/utils/build_windows.sh
+++ b/.github/workflows/utils/build_windows.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+CUDA_VERSION="${1:?Specify cuda version, e.g. cpu, cu130}"
+TORCH_VERSION="${2:?Specify torch version, e.g. 2.13.0}"
+
+echo "CUDA_VERSION: ${CUDA_VERSION}"
+echo "TORCH_VERSION: ${TORCH_VERSION}"
+
+source ./.github/workflows/cuda/Windows-env.sh "${CUDA_VERSION}"
+echo "FORCE_CUDA: ${FORCE_CUDA:-0}"
+echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST:-}"
+
+# pyg-lib doesn't have torch as a dependency, so we need to explicitly install
+# it when building and testing wheels.
+if [[ "${TORCH_VERSION}" == "2.14.0" ]]; then
+  export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools packaging && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${CUDA_VERSION}"
+  export CIBW_BEFORE_TEST="pip install pytest packaging && pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/${CUDA_VERSION}"
+else
+  export CIBW_BEFORE_BUILD="pip install ninja wheel setuptools && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION}"
+  export CIBW_BEFORE_TEST="pip install pytest && pip install torch==${TORCH_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION}"
+fi
+
+rm -rf Testing pyg_lib/libpyg.pyd build dist outputs  # for local testing
+python -m cibuildwheel --output-dir dist
+ls -ahl dist/
+WHEELS=(dist/*.whl)
+if [[ ${#WHEELS[@]} -ne 1 || ${WHEELS[0]} != *-cp310-abi3-* ]]; then
+  echo "Expected exactly one cp310-abi3 wheel, found: ${WHEELS[*]}"
+  exit 1
+fi

--- a/.github/workflows/utils/full_matrix_linux.json
+++ b/.github/workflows/utils/full_matrix_linux.json
@@ -1,25 +1,21 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
     "arch": ["x86_64", "aarch64"]
   },
   {
     "torch-version": "2.12.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
     "arch": ["x86_64", "aarch64"]
   },
   {
     "torch-version": "2.11.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu128", "cu130"],
     "arch": ["x86_64", "aarch64"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu128", "cu130"],
     "arch": ["x86_64", "aarch64"]
   }

--- a/.github/workflows/utils/full_matrix_macos.json
+++ b/.github/workflows/utils/full_matrix_macos.json
@@ -1,22 +1,18 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu"]
   },
   {
     "torch-version": "2.12.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu"]
   },
   {
     "torch-version": "2.11.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu"]
   }
 ]

--- a/.github/workflows/utils/full_matrix_windows.json
+++ b/.github/workflows/utils/full_matrix_windows.json
@@ -1,22 +1,18 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
   },
   {
     "torch-version": "2.12.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
   },
   {
     "torch-version": "2.11.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu128", "cu130"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "cuda-version": ["cpu", "cu126", "cu128", "cu130"]
   }
 ]

--- a/.github/workflows/utils/minimal_matrix_linux.json
+++ b/.github/workflows/utils/minimal_matrix_linux.json
@@ -1,13 +1,11 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cu132"],
     "arch": ["x86_64"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cu126"],
     "arch": ["x86_64"]
   }

--- a/.github/workflows/utils/minimal_matrix_macos.json
+++ b/.github/workflows/utils/minimal_matrix_macos.json
@@ -1,12 +1,10 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cpu"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cpu"]
   }
 ]

--- a/.github/workflows/utils/minimal_matrix_windows.json
+++ b/.github/workflows/utils/minimal_matrix_windows.json
@@ -1,12 +1,10 @@
 [
   {
     "torch-version": "2.13.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cu132"]
   },
   {
     "torch-version": "2.10.0",
-    "python-version": ["3.10", "3.14"],
     "cuda-version": ["cu126"]
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Built wheels against CPython's stable ABI so that one wheel supports Python
+  3.10 through 3.14 for each platform/PyTorch/CUDA/architecture combination
+  ([#700](https://github.com/pyg-team/pyg-lib/pull/700))
+
 ### Deprecated
 
 ### Removed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ if (WITH_CUDA)
 endif()
 add_library(${PROJECT_NAME} SHARED ${ALL_SOURCES})
 target_include_directories(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(${PROJECT_NAME} PRIVATE Py_LIMITED_API=0x030A0000)
 if(MKL_INCLUDE_FOUND)
     target_include_directories(${PROJECT_NAME} PRIVATE ${BLAS_INCLUDE_DIR})
 endif()
@@ -187,9 +188,18 @@ if(BUILD_BENCHMARK)
   include(cmake/benchmark.cmake)
 endif()
 
-set_target_properties(${PROJECT_NAME} PROPERTIES
-  EXPORT_NAME PyG
-  INSTALL_RPATH ${TORCH_INSTALL_PREFIX}/lib)
+if(APPLE)
+  set(PYG_INSTALL_RPATH "@loader_path/../torch/lib")
+elseif(UNIX)
+  set(PYG_INSTALL_RPATH "$ORIGIN/../torch/lib")
+endif()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_NAME PyG)
+if(PYG_INSTALL_RPATH)
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${PYG_INSTALL_RPATH}")
+endif()
 
 # Cmake creates *.dylib by default, but python expects *.so by default
 if (APPLE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 We provide pre-built Python wheels for all major OS/PyTorch/CUDA
 combinations, see [here](https://data.pyg.org/whl). Each wheel supports CPython
-3.10 through 3.14 via CPython's stable ABI.
+3.10 through 3.14 via CPython's stable ABI. CI checks every repaired wheel with
+`abi3audit --strict` and tests it on each supported CPython version.
 
 To install the wheels, simply run
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 
 ## Installation
 
-We provide pre-built Python wheels for all major OS/PyTorch/CUDA combinations from Python 3.10 till 3.14, see [here](https://data.pyg.org/whl).
+We provide pre-built Python wheels for all major OS/PyTorch/CUDA
+combinations, see [here](https://data.pyg.org/whl). Each wheel supports CPython
+3.10 through 3.14 via CPython's stable ABI.
 
 To install the wheels, simply run
 
@@ -52,7 +54,7 @@ The following combinations are supported:
 
 ### From nightly
 
-Nightly wheels are provided for Linux from Python 3.10 till 3.14:
+Nightly wheels are provided for Linux and support CPython 3.10 through 3.14:
 
 ```
 pip install pyg-lib -f https://data.pyg.org/whl/nightly/torch-${TORCH}+${CUDA}.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dev = [
 ]
 
 [tool.cibuildwheel]
+build = "cp3{10,11,12,13,14}-*"
+skip = "*-musllinux_*"
 build-frontend = {name = "build", args = ["--no-isolation"] }
 test-command = "pytest {project}/test"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,18 @@ DYLD_LIBRARY_PATH="$(python -c 'import os, torch; print(os.path.join(os.path.dir
   --exclude libomp.dylib
 """
 
+[tool.cibuildwheel.windows]
+repair-wheel-command = """
+delvewheel repair \
+  --wheel-dir {dest_dir} {wheel} \
+  --exclude "torch*.dll" \
+  --exclude "c10*.dll" \
+  --exclude "caffe2*.dll" \
+  --exclude "libomp*.dll" \
+  --exclude "cuda*.dll" \
+  --exclude "nvrtc*.dll"
+"""
+
 [tool.uv]
 exclude-newer = "7 days"
 exclude-newer-package = { torch = "2099-01-01" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ auditwheel repair \
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = """
-delocate-wheel \
+DYLD_LIBRARY_PATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib"))')" \
+  delocate-wheel \
   --require-archs {delocate_archs} \
   --wheel-dir {dest_dir} {wheel} \
   --exclude libtorch.dylib \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
 build = "cp3{10,11,12,13,14}-*"
 skip = "*-musllinux_*"
 build-frontend = {name = "build", args = ["--no-isolation"] }
+# Check the repaired native wheel, not just its abi3 filename tag.
+audit-requires = ["abi3audit"]
+audit-command = "abi3audit --strict --report {abi3_wheel}"
 test-command = "pytest {project}/test"
 
 [tool.cibuildwheel.linux]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,12 @@ URL = 'https://github.com/pyg-team/pyg-lib'
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
-        Extension.__init__(self, name, sources=[])
+        Extension.__init__(
+            self,
+            name,
+            sources=[],
+            py_limited_api=True,
+        )
         self.sourcedir = osp.abspath(sourcedir)
 
 
@@ -161,4 +166,5 @@ setup(
     packages=find_packages(),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
+    options={'bdist_wheel': {'py_limited_api': 'cp310'}},
 )


### PR DESCRIPTION
The size of combinations shrink from:
```
linux: 160
mac: 20
windows: 80
```
to:
```
linux: 32
mac: 4
windows: 16
```

CI runs:
- [Minimal build matrix](https://github.com/pyg-team/pyg-lib/actions/runs/29513906556)
- [Full build matrix](https://github.com/pyg-team/pyg-lib/actions/runs/29517212034)