### PR TITLE
Fix segment_csr kernels silently dropping rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a regression test covering `segment_csr` inputs that need more than one
+  grid ([#718](https://github.com/pyg-team/pyg-lib/pull/718))
+
 ### Changed
 
 ### Deprecated
@@ -18,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for PyTorch 2.10 ([#706](https://github.com/pyg-team/pyg-lib/pull/706))
 
 ### Fixed
+
+- Fixed `segment_csr` kernels silently dropping rows past
+  `gridDim.x * blockDim.x` ([#718](https://github.com/pyg-team/pyg-lib/pull/718))
 
 ### Security
 

--- a/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
+++ b/pyg_lib/csrc/ops/cuda/segment_csr_kernel.cu
@@ -65,12 +65,14 @@ int threads() {
 }
 
 int blocks(int numel) {
-  const auto props = at::cuda::getCurrentDeviceProperties();
-  const auto blocks_per_sm = props->maxThreadsPerMultiProcessor / 256;
-  const auto max_blocks = props->multiProcessorCount * blocks_per_sm;
+  // NOTE: no occupancy cap here. Unlike `scatter_kernel.cu`, the kernels in
+  // this file are not grid-stride: they compute a single `thread_idx` and
+  // return early when it is out of range. Capping the grid would silently drop
+  // every element past `gridDim.x * blockDim.x` instead of merely serialising
+  // it. This matches upstream `pytorch_scatter/csrc/cuda/segment_csr_cuda.cu`,
+  // whose `BLOCKS(TB, N)` is likewise uncapped.
   const auto max_threads = threads();
-  return std::max(
-      1, std::min(max_blocks, (numel + max_threads - 1) / max_threads));
+  return std::max(1, (numel + max_threads - 1) / max_threads);
 }
 
 // Strided-offset helper specialised for `indptr` row pointers.

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1359,3 +1359,40 @@ def test_segment_csr_dispatcher_default_reduce_is_sum(device):
     out = pyg_lib.ops.segment_csr(src, indptr)
     expected = pyg_lib.ops.segment_sum_csr(src, indptr)
     torch.testing.assert_close(out, expected)
+
+
+@withCUDA
+@withSeed
+def test_segment_csr_covers_all_rows_beyond_one_grid(device):
+    """Regression test: the CSR kernels are not grid-stride, so a grid sized
+    by occupancy rather than by the work silently drops every element past
+    ``gridDim.x * blockDim.x``.
+
+    The number of rows needed to trigger this depends on the device, so derive
+    it: the old cap was ``multiProcessorCount * (maxThreadsPerMultiProcessor /
+    256)`` blocks, and the broadcast kernel launches one thread per
+    ``(row, col)`` pair.
+    """
+    if device.type != 'cuda':
+        pytest.skip('needs a GPU grid')
+
+    props = torch.cuda.get_device_properties(device)
+    max_threads = min(props.max_threads_per_block, 1024)
+    capped_threads = (props.multi_processor_count *
+                      (props.max_threads_per_multi_processor // 256) *
+                      max_threads)
+
+    K = 32
+    # Two grids' worth of work, so the tail cannot fit in a capped launch.
+    num_rows = (2 * capped_threads) // K
+    rows_per_segment = 2
+
+    indptr = torch.arange(0, num_rows * rows_per_segment + 1, rows_per_segment,
+                          device=device)
+    src = torch.randn(num_rows * rows_per_segment, K, device=device)
+
+    out = pyg_lib.ops.segment_sum_csr(src, indptr)
+    expected = src.view(num_rows, rows_per_segment, K).sum(dim=1)
+
+    assert out.size() == (num_rows, K)
+    torch.testing.assert_close(out, expected, atol=1e-4, rtol=1e-4)

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1378,17 +1378,20 @@ def test_segment_csr_covers_all_rows_beyond_one_grid(device):
 
     props = torch.cuda.get_device_properties(device)
     max_threads = min(props.max_threads_per_block, 1024)
-    capped_threads = (props.multi_processor_count *
-                      (props.max_threads_per_multi_processor // 256) *
-                      max_threads)
+    capped_threads = (
+        props.multi_processor_count
+        * (props.max_threads_per_multi_processor // 256)
+        * max_threads
+    )
 
     K = 32
     # Two grids' worth of work, so the tail cannot fit in a capped launch.
     num_rows = (2 * capped_threads) // K
     rows_per_segment = 2
 
-    indptr = torch.arange(0, num_rows * rows_per_segment + 1, rows_per_segment,
-                          device=device)
+    indptr = torch.arange(
+        0, num_rows * rows_per_segment + 1, rows_per_segment, device=device
+    )
     src = torch.randn(num_rows * rows_per_segment, K, device=device)
 
     out = pyg_lib.ops.segment_sum_csr(src, indptr)

--- a/test/ops/test_segment_csr.py
+++ b/test/ops/test_segment_csr.py
@@ -1389,10 +1389,9 @@ def test_segment_csr_covers_all_rows_beyond_one_grid(device):
     num_rows = (2 * capped_threads) // K
     rows_per_segment = 2
 
-    indptr = torch.arange(
-        0, num_rows * rows_per_segment + 1, rows_per_segment, device=device
-    )
-    src = torch.randn(num_rows * rows_per_segment, K, device=device)
+    num_src = num_rows * rows_per_segment
+    indptr = torch.arange(0, num_src + 1, rows_per_segment, device=device)
+    src = torch.randn(num_src, K, device=device)
 
     out = pyg_lib.ops.segment_sum_csr(src, indptr)
     expected = src.view(num_rows, rows_per_segment, K).sum(dim=1)


### PR DESCRIPTION
`blocks()` in `segment_csr_kernel.cu` caps the grid at `multiProcessorCount * (maxThreadsPerMultiProcessor / 256)`, but the kernels in that file aren't grid-stride — they compute one `thread_idx` and return early if it's out of range. So anything past `gridDim.x * blockDim.x` is never written, silently.

I hit this on an 8-CU card, where the cap works out to 64 blocks x 1024 threads = 65536 threads. With `K = 32` that means every row from 2048 on came back wrong for `segment_{sum,mean,min,max}_csr`. Rows 0-2047 were fine, which is what makes it nasty — you get plausible-looking output.

It isn't specific to small GPUs, just easier to hit there. On a 108-SM A100 the cap is ~884k threads, so any `N * K` above that has the same problem.

`scatter_kernel.cu` isn't affected because its kernels *are* grid-stride. Upstream `pytorch_scatter`'s `BLOCKS(TB, N)` was uncapped, which is what these kernels were ported against, so this restores that.

Tested on ROCm 7.2 / gfx1150: full suite passes (693 passed, 11 skipped), and the mismatched rows go away.
