### PR TITLE
Drop CUDA 12.x support

### DIFF
--- a/.github/workflows/_build_docker.yml
+++ b/.github/workflows/_build_docker.yml
@@ -17,13 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda-version: [cu126, cu128, cu130, cu132]
+        cuda-version: [cu130, cu132]
         arch: [x86_64, aarch64]
         include:
-          - cuda-version: cu126
-            cuda-number: "12.6"
-          - cuda-version: cu128
-            cuda-number: "12.8"
           - cuda-version: cu130
             cuda-number: "13.0"
           - cuda-version: cu132

--- a/.github/workflows/utils/full_matrix_linux.json
+++ b/.github/workflows/utils/full_matrix_linux.json
@@ -1,17 +1,17 @@
 [
   {
     "torch-version": "2.14.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
+    "cuda-version": ["cpu", "cu130", "cu132"],
     "arch": ["x86_64", "aarch64"]
   },
   {
     "torch-version": "2.13.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
+    "cuda-version": ["cpu", "cu130", "cu132"],
     "arch": ["x86_64", "aarch64"]
   },
   {
     "torch-version": "2.12.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"],
+    "cuda-version": ["cpu", "cu130", "cu132"],
     "arch": ["x86_64", "aarch64"]
   }
 ]

--- a/.github/workflows/utils/full_matrix_windows.json
+++ b/.github/workflows/utils/full_matrix_windows.json
@@ -1,14 +1,14 @@
 [
   {
     "torch-version": "2.14.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
+    "cuda-version": ["cpu", "cu130", "cu132"]
   },
   {
     "torch-version": "2.13.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
+    "cuda-version": ["cpu", "cu130", "cu132"]
   },
   {
     "torch-version": "2.12.0",
-    "cuda-version": ["cpu", "cu126", "cu130", "cu132"]
+    "cuda-version": ["cpu", "cu130", "cu132"]
   }
 ]

--- a/.github/workflows/utils/minimal_matrix_linux.json
+++ b/.github/workflows/utils/minimal_matrix_linux.json
@@ -6,7 +6,7 @@
   },
   {
     "torch-version": "2.12.0",
-    "cuda-version": ["cu126"],
+    "cuda-version": ["cu130"],
     "arch": ["x86_64"]
   }
 ]

--- a/.github/workflows/utils/minimal_matrix_windows.json
+++ b/.github/workflows/utils/minimal_matrix_windows.json
@@ -5,6 +5,6 @@
   },
   {
     "torch-version": "2.12.0",
-    "cuda-version": ["cu126"]
+    "cuda-version": ["cu130"]
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Dropped support for CUDA 12.x and pre-Turing GPU architectures ([#725](https://github.com/pyg-team/pyg-lib/pull/725))
 - Dropped support for PyTorch 2.11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,27 +25,27 @@ pip install pyg-lib -f https://data.pyg.org/whl/torch-${TORCH}+${CUDA}.html
 where
 
 - `${TORCH}` should be replaced by either `2.12.0`, `2.13.0`, or `2.14.0`
-- `${CUDA}` should be replaced by either `cpu`, `cu126`, `cu130`, or `cu132`
+- `${CUDA}` should be replaced by either `cpu`, `cu130`, or `cu132`
 
 The following combinations are supported:
 
-| PyTorch 2.14 | `cpu` | `cu126` | `cu130` | `cu132` |
-| ------------ | ----- | ------- | ------- | ------- |
-| **Linux**    | ✅    | ✅      | ✅      | ✅      |
-| **Windows**  | ✅    | ✅      | ✅      | ✅      |
-| **macOS**    | ✅    |         |         |         |
+| PyTorch 2.14 | `cpu` | `cu130` | `cu132` |
+| ------------ | ----- | ------- | ------- |
+| **Linux**    | ✅    | ✅      | ✅      |
+| **Windows**  | ✅    | ✅      | ✅      |
+| **macOS**    | ✅    |         |         |
 
-| PyTorch 2.13 | `cpu` | `cu126` | `cu130` | `cu132` |
-| ------------ | ----- | ------- | ------- | ------- |
-| **Linux**    | ✅    | ✅      | ✅      | ✅      |
-| **Windows**  | ✅    | ✅      | ✅      | ✅      |
-| **macOS**    | ✅    |         |         |         |
+| PyTorch 2.13 | `cpu` | `cu130` | `cu132` |
+| ------------ | ----- | ------- | ------- |
+| **Linux**    | ✅    | ✅      | ✅      |
+| **Windows**  | ✅    | ✅      | ✅      |
+| **macOS**    | ✅    |         |         |
 
-| PyTorch 2.12 | `cpu` | `cu126` | `cu130` | `cu132` |
-| ------------ | ----- | ------- | ------- | ------- |
-| **Linux**    | ✅    | ✅      | ✅      | ✅      |
-| **Windows**  | ✅    | ✅      | ✅      | ✅      |
-| **macOS**    | ✅    |         |         |         |
+| PyTorch 2.12 | `cpu` | `cu130` | `cu132` |
+| ------------ | ----- | ------- | ------- |
+| **Linux**    | ✅    | ✅      | ✅      |
+| **Windows**  | ✅    | ✅      | ✅      |
+| **macOS**    | ✅    |         |         |
 
 ### From nightly
 


### PR DESCRIPTION
## Summary

- remove CUDA 12.x from the Linux and Windows wheel matrices
- keep CUDA 13.0 and 13.2 coverage, including the minimal CI matrix
- stop publishing CUDA 12.x manylinux images
- update the support tables and changelog for the pre-Turing architecture drop

Context: https://github.com/pytorch/pytorch/issues/190385

## Validation

- parsed all wheel matrix JSON files with jq
- ran pre-commit hooks for every changed file (excluding the main-branch guard)
- verified active matrices, Docker builds, and the README contain no CUDA 12.x entries